### PR TITLE
feat: model picker for AI answers + sign-out fixes (v1.1.0)

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -108,12 +108,12 @@ curl -s https://job-autofill-proxy-rz75fufhtq-uc.a.run.app/ | jq   # expect "dai
 OAuth "Publish app" ≠ Web Store listing. Listing copy and privacy policy live in
 [`STORE_LISTING.md`](STORE_LISTING.md) and [`PRIVACY.md`](PRIVACY.md).
 
-> **Status (2026-06-19): submitted for review.** Store **Item ID**
-> `iibpijacaghdcckphindbaijjgcbaoll`. The OAuth client "AI Job Assistant" was rebound to
-> that Item ID, and `manifest.config.ts` `key` now holds the store's public key (dev-only;
-> `npm run package` strips it via `CRX_NO_KEY`). Verified the local `npm run build` ID
-> matches the store Item ID. Publisher contact email verified. Awaiting Google review
-> (flagged for in-depth host-permission review).
+> **Status: ✅ LIVE** — published 2026-06-22.
+> Chrome Web Store URL: <https://chromewebstore.google.com/detail/Little%20AI%20Helper/iibpijacaghdcckphindbaijjgcbaoll>
+> Store **Item ID** `iibpijacaghdcckphindbaijjgcbaoll`. The OAuth client "AI Job Assistant"
+> was rebound to that Item ID, and `manifest.config.ts` `key` now holds the store's public
+> key (dev-only; `npm run package` strips it via `CRX_NO_KEY`). Verified the local
+> `npm run build` ID matches the store Item ID.
 
 **Key gotcha:** the Web Store assigns the published item its **own** ID/public key — it
 does **not** honor the local `key.pem`. So the OAuth client (currently bound to the dev

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -96,6 +96,18 @@ Sanity check:
 curl -s https://job-autofill-proxy-rz75fufhtq-uc.a.run.app/ | jq   # expect "dailyLimit": 50
 ```
 
+### Redeploy after the model picker
+
+The proxy now honors a client-requested model (validated against `MODEL_ALLOWLIST` in
+[`server/index.js`](server/index.js); keep it in sync with
+[`src/lib/ai/models.ts`](src/lib/ai/models.ts)). Redeploy to pick up the change — **no
+secret needed**, the existing env vars are preserved when you omit `--update-env-vars`:
+
+```bash
+gcloud run deploy job-autofill-proxy --source server --region us-central1
+curl -s https://job-autofill-proxy-rz75fufhtq-uc.a.run.app/ | jq   # still healthy
+```
+
 ## Verify
 
 1. `npm run build` → reload unpacked at `chrome://extensions` (ID should match Step 1).

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Little AI Helper (Chrome Extension)
 
+**[Install from the Chrome Web Store](https://chromewebstore.google.com/detail/Little%20AI%20Helper/iibpijacaghdcckphindbaijjgcbaoll)**
+
 Auto-fills repetitive job applications on **Greenhouse**, **Lever**, and
 **Workday** from a structured profile, and uses AI to:
 
@@ -101,7 +103,6 @@ cover-letter generator, tailored-resume generator, save-job context, PDF export.
 Still ahead (v2+):
 
 - Multi-provider picker (Groq / OpenRouter / Claude) — interface already supports it.
-- Chrome Web Store packaging + privacy policy.
 
 ### Publishing & the managed proxy
 

--- a/README.md
+++ b/README.md
@@ -23,6 +23,12 @@ proxy** — a small Cloud Run service that relays to **Vertex AI** so you can sp
 GCP $300 credit (AI Studio's Gemini API is excluded from the credit; Vertex isn't). See
 [`server/README.md`](server/README.md) to deploy it, then pick "Managed proxy" in options.
 
+**Model picker:** for the Gemini and managed-proxy providers, options has a **Model**
+dropdown — choose between Gemini 2.5 Pro (best), 2.5 Flash (default), or 2.5 Flash-Lite.
+The choice applies **only to ✨ AI answers** for open-ended questions; resume parsing and
+the eligibility-badge check always run on the fast default model. The proxy validates the
+requested model against an allowlist server-side.
+
 **Where it runs:** full autofill on **Greenhouse**, **Lever**, and **Workday**
 (`*.myworkdayjobs.com`). The eligibility badge
 runs on **every page** (so no job board is missed), but it self-gates — it only appears

--- a/STORE_LISTING.md
+++ b/STORE_LISTING.md
@@ -1,5 +1,8 @@
 # Chrome Web Store listing — copy & answers
 
+**Live listing:** <https://chromewebstore.google.com/detail/Little%20AI%20Helper/iibpijacaghdcckphindbaijjgcbaoll>
+**Published:** 2026-06-22
+
 Paste-ready content for the Web Store Developer Dashboard. Keep this in sync with the
 actual listing so submissions are reproducible.
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "job-autofill-extension",
   "private": true,
-  "version": "1.0.0",
+  "version": "1.1.0",
   "type": "module",
   "description": "Autofill job applications on Greenhouse, Lever & Workday and draft AI answers and tailored cover letters from your profile.",
   "scripts": {

--- a/server/index.js
+++ b/server/index.js
@@ -25,6 +25,14 @@ const LOCATION = process.env.VERTEX_LOCATION || 'us-central1';
 // Vertex AI needs versioned/current model IDs (unlike AI Studio's bare aliases).
 // gemini-2.5-flash is broadly available; older 1.5/2.0 IDs 404 on newer projects.
 const MODEL = process.env.VERTEX_MODEL || 'gemini-2.5-flash';
+// Models a client is allowed to request via the request body. Keep in sync with
+// the curated list in src/lib/ai/models.ts. Anything outside this set falls back
+// to MODEL, so a client can't bill the project against an arbitrary/expensive id.
+const MODEL_ALLOWLIST = new Set([
+  'gemini-2.5-pro',
+  'gemini-2.5-flash',
+  'gemini-2.5-flash-lite',
+]);
 const PROXY_TOKEN = process.env.PROXY_TOKEN || '';
 // The OAuth client id the extension's tokens are minted for. We reject any token
 // whose audience is a different app, so a token grabbed elsewhere can't be replayed.
@@ -133,17 +141,21 @@ function readBody(req) {
   });
 }
 
-async function generate({ system, prompt, maxOutputTokens, json, thinking }) {
+async function generate({ system, prompt, maxOutputTokens, json, thinking, model: requested }) {
+  // Honor the client's model only if it's allowlisted; otherwise use the default.
+  const modelId = requested && MODEL_ALLOWLIST.has(requested) ? requested : MODEL;
   const model = vertex.getGenerativeModel({
-    model: MODEL,
+    model: modelId,
     systemInstruction: system ? { role: 'system', parts: [{ text: system }] } : undefined,
     generationConfig: {
       temperature: 0.7,
       maxOutputTokens: maxOutputTokens ?? 1024,
       // Thinking on (dynamic budget) only when asked — better open-ended
       // answers. Off by default: 2.5 Flash otherwise spends the output budget
-      // on hidden reasoning and truncates/empties short requests.
-      thinkingConfig: { thinkingBudget: thinking ? -1 : 0 },
+      // on hidden reasoning and truncates/empties short requests. 2.5 Pro can't
+      // disable thinking (budget 0 → 400 INVALID_ARGUMENT), so always give it a
+      // dynamic budget.
+      thinkingConfig: { thinkingBudget: thinking || modelId.includes('2.5-pro') ? -1 : 0 },
       // JSON mode for structured extraction (e.g. resume parsing) so the model
       // returns parseable JSON with no markdown fences or prose.
       ...(json ? { responseMimeType: 'application/json' } : {}),
@@ -200,10 +212,10 @@ const server = http.createServer(async (req, res) => {
 
   try {
     const raw = await readBody(req);
-    const { system = '', prompt = '', maxOutputTokens, json, thinking } = JSON.parse(raw || '{}');
+    const { system = '', prompt = '', maxOutputTokens, json, thinking, model } = JSON.parse(raw || '{}');
     if (!prompt) return send(res, 400, { error: 'Missing "prompt"' });
 
-    const text = await generate({ system, prompt, maxOutputTokens, json, thinking });
+    const text = await generate({ system, prompt, maxOutputTokens, json, thinking, model });
     if (!text) return send(res, 502, { error: 'Empty response from Vertex AI' });
     return send(res, 200, { text });
   } catch (err) {

--- a/server/index.js
+++ b/server/index.js
@@ -215,7 +215,13 @@ const server = http.createServer(async (req, res) => {
     const { system = '', prompt = '', maxOutputTokens, json, thinking, model } = JSON.parse(raw || '{}');
     if (!prompt) return send(res, 400, { error: 'Missing "prompt"' });
 
-    const text = await generate({ system, prompt, maxOutputTokens, json, thinking, model });
+    const args = { system, prompt, maxOutputTokens, json, thinking, model };
+    // Gemini occasionally returns an empty candidate for no real reason (a
+    // transient hiccup). One retry almost always succeeds and saves the user a
+    // manual re-run. The quota was already counted above, so the retry is free
+    // to the user and doesn't double-count.
+    let text = await generate(args);
+    if (!text) text = await generate(args);
     if (!text) return send(res, 502, { error: 'Empty response from Vertex AI' });
     return send(res, 200, { text });
   } catch (err) {

--- a/src/background/service-worker.ts
+++ b/src/background/service-worker.ts
@@ -81,7 +81,12 @@ async function handle(msg: BackgroundMessage): Promise<string> {
 
   if (msg.type === 'AI_GENERATE_ANSWER') {
     const provider = await resolveProvider(profile.ai);
-    return provider.generate(buildAnswerPrompt(msg.question, context, jobText));
+    // The free-text answer is the only feature that honors the user's model
+    // choice; everything else stays on the provider's fast default.
+    return provider.generate({
+      ...buildAnswerPrompt(msg.question, context, jobText),
+      model: profile.ai.model,
+    });
   }
 
   const company = msg.company.trim() || activeJob?.company || '';

--- a/src/lib/ai/gemini.ts
+++ b/src/lib/ai/gemini.ts
@@ -1,4 +1,5 @@
 import { AIError, type AIProvider, type GenerateInput } from './provider';
+import { DEFAULT_MODEL } from './models';
 
 // Google Gemini via the Generative Language REST API. The user supplies their
 // own free AI Studio key (https://aistudio.google.com/apikey); it is read from
@@ -12,15 +13,17 @@ export class GeminiProvider implements AIProvider {
 
   constructor(
     private apiKey: string,
-    private model = 'gemini-2.0-flash',
+    private model = DEFAULT_MODEL,
   ) {}
 
-  async generate({ system, prompt, maxOutputTokens, json, thinking }: GenerateInput): Promise<string> {
+  async generate({ system, prompt, maxOutputTokens, json, thinking, model }: GenerateInput): Promise<string> {
     if (!this.apiKey) {
       throw new AIError('No Gemini API key set. Add one in the extension options.');
     }
 
-    const url = `${ENDPOINT}/${encodeURIComponent(this.model)}:generateContent?key=${encodeURIComponent(
+    // Per-request override (free-text answers) wins; otherwise the fast default.
+    const modelId = model || this.model;
+    const url = `${ENDPOINT}/${encodeURIComponent(modelId)}:generateContent?key=${encodeURIComponent(
       this.apiKey,
     )}`;
 
@@ -33,8 +36,14 @@ export class GeminiProvider implements AIProvider {
         // Gemini 2.5 models default thinking ON over REST, which can eat the
         // whole output budget and truncate the answer. Pin the budget (dynamic
         // when asked, off otherwise). thinkingConfig only applies to 2.5 models.
-        ...(this.model.includes('2.5')
-          ? { thinkingConfig: { thinkingBudget: thinking ? -1 : 0 } }
+        // 2.5 Pro can't disable thinking (budget 0 is rejected), so it always
+        // gets a dynamic budget.
+        ...(modelId.includes('2.5')
+          ? {
+              thinkingConfig: {
+                thinkingBudget: thinking || modelId.includes('2.5-pro') ? -1 : 0,
+              },
+            }
           : {}),
         ...(json ? { responseMimeType: 'application/json' } : {}),
       },

--- a/src/lib/ai/index.ts
+++ b/src/lib/ai/index.ts
@@ -13,10 +13,13 @@ export function getProvider(settings: AISettings): AIProvider {
   switch (settings.provider) {
     case 'onDevice':
       return new OnDeviceProvider();
+    // Providers default to the fixed fast model. The user's model choice is
+    // applied per-request (only for free-text answers) via GenerateInput.model,
+    // so resume parsing, the eligibility check, etc. always use the fast default.
     case 'proxy':
       return new ProxyProvider(settings.proxyUrl, settings.proxyToken);
     case 'gemini':
     default:
-      return new GeminiProvider(settings.apiKey, settings.model);
+      return new GeminiProvider(settings.apiKey);
   }
 }

--- a/src/lib/ai/models.ts
+++ b/src/lib/ai/models.ts
@@ -1,0 +1,23 @@
+// Curated Gemini models the user can pick from in Options. Single source of
+// truth for the dropdown and for default/normalization logic. All four ids exist
+// on both AI Studio (BYO key, src/lib/ai/gemini.ts) and Vertex AI (the managed
+// proxy, server/index.js). When this list changes, mirror it in the server's
+// MODEL_ALLOWLIST so the proxy accepts the new ids.
+
+export interface ModelOption {
+  id: string;
+  label: string;
+}
+
+export const GEMINI_MODELS: ModelOption[] = [
+  { id: 'gemini-2.5-pro', label: 'Gemini 2.5 Pro — best quality, slower' },
+  { id: 'gemini-2.5-flash', label: 'Gemini 2.5 Flash — fast (recommended)' },
+  { id: 'gemini-2.5-flash-lite', label: 'Gemini 2.5 Flash-Lite — fastest, cheapest' },
+];
+
+export const DEFAULT_MODEL = 'gemini-2.5-flash';
+
+/** True if `id` is one of the curated models we offer. */
+export function isKnownModel(id: string): boolean {
+  return GEMINI_MODELS.some((m) => m.id === id);
+}

--- a/src/lib/ai/provider.ts
+++ b/src/lib/ai/provider.ts
@@ -13,6 +13,13 @@ export interface GenerateInput {
   json?: boolean;
   /** Allow the model to "think" before answering (better quality, slower). */
   thinking?: boolean;
+  /**
+   * Optional per-request model override. Omitted, the provider uses its default
+   * (the fixed fast model). Only the free-text answer feature sets this to the
+   * user's picked model; internal calls (resume parse, eligibility, tailored
+   * resume) leave it unset so they always run on the fast default.
+   */
+  model?: string;
 }
 
 export interface AIProvider {

--- a/src/lib/ai/proxy.ts
+++ b/src/lib/ai/proxy.ts
@@ -1,4 +1,5 @@
 import { AIError, type AIProvider, type GenerateInput } from './provider';
+import { DEFAULT_MODEL } from './models';
 
 // Managed-proxy provider: posts to the Cloud Run service, which holds the Google
 // Cloud credential and relays to Vertex AI. `token` is the bearer to send — the
@@ -12,9 +13,10 @@ export class ProxyProvider implements AIProvider {
   constructor(
     private url: string,
     private token: string,
+    private model = DEFAULT_MODEL,
   ) {}
 
-  async generate({ system, prompt, maxOutputTokens, json, thinking }: GenerateInput): Promise<string> {
+  async generate({ system, prompt, maxOutputTokens, json, thinking, model }: GenerateInput): Promise<string> {
     if (!this.url) {
       throw new AIError('No proxy URL set. Add your Cloud Run URL in the extension options.');
     }
@@ -27,7 +29,10 @@ export class ProxyProvider implements AIProvider {
           'Content-Type': 'application/json',
           Authorization: `Bearer ${this.token}`,
         },
-        body: JSON.stringify({ system, prompt, maxOutputTokens, json, thinking }),
+        // `model` lets the user pick which Gemini model the proxy runs (only the
+        // free-text answer feature overrides; everything else uses the fast
+        // default). The server validates it against an allowlist and falls back.
+        body: JSON.stringify({ system, prompt, maxOutputTokens, json, thinking, model: model || this.model }),
       });
     } catch (e) {
       throw new AIError(`Could not reach the proxy: ${(e as Error).message}`);

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -9,6 +9,11 @@
 // Requires `identity` permission + an `oauth2` block in the manifest.
 
 const AUTH_KEY = 'auth';
+// Sticky "the user explicitly signed out" flag. Chrome silently re-mints tokens
+// for basic scopes (email/profile) even after we revoke, so revocation alone
+// can't keep sign-out from snapping back. While this flag is set we refuse silent
+// tokens; an interactive signIn() clears it.
+const SIGNED_OUT_KEY = 'signedOut';
 
 export interface AuthUser {
   email: string;
@@ -56,18 +61,27 @@ export async function signIn(): Promise<AuthUser> {
   const token = await getToken(true);
   const user: AuthUser = { email: await fetchEmail(token) };
   await chrome.storage.local.set({ [AUTH_KEY]: user });
+  // Clear the sticky sign-out flag — the user is deliberately signing back in.
+  await chrome.storage.local.remove(SIGNED_OUT_KEY);
   return user;
 }
 
-/** Silent token for proxy calls. Rejects (→ "Sign in…") when not signed in. */
-export function getCachedToken(): Promise<string> {
+/**
+ * Silent token for proxy calls. Rejects (→ "Sign in…") when not signed in, or
+ * when the user explicitly signed out (even if Chrome would still mint a token).
+ */
+export async function getCachedToken(): Promise<string> {
+  const r = await chrome.storage.local.get(SIGNED_OUT_KEY);
+  if (r[SIGNED_OUT_KEY]) throw new Error('Signed out');
   return getToken(false);
 }
 
-/** Revokes the token, clears Chrome's cache, and forgets the stored email. */
+/** Revokes the grant, clears Chrome's cache, and forgets the stored email. */
 export async function signOut(): Promise<void> {
   try {
     const token = await getToken(false);
+    // Revoke at Google — revoking the access token also revokes its refresh
+    // token, killing the grant so a silent getAuthToken can't mint a new one.
     await fetch('https://oauth2.googleapis.com/revoke?token=' + encodeURIComponent(token)).catch(
       () => {},
     );
@@ -77,6 +91,14 @@ export async function signOut(): Promise<void> {
   } catch {
     // Not signed in — nothing to revoke.
   }
+  // Flush ALL cached tokens for this extension. removeCachedAuthToken only drops
+  // the one token we saw; Chrome may hold others it would otherwise hand back to
+  // a silent getAuthToken, making sign-out look ineffective (Test proxy still
+  // works). Clearing the whole cache + the revoke above makes sign-out stick.
+  await new Promise<void>((resolve) => chrome.identity.clearAllCachedAuthTokens(() => resolve()));
+  // Set the sticky flag BEFORE removing the email so getCachedToken refuses to
+  // silently re-mint, and reconcileAuthUser won't snap us back to "signed in".
+  await chrome.storage.local.set({ [SIGNED_OUT_KEY]: true });
   await chrome.storage.local.remove(AUTH_KEY);
 }
 
@@ -84,6 +106,27 @@ export async function signOut(): Promise<void> {
 export async function getAuthUser(): Promise<AuthUser | null> {
   const r = await chrome.storage.local.get(AUTH_KEY);
   return (r[AUTH_KEY] as AuthUser) ?? null;
+}
+
+/**
+ * Sign-in state for the UI, reconciled with Chrome's actual OAuth grant. If we
+ * have a stored user, use it. Otherwise a silent token may still exist — e.g. the
+ * account-level grant survived an extension reload that cleared our stored email —
+ * so detect it, persist the email (which fires onAuthChanged so every surface
+ * syncs), and report as signed in. Returns null only when truly signed out.
+ */
+export async function reconcileAuthUser(): Promise<AuthUser | null> {
+  const stored = await getAuthUser();
+  if (stored) return stored;
+  let token: string;
+  try {
+    token = await getCachedToken();
+  } catch {
+    return null;
+  }
+  const user: AuthUser = { email: await fetchEmail(token) };
+  await chrome.storage.local.set({ [AUTH_KEY]: user });
+  return user;
 }
 
 /** Subscribe to sign-in/out changes so the UI stays in sync across surfaces. */

--- a/src/lib/profile.ts
+++ b/src/lib/profile.ts
@@ -2,6 +2,8 @@
 // Everything here stays on the user's machine (storage.local, not sync) because
 // it contains PII (resume text, contact info, optional demographics).
 
+import { DEFAULT_MODEL, isKnownModel } from './ai/models';
+
 export interface PersonalInfo {
   firstName: string;
   lastName: string;
@@ -123,7 +125,7 @@ export const DEFAULT_PROFILE: Profile = {
     // proxy owner's admin override.
     provider: 'proxy',
     apiKey: '',
-    model: 'gemini-2.0-flash',
+    model: DEFAULT_MODEL,
     proxyUrl: 'https://job-autofill-proxy-rz75fufhtq-uc.a.run.app/generate',
     proxyToken: '',
   },
@@ -137,12 +139,17 @@ const STORAGE_KEY = 'profile';
 /** Deep-merges stored data over defaults so new fields always have a value. */
 function withDefaults(stored: Partial<Profile> | undefined): Profile {
   if (!stored) return structuredClone(DEFAULT_PROFILE);
+  const ai = { ...DEFAULT_PROFILE.ai, ...stored.ai };
+  // Old/hand-typed model ids (e.g. the previous gemini-2.0-flash default) may not
+  // be in the curated dropdown — snap them to the default so the picker is never
+  // blank and the proxy never gets an unknown id.
+  if (!isKnownModel(ai.model)) ai.model = DEFAULT_MODEL;
   return {
     ...DEFAULT_PROFILE,
     ...stored,
     personal: { ...DEFAULT_PROFILE.personal, ...stored.personal },
     preferences: { ...DEFAULT_PROFILE.preferences, ...stored.preferences },
-    ai: { ...DEFAULT_PROFILE.ai, ...stored.ai },
+    ai,
     workHistory: stored.workHistory ?? DEFAULT_PROFILE.workHistory,
     education: stored.education ?? DEFAULT_PROFILE.education,
     skills: stored.skills ?? DEFAULT_PROFILE.skills,

--- a/src/options/Options.tsx
+++ b/src/options/Options.tsx
@@ -6,8 +6,9 @@ import { sendToBackground } from '../lib/messages';
 import type { AIResult } from '../lib/messages';
 import { parseResumeJson } from '../lib/resumeImport';
 import { ProxyProvider } from '../lib/ai/proxy';
+import { GEMINI_MODELS } from '../lib/ai/models';
 import { AIError } from '../lib/ai';
-import { signIn, signOut, getAuthUser, onAuthChanged, getCachedToken, type AuthUser } from '../lib/auth';
+import { signIn, signOut, reconcileAuthUser, onAuthChanged, getCachedToken, type AuthUser } from '../lib/auth';
 
 export function Options() {
   const { profile, loaded, saveState, update } = useProfile();
@@ -67,7 +68,7 @@ function OptionsView({
   const [authBusy, setAuthBusy] = useState(false);
   const [authErr, setAuthErr] = useState('');
   useEffect(() => {
-    getAuthUser().then(setAuthUser);
+    reconcileAuthUser().then(setAuthUser);
     return onAuthChanged(setAuthUser);
   }, []);
 
@@ -106,6 +107,7 @@ function OptionsView({
           throw new AIError('Sign in with Google first (or paste an admin token).');
         }
       }
+      // Connectivity test only — runs on the fast default model.
       const provider = new ProxyProvider(p.ai.proxyUrl, token);
       const text = await provider.generate({
         system: 'You are a connectivity test. Reply with exactly: OK',
@@ -184,9 +186,22 @@ function OptionsView({
               <option value="onDevice">On-device (Chrome built-in, no key)</option>
             </select>
           </Field>
-          <Field label="Model">
-            <input value={p.ai.model} onChange={(e) => setAI('model', e.target.value)} />
-          </Field>
+          {/* On-device (Gemini Nano) has no model choice, so hide the picker. */}
+          {p.ai.provider !== 'onDevice' && (
+            <Field label="Model (for AI answers)">
+              <select value={p.ai.model} onChange={(e) => setAI('model', e.target.value)}>
+                {GEMINI_MODELS.map((m) => (
+                  <option key={m.id} value={m.id}>
+                    {m.label}
+                  </option>
+                ))}
+              </select>
+              <div className="help">
+                Used only for ✨ AI answers to open-ended questions. Resume parsing and the
+                eligibility badge always use the fast default model.
+              </div>
+            </Field>
+          )}
         </div>
         {p.ai.provider === 'gemini' && (
           <Field label="Gemini API key">

--- a/src/popup/Popup.tsx
+++ b/src/popup/Popup.tsx
@@ -12,7 +12,7 @@ import { sendToBackground, sendToTab } from '../lib/messages';
 import type { AIResult, CapturedJob, FillResult, PageInfo } from '../lib/messages';
 import { downloadLetter } from '../lib/coverLetter';
 import { downloadResume } from '../lib/resume';
-import { signIn, getAuthUser, onAuthChanged, type AuthUser } from '../lib/auth';
+import { signIn, reconcileAuthUser, onAuthChanged, type AuthUser } from '../lib/auth';
 
 export function Popup() {
   const [tabId, setTabId] = useState<number | null>(null);
@@ -88,7 +88,7 @@ export function Popup() {
 
   // Google sign-in status for the managed proxy.
   useEffect(() => {
-    getAuthUser().then(setAuthUser);
+    reconcileAuthUser().then(setAuthUser);
     return onAuthChanged(setAuthUser);
   }, []);
 


### PR DESCRIPTION
## Summary

Adds a **Model picker** so users can choose which Gemini model drafts their AI answers, and fixes two real issues found while testing it: Vertex model errors and a Google sign-out that didn't stick. Bumps the extension to **v1.1.0**.

## What changed

### Model picker (scoped to AI answers)
- New `src/lib/ai/models.ts` — curated `GEMINI_MODELS` (2.5 Pro / 2.5 Flash / 2.5 Flash-Lite) + `DEFAULT_MODEL`, the single source of truth (mirrored by the server allowlist).
- Options page shows a **Model (for AI answers)** dropdown (hidden for on-device, which has no model choice).
- The choice applies **only to free-text ✨ AI answers** — threaded per-request via `GenerateInput.model`, set only by the `AI_GENERATE_ANSWER` handler. Resume parsing, the eligibility-badge check, and tailored resume always use the fast default.
- The managed proxy now honors a requested model: it's sent in the request body and validated server-side against `MODEL_ALLOWLIST` (falls back to the default for anything off-list, so a client can't bill an arbitrary/expensive model).
- Default model aligned to `gemini-2.5-flash` (what the proxy already ran); legacy/unknown stored ids normalize to the default so the dropdown is never blank.

### Vertex fixes
- **2.5 Pro** can't disable thinking (`thinkingBudget: 0` → 400 `INVALID_ARGUMENT`), so it now always gets a dynamic budget — fixed in both the proxy and the BYO-key client.
- Dropped **gemini-2.0-flash** — it 404s on Vertex in this project/region.

### Auth
- `reconcileAuthUser()` shows the true signed-in state on load even when our stored email was cleared (e.g. after re-loading the unpacked extension, which previously left the UI showing "Sign in" while a silent token still worked).
- **Sign-out now sticks**: revokes the grant, flushes *all* cached tokens, and sets a sticky `signedOut` flag. `getCachedToken()` refuses to silently re-mint while that flag is set, so sign-out survives reloads and blocks Test proxy / AI calls (not just the label). An interactive sign-in clears the flag.

## Reviewer notes
- **Server redeploy required** for the proxy to honor the model choice + Pro thinking fix:
  ```
  gcloud run deploy job-autofill-proxy --source server --region us-central1
  ```
  No new env vars; existing env is preserved.
- Keep `MODEL_ALLOWLIST` in `server/index.js` in sync with `src/lib/ai/models.ts`.
- After merge: `npm run package` and upload to the Web Store. No new permissions → fast review.
- `npm run build` (tsc + bundle) passes clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
