### PR TITLE
chore: prepare Chrome Web Store listing (v1.0.0)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ dist
 .DS_Store
 .vite
 key.pem
+web-store-package.zip

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -103,11 +103,40 @@ curl -s https://job-autofill-proxy-rz75fufhtq-uc.a.run.app/ | jq   # expect "dai
 3. Run an AI feature → Firestore `usage` doc appears, `count` increments per call.
 4. (owner) Paste `PROXY_TOKEN` into Options → Admin token → calls run unmetered.
 
-## Still ahead — Chrome Web Store (separate from the above)
+## Chrome Web Store listing (separate from the above)
 
-OAuth "Publish app" ≠ Web Store listing. To list publicly:
-1. Pay the one-time **$5** developer fee at the Chrome Web Store Developer Dashboard.
-2. `npm run build`, then zip the `dist/` folder.
-3. Upload zip + screenshots + description + privacy policy → Google review (~1–3 days).
-4. Use the **same `key.pem`** so the published ID matches the OAuth client (otherwise
-   create a second OAuth client for the store-assigned ID).
+OAuth "Publish app" ≠ Web Store listing. Listing copy and privacy policy live in
+[`STORE_LISTING.md`](STORE_LISTING.md) and [`PRIVACY.md`](PRIVACY.md).
+
+**Key gotcha:** the Web Store assigns the published item its **own** ID/public key — it
+does **not** honor the local `key.pem`. So the OAuth client (currently bound to the dev
+ID from `key.pem`) must be **rebound to the store-assigned Item ID** after the first
+upload, or `getAuthToken` / managed-proxy sign-in breaks for installed users.
+
+Ordered steps:
+
+1. Register a Web Store developer account (one-time **$5**) at
+   <https://chrome.google.com/webstore/devconsole>.
+2. `npm run package` → upload `web-store-package.zip` as a **new item** (don't submit).
+   This mints the permanent **Item ID** + a store key.
+3. **Rebind OAuth + adopt the store key:**
+   - Dashboard → item → **Package** tab → copy the **public key**, note the **Item ID**.
+   - Google Auth Platform → **Clients** → edit **"AI Job Assistant"** → set its **Item ID**
+     to the store Item ID. `client_id` is unchanged, so `OAUTH_CLIENT_ID` /
+     `oauth2.client_id` stay the same and **no Cloud Run redeploy** is needed.
+   - Replace `key:` in [`manifest.config.ts`](manifest.config.ts) with the store public key
+     (so local unpacked dev shares the store ID; `key.pem` is then superseded — keep it
+     backed up but it no longer drives the ID).
+   - `npm run package` again → upload the new version.
+4. Fill the listing from [`STORE_LISTING.md`](STORE_LISTING.md): description, single
+   purpose, category, icon (128px in the package), **screenshots** (guide below), privacy
+   policy URL, and the **Privacy practices** disclosures.
+5. Submit with **Public** visibility → Google review (~1–3 days; the `<all_urls>`
+   justification is in `STORE_LISTING.md`).
+
+### Screenshot capture (1–5 × 1280×800 PNG)
+
+After step 3 (so the dev ID matches and sign-in works): `npm run build`, load `dist/`
+unpacked, size the captured area to exactly **1280×800**, and capture: the **Options**
+page filled in, the **side panel** on a Greenhouse/Lever posting, the **eligibility
+badge** (YES/NO), an **✨ AI answer** draft, and a generated **cover letter**.

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -1,0 +1,77 @@
+# Privacy Policy — AI Job Application Autofill
+
+_Last updated: June 18, 2026_
+
+AI Job Application Autofill ("the extension") is a Chrome extension that fills out
+job applications and drafts answers and cover letters from a profile **you** enter.
+This policy explains what data the extension handles and where it goes. In plain
+terms: **your data stays on your machine**, and the only time anything leaves your
+device is when *you* ask the AI to generate text.
+
+## What the extension stores
+
+All of the following is saved **locally on your computer** using Chrome's
+`chrome.storage.local`. It is never sent to, or stored on, any server operated by us:
+
+- **Profile / personal information** you enter: name, email, phone, city/state/country,
+  LinkedIn, portfolio, GitHub.
+- **Work history, education, and skills.**
+- **Résumé text and uploaded documents** (PDF/DOCX are converted to plain text on your
+  device for use as AI context).
+- **Preferences**, including optional, self-reported EEO/demographic answers
+  (gender, ethnicity, veteran status, disability status). These are blank by default
+  and entirely under your control.
+- **Cover-letter template** and **saved job postings.**
+- **Your Google account email**, cached after you choose to sign in (see below).
+
+We do **not** use analytics, tracking, advertising, or crash reporting. There is no
+telemetry of any kind.
+
+## When data leaves your device
+
+The extension only contacts a network service when you actively use an AI feature
+(generating an answer, cover letter, or eligibility check). Which service it contacts
+depends on the AI provider you select in Options:
+
+1. **Bring-your-own Gemini key** — your selected profile context (résumé, work history,
+   the relevant job text, etc.) and your own Google Gemini API key are sent directly to
+   Google's Gemini API (`generativelanguage.googleapis.com`) to generate text.
+2. **Managed proxy** — the same context is sent to a Cloud Run service (operated by the
+   extension's publisher) that relays the request to Google Vertex AI. To use it you
+   **sign in with Google** via Chrome's identity API; a Google access token is sent so
+   the service can verify you and enforce a per-user daily request limit. The service
+   reads your Google account ID and email for metering only and does not sell, share, or
+   repurpose them.
+3. **On-device model** — when available, Chrome's built-in model generates text
+   **entirely on your device with no network request**.
+
+The extension does **not** transmit your data anywhere except the AI provider you
+choose, and only for the purpose of generating the text you requested.
+
+## Google sign-in
+
+Sign-in is optional and only used for the **Managed proxy** provider. It uses Chrome's
+`identity` API with the `openid`, `email`, and `profile` scopes. We use your email and
+Google account ID solely to identify your requests and apply the daily usage limit. You
+can sign out at any time from the Options page, which clears the cached email and revokes
+the token.
+
+## How to delete your data
+
+- Clear individual fields in the Options page, or
+- **Remove the extension** from `chrome://extensions` — this deletes everything stored in
+  `chrome.storage.local`.
+
+To stop managed-proxy usage, sign out in Options and/or switch to the bring-your-own key
+or on-device provider.
+
+## What we do not do
+
+- We do **not** sell or rent your data.
+- We do **not** use your data for any purpose unrelated to the extension's single
+  purpose (autofilling job applications and generating job-application text).
+- We do **not** use your data to determine creditworthiness or for lending purposes.
+
+## Contact
+
+Questions about this policy: akitirsth@gmail.com

--- a/STORE_LISTING.md
+++ b/STORE_LISTING.md
@@ -1,0 +1,118 @@
+# Chrome Web Store listing — copy & answers
+
+Paste-ready content for the Web Store Developer Dashboard. Keep this in sync with the
+actual listing so submissions are reproducible.
+
+---
+
+## Product name
+
+AI Job Application Autofill
+
+## Summary (≤132 characters)
+
+> Autofill job applications on Greenhouse, Lever & Workday, draft AI answers and cover letters, and flag work-eligibility at a glance.
+
+(127 chars.)
+
+## Category
+
+Productivity
+
+## Language
+
+English
+
+---
+
+## Detailed description
+
+> **Stop retyping the same job-application fields.** AI Job Application Autofill fills
+> repetitive applications from a profile you enter once, drafts answers to open-ended
+> questions, generates tailored cover letters, and flags work-eligibility requirements
+> before you waste time on a posting you can't take.
+>
+> **What it does**
+> - **Autofill** standard fields on Greenhouse, Lever, and Workday applications from your
+>   saved profile.
+> - **✨ AI answers** — a button appears beside free-text questions and drafts a response
+>   from your résumé and uploaded documents.
+> - **Cover letters** — generate a tailored letter from your template (company, role, and
+>   date filled in) and download it as a PDF.
+> - **Eligibility badge** — every job posting is scanned for visa-sponsorship,
+>   U.S.-citizenship, and security-clearance language and shows a bold YES / NO badge in
+>   the corner. On Handshake it also hosts a one-click cover-letter generator.
+>
+> **Your data stays yours.** Everything you enter is stored locally in your browser. Text
+> is only sent to an AI provider when you ask it to generate something — and you choose
+> the provider: your own free Google Gemini key, a managed proxy (sign in with Google),
+> or Chrome's on-device model (no network at all). No analytics, no tracking.
+>
+> **AI providers**
+> - Bring your own free Gemini key, or
+> - Use the managed proxy (Google sign-in; metered per user), or
+> - Use Chrome's built-in on-device model when available.
+
+---
+
+## Single purpose
+
+> The extension's single purpose is to help users complete job applications: it autofills
+> application form fields from a user-entered profile and generates job-application text
+> (answers and cover letters), with an at-a-glance badge summarizing a posting's
+> work-eligibility requirements.
+
+---
+
+## Permission justifications
+
+| Permission | Justification |
+| --- | --- |
+| `storage` | Save the user's profile, résumé, documents, and settings locally in the browser. |
+| `activeTab` | Read and fill fields on the job-application page the user is currently on, when they click the extension. |
+| `scripting` | Inject the autofill logic that populates form fields on supported application pages. |
+| `sidePanel` | The extension's main UI is a side panel that stays open while the user works through an application. |
+| `identity` | Optional Google sign-in (OpenID/email/profile) so users can authenticate to the managed AI proxy, which meters usage per user. |
+| Host access to Greenhouse, Lever, Workday (`*.greenhouse.io`, `jobs.lever.co`, `*.myworkdayjobs.com`, etc.) | Run the autofill content script on supported job-application sites. |
+| `generativelanguage.googleapis.com` | Send the user's context to Google's Gemini API to generate answers/cover letters when the user supplies their own key. |
+| `*.run.app` | Send requests to the managed proxy (Cloud Run) that relays to Vertex AI, when the user selects that provider. |
+| Content script on `<all_urls>` | The work-eligibility badge must be able to scan any job posting regardless of which site hosts it. It self-gates at runtime: it only renders when the user has scanning enabled **and** the page actually looks like a job posting, and it activates autofill only on the supported job boards above. Users can turn scanning off entirely from the side panel. |
+
+## Remote code
+
+**No.** The extension does not load or execute remote code. It calls AI provider APIs to
+send context and receive generated text (data only); all executable code is bundled in
+the package.
+
+---
+
+## Privacy practices tab — disclosure answers
+
+**Single purpose**: (use the statement above.)
+
+**Data collected** (declare the categories the extension handles; all stored locally):
+- **Personally identifiable information** — name, email address, phone number, physical
+  location (city/state/country) the user enters for their profile, plus optional
+  self-reported demographic fields.
+- **Authentication information** — Google account email/token used for optional managed-
+  proxy sign-in.
+
+(We do not collect: health info, financial/payment info, web-browsing history, user
+activity/analytics, or personal communications.)
+
+**Required certifications** (all true):
+- ✅ I do not sell or transfer user data to third parties outside of approved use cases.
+- ✅ I do not use or transfer user data for purposes unrelated to the item's single purpose.
+- ✅ I do not use or transfer user data to determine creditworthiness or for lending purposes.
+
+**Privacy policy URL**:
+`https://github.com/ritsth/job-autofill-extension/blob/main/PRIVACY.md`
+
+---
+
+## Assets checklist
+
+- **Store icon**: 128×128 PNG — already in the package (`public/icons/icon128.png`).
+- **Screenshots**: 1–5 at **1280×800** PNG (see the capture guide in `DEPLOYMENT.md`).
+- **Small promo tile** (optional): 440×280.
+- **Marquee promo tile** (optional): 1400×560.

--- a/package.json
+++ b/package.json
@@ -1,14 +1,15 @@
 {
   "name": "job-autofill-extension",
   "private": true,
-  "version": "0.1.0",
+  "version": "1.0.0",
   "type": "module",
-  "description": "AI-powered Chrome extension that autofills job applications (Greenhouse, Lever) and generates tailored answers + cover letters.",
+  "description": "AI-powered Chrome extension that autofills job applications (Greenhouse, Lever, Workday) and generates tailored answers + cover letters.",
   "scripts": {
     "dev": "vite",
     "build": "tsc --noEmit && vite build",
     "typecheck": "tsc --noEmit",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "package": "npm run build && cd dist && zip -r -FS ../web-store-package.zip . -x '.DS_Store' && cd .."
   },
   "dependencies": {
     "react": "^18.3.1",


### PR DESCRIPTION
## What

Prepares the repo for a **public** Chrome Web Store submission (managed proxy stays the
default AI provider). No runtime/extension behavior changes — packaging, docs, and the
mandatory store artifacts.

## Changes

- **`package.json`** — version `0.1.0` → `1.0.0`; new `npm run package` (build + zip
  `dist/` → `web-store-package.zip`, gitignored). Description now mentions Workday.
- **`PRIVACY.md`** (new) — privacy policy. Served to the store via its GitHub URL:
  `https://github.com/ritsth/job-autofill-extension/blob/main/PRIVACY.md`.
- **`STORE_LISTING.md`** (new) — paste-ready listing copy: summary, detailed description,
  single purpose, category, **permission justifications** (including the `<all_urls>`
  eligibility-badge rationale), remote-code answer (No), and the **Privacy practices**
  disclosure answers + certifications.
- **`DEPLOYMENT.md`** — corrected Web Store section. The previous note claimed reusing
  `key.pem` keeps the published ID matching the OAuth client; that's wrong. The store
  assigns its **own** ID/key, so the OAuth client must be **rebound to the store Item ID**
  after the first upload (and the manifest `key` swapped to the store key for local-dev
  parity). `client_id` is unchanged → no Cloud Run redeploy.

## Manual steps still required (can't be done in-repo)

1. $5 developer registration.
2. First upload → get Item ID + store key → rebind OAuth client → re-upload.
3. Capture 1280×800 screenshots (guide in `DEPLOYMENT.md`).
4. Fill the listing from `STORE_LISTING.md` and submit (Public).

🤖 Generated with [Claude Code](https://claude.com/claude-code)