### PR TITLE
fix: use the app icon as the side-panel header logo

### DIFF
--- a/src/popup/Popup.tsx
+++ b/src/popup/Popup.tsx
@@ -214,13 +214,7 @@ export function Popup() {
     <div className="popup">
       <header className="brand">
         <span className="brand-logo" aria-hidden>
-          <svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-            <path
-              d="M12 2.5l1.9 5.1a3 3 0 0 0 1.78 1.78L20.8 11.3a.75.75 0 0 1 0 1.4l-5.12 1.92a3 3 0 0 0-1.78 1.78L12 21.5l-1.9-5.1a3 3 0 0 0-1.78-1.78L3.2 12.7a.75.75 0 0 1 0-1.4l5.12-1.92a3 3 0 0 0 1.78-1.78L12 2.5z"
-              fill="#fff"
-            />
-            <path d="M18.5 3.5l.6 1.6 1.6.6-1.6.6-.6 1.6-.6-1.6-1.6-.6 1.6-.6.6-1.6z" fill="#c7d2fe" />
-          </svg>
+          <img src={chrome.runtime.getURL('icons/icon128.png')} alt="" width={36} height={36} />
         </span>
         <div className="brand-text">
           <h1>Little AI Helper</h1>

--- a/src/ui/ui.css
+++ b/src/ui/ui.css
@@ -74,11 +74,9 @@ button:disabled { opacity: .6; cursor: default; }
 .brand { display: flex; align-items: center; gap: 11px; margin-bottom: 14px; }
 .brand-logo {
   flex: none; width: 36px; height: 36px; border-radius: 10px;
-  display: grid; place-items: center;
-  background: linear-gradient(135deg, #6b7790, #44506b);
   box-shadow: 0 3px 8px rgba(68, 80, 107, .35);
 }
-.brand-logo svg { width: 21px; height: 21px; display: block; }
+.brand-logo img { width: 36px; height: 36px; display: block; border-radius: 10px; }
 .brand-text { flex: 1; min-width: 0; }
 .brand .tagline { font-size: 11px; color: var(--muted); margin: 2px 0 0; }
 .icon-btn {


### PR DESCRIPTION
Swaps the old inline sparkle SVG in the side-panel/popup header for the new star+pencil icon so the in-app logo matches the extension icon. Drops the unused gradient on `.brand-logo`. Part of the v1.1.0 store release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)