### PR TITLE
docs: correct cover-letter copy to placeholder-only (no AI tailoring)

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@ Auto-fills repetitive job applications on **Greenhouse**, **Lever**, and
   questions; it drafts an answer from your resume + uploaded documents. On Greenhouse,
   Lever, and Workday it's automatic; on any other job site, **save the job** (💾 in the
   side panel) and the same button lights up next to that application's questions.
-- **Generate a tailored cover letter** from your base template (company / role / date
-  substituted, then AI-tailored), downloadable as a `.pdf`.
+- **Generate a cover letter** from your base template (company / role / date
+  placeholders substituted), downloadable as a `.pdf`.
 - **Flag eligibility at a glance** every covered page is scanned for visa-sponsorship /
   U.S.-citizenship / security-clearance language and shows a bold **YES / NO** badge
   in the corner. On **Handshake** the badge also hosts a one-click cover-letter

--- a/STORE_LISTING.md
+++ b/STORE_LISTING.md
@@ -37,8 +37,8 @@ English
 >   saved profile.
 > - **✨ AI answers** — a button appears beside free-text questions and drafts a response
 >   from your resume and uploaded documents.
-> - **Cover letters** — generate a tailored letter from your template (company, role, and
->   date filled in) and download it as a PDF.
+> - **Cover letters** — generate a cover letter from your template (company, role, and
+>   date placeholders filled in) and download it as a PDF.
 > - **Eligibility badge** — every job posting is scanned for visa-sponsorship,
 >   U.S.-citizenship, and security-clearance language and shows a bold YES / NO badge in
 >   the corner. On Handshake it also hosts a one-click cover-letter generator.

--- a/src/lib/coverLetter.ts
+++ b/src/lib/coverLetter.ts
@@ -1,6 +1,7 @@
-// Cover-letter helpers: placeholder substitution and download. The AI-tailoring
-// step itself is done in the background service worker (it owns the provider);
-// this module prepares the base text and handles the file download.
+// Cover-letter helpers: placeholder substitution and download. The cover letter
+// is placeholder-only — the background service worker substitutes
+// {{company}}/{{role}}/{{date}} with no AI rewrite; this module prepares the
+// base text and handles the file download.
 
 import { downloadTextPdf } from './pdf';
 

--- a/src/options/Options.tsx
+++ b/src/options/Options.tsx
@@ -496,7 +496,7 @@ function OptionsView({
           />
         </Field>
         <div className="help">
-          On a job page, the popup substitutes the company/role/date and the AI tailors the body.
+          On a job page, the popup substitutes the company/role/date placeholders.
         </div>
       </section>
     </div>


### PR DESCRIPTION
## What

Corrects UI strings and docs that claimed the cover-letter body is **AI-tailored**. Cover letters are now **placeholder-only**.

- **`src/options/Options.tsx`** — template help text dropped the "and the AI tailors the body" claim; now reads "substitutes the company/role/date placeholders."
- **`README.md`** — "company / role / date substituted, then AI-tailored" → "placeholders substituted."
- **`STORE_LISTING.md`** — "generate a tailored letter… (date filled in)" → "generate a cover letter… (date placeholders filled in)."
- **`src/lib/coverLetter.ts`** — stale module comment referencing an AI-tailoring step in the service worker corrected to state it's placeholder-only.

## Why

The `AI_GENERATE_COVER_LETTER` branch in `src/background/service-worker.ts` returns `substitutePlaceholders(profile.baseCoverLetter, { company, role })` with no AI rewrite — `buildCoverLetterPrompt` / `COVER_LETTER_SYSTEM` were removed earlier. The copy hadn't caught up, so it overstated the feature.

## Notes for reviewer

- **Resume copy is intentionally untouched** — the tailored-resume feature (`buildTailoredResumePrompt`) is still genuinely AI-driven.
- Docs/UI-string fix only; no logic changes. `npm run build` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)