### PR TITLE
feat: badge coachmark + on-badge "turn off everywhere" (v1.1.1)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "job-autofill-extension",
   "private": true,
-  "version": "1.1.0",
+  "version": "1.1.1",
   "type": "module",
   "description": "Autofill job applications on Greenhouse, Lever & Workday and draft AI answers and tailored cover letters from your profile.",
   "scripts": {

--- a/src/content/index.ts
+++ b/src/content/index.ts
@@ -14,6 +14,7 @@ import {
   startSponsorshipWatch,
   setScannerEnabled,
   setBadgeFeatures,
+  setBadgeIntroSeen,
   getScanText,
   captureJob,
 } from './sponsorship';
@@ -163,6 +164,10 @@ if (window.top === window.self && !scannerGlobal.__jafScannerStarted) {
   scannerGlobal.__jafScannerStarted = true;
   (async () => {
     const profile = await getProfile();
+    // Seed the one-time badge coachmark flag before enabling the scanner, so the
+    // first badge render knows whether to show it.
+    const { badgeIntroSeen } = await chrome.storage.local.get('badgeIntroSeen');
+    setBadgeIntroSeen(Boolean(badgeIntroSeen));
     setBadgeFeatures({ coverLetter: profile.coverLetterEnabled, resume: profile.tailoredResumeEnabled });
     setScannerEnabled(profile.scanEnabled);
     startSponsorshipWatch();

--- a/src/content/sponsorship.ts
+++ b/src/content/sponsorship.ts
@@ -525,13 +525,16 @@ function renderBadge(a: SponsorAnalysis): HTMLElement {
   const style = document.createElement('style');
   style.textContent = `
     :host { all: initial; }
-    .card {
+    .wrap {
       position: fixed; top: 14px; right: 14px; z-index: 2147483646;
+      display: flex; flex-direction: column; align-items: flex-end; gap: 10px;
+      font: 13px/1.4 ui-sans-serif, system-ui, -apple-system, 'Segoe UI', Roboto, sans-serif;
+    }
+    .card {
       width: 230px; box-sizing: border-box; padding: 12px 14px;
       background: #fff; color: #0f172a; border: 1px solid #e2e8f0;
       border-left: 6px solid ${s.color}; border-radius: 10px;
       box-shadow: 0 6px 24px rgba(0,0,0,.16);
-      font: 13px/1.4 ui-sans-serif, system-ui, -apple-system, 'Segoe UI', Roboto, sans-serif;
     }
     .head { display: flex; align-items: center; gap: 8px; }
     .word { font-size: 20px; font-weight: 800; color: ${s.color}; letter-spacing: .5px; }
@@ -553,14 +556,18 @@ function renderBadge(a: SponsorAnalysis): HTMLElement {
            border-top: 1px solid #eef2f7; padding-top: 7px; }
     .off { color: #44506b; font-weight: 600; cursor: pointer; white-space: nowrap; }
     .off:hover { text-decoration: underline; }
-    .intro { margin-top: 10px; background: #44506b; color: #fff; border-radius: 9px; padding: 11px 12px; }
-    .intro-t { font-weight: 700; font-size: 13px; margin-bottom: 4px; }
-    .intro-d { font-size: 12px; line-height: 1.45; color: #dbe1ec; }
-    .intro-row { display: flex; gap: 7px; margin-top: 10px; }
-    .intro-off { flex: 1; background: #fff; color: #44506b; border: none; border-radius: 7px;
-                 padding: 7px 9px; font-size: 12px; font-weight: 700; cursor: pointer; }
-    .intro-ok { background: rgba(255,255,255,.16); color: #fff; border: none; border-radius: 7px;
-                padding: 7px 13px; font-size: 12px; font-weight: 700; cursor: pointer; }
+    .coach { position: relative; width: 252px; box-sizing: border-box;
+             background: #44506b; color: #fff; border-radius: 12px; padding: 14px 15px;
+             box-shadow: 0 10px 30px rgba(15,23,42,.3); }
+    .coach::before { content: ''; position: absolute; top: -6px; right: 34px;
+                     width: 14px; height: 14px; background: #44506b; transform: rotate(45deg); }
+    .coach-t { font-weight: 700; font-size: 14px; margin-bottom: 5px; }
+    .coach-d { font-size: 12px; line-height: 1.5; color: #dbe1ec; }
+    .coach-row { display: flex; gap: 8px; margin-top: 12px; }
+    .coach-off { flex: 1; background: #fff; color: #44506b; border: none; border-radius: 7px;
+                 padding: 8px 10px; font-size: 12px; font-weight: 700; cursor: pointer; }
+    .coach-ok { background: rgba(255,255,255,.16); color: #fff; border: none; border-radius: 7px;
+                padding: 8px 14px; font-size: 12px; font-weight: 700; cursor: pointer; }
     .cl { margin-top: 10px; border-top: 1px solid #eef2f7; padding-top: 8px; }
     .clbtn { border: none; background: #0f172a; color: #fff; border-radius: 6px;
              padding: 5px 10px; font-size: 12px; font-weight: 600; cursor: pointer; }
@@ -657,44 +664,51 @@ function renderBadge(a: SponsorAnalysis): HTMLElement {
   // the side-panel toggle a new user may never open).
   const foot = document.createElement('div');
   foot.className = 'tag';
-  foot.appendChild(el('span', '', 'Little AI Helper · auto-detected'));
+  foot.appendChild(el('span', '', 'Little AI Helper'));
   const off = el('span', 'off', '⚙ Turn off on all sites');
   off.title = 'Stop showing this badge on every page';
   off.addEventListener('click', () => void disableScannerEverywhere());
   foot.appendChild(off);
   card.appendChild(foot);
 
-  // One-time coachmark: the first time the badge ever appears, explain what it is
-  // and offer a one-click global off. Removed (and never shown again) on dismissal.
+  // Stack the card and (optionally) the coachmark in a fixed, right-aligned
+  // column so the coachmark floats as a separate bubble below the badge.
+  const wrap = document.createElement('div');
+  wrap.className = 'wrap';
+  wrap.appendChild(card);
+
+  // One-time coachmark: a separate bubble below the badge the first time it ever
+  // appears, explaining what it is with a one-click global off. Removed (and never
+  // shown again) on dismissal.
   if (!introSeen) {
-    const intro = document.createElement('div');
-    intro.className = 'intro';
-    intro.appendChild(el('div', 'intro-t', 'First time seeing this?'));
-    intro.appendChild(
+    const coach = document.createElement('div');
+    coach.className = 'coach';
+    coach.appendChild(el('div', 'coach-t', 'First time seeing this?'));
+    coach.appendChild(
       el(
         'div',
-        'intro-d',
-        "I flag visa / citizenship / clearance requirements on pages that look like job " +
-          "postings, so you don't waste time on a role you can't take.",
+        'coach-d',
+        'I flag visa / citizenship / clearance requirements on pages that look like job ' +
+          "postings — so you don't waste time on a role you can't take.",
       ),
     );
-    const introRow = document.createElement('div');
-    introRow.className = 'intro-row';
-    const turnOff = el('button', 'intro-off', 'Turn off everywhere');
+    const row = document.createElement('div');
+    row.className = 'coach-row';
+    const turnOff = el('button', 'coach-off', 'Turn off everywhere');
     turnOff.addEventListener('click', () => {
       markIntroSeen();
       void disableScannerEverywhere();
     });
-    const gotIt = el('button', 'intro-ok', 'Got it');
+    const gotIt = el('button', 'coach-ok', 'Got it');
     gotIt.addEventListener('click', () => {
       markIntroSeen();
-      intro.remove();
+      coach.remove();
     });
-    introRow.append(turnOff, gotIt);
-    intro.appendChild(introRow);
-    card.appendChild(intro);
+    row.append(turnOff, gotIt);
+    coach.appendChild(row);
+    wrap.appendChild(coach);
   }
 
-  root.appendChild(card);
+  root.appendChild(wrap);
   return host;
 }

--- a/src/content/sponsorship.ts
+++ b/src/content/sponsorship.ts
@@ -9,6 +9,7 @@ import type { AIResult } from '../lib/messages';
 import { parseEligibilityJson } from '../lib/jobEligibility';
 import { downloadLetter } from '../lib/coverLetter';
 import { downloadResume } from '../lib/resume';
+import { getProfile, saveProfile } from '../lib/profile';
 
 export type Verdict = 'yes' | 'no' | 'caution' | 'unknown';
 
@@ -252,6 +253,33 @@ export function setScannerEnabled(value: boolean): void {
   enabled = value;
   if (!enabled) removeBadge();
   else scanSponsorship();
+}
+
+// One-time "what is this badge" coachmark, shown the first time the badge ever
+// appears. `introSeen` defaults true so it never flashes before the stored flag
+// is loaded (index.ts loads it at init and calls setBadgeIntroSeen).
+const INTRO_SEEN_KEY = 'badgeIntroSeen';
+let introSeen = true;
+
+/** Seeds the intro-seen flag from storage (called once from the content init). */
+export function setBadgeIntroSeen(value: boolean): void {
+  introSeen = value;
+}
+
+/** Marks the coachmark as seen so it never shows again. */
+function markIntroSeen(): void {
+  introSeen = true;
+  chrome.storage.local.set({ [INTRO_SEEN_KEY]: true });
+}
+
+/**
+ * Turns the eligibility scanner off everywhere by persisting scanEnabled=false.
+ * The profile-change listener in index.ts then removes the badge and the
+ * side-panel toggle updates in lockstep — no direct setScannerEnabled needed.
+ */
+async function disableScannerEverywhere(): Promise<void> {
+  const p = await getProfile();
+  await saveProfile({ ...p, scanEnabled: false });
 }
 
 /** Which generators the badge shows (driven by the user's settings). */
@@ -520,7 +548,19 @@ function renderBadge(a: SponsorAnalysis): HTMLElement {
           padding: 5px 10px; font-size: 12px; font-weight: 600; cursor: pointer; }
     .ai:disabled { opacity: .7; cursor: default; }
     .aitag { font-size: 11px; color: #44506b; font-weight: 700; }
-    .tag { margin-top: 8px; font-size: 11px; color: #94a3b8; }
+    .tag { margin-top: 8px; font-size: 11px; color: #94a3b8;
+           display: flex; justify-content: space-between; align-items: center; gap: 8px;
+           border-top: 1px solid #eef2f7; padding-top: 7px; }
+    .off { color: #44506b; font-weight: 600; cursor: pointer; white-space: nowrap; }
+    .off:hover { text-decoration: underline; }
+    .intro { margin-top: 10px; background: #44506b; color: #fff; border-radius: 9px; padding: 11px 12px; }
+    .intro-t { font-weight: 700; font-size: 13px; margin-bottom: 4px; }
+    .intro-d { font-size: 12px; line-height: 1.45; color: #dbe1ec; }
+    .intro-row { display: flex; gap: 7px; margin-top: 10px; }
+    .intro-off { flex: 1; background: #fff; color: #44506b; border: none; border-radius: 7px;
+                 padding: 7px 9px; font-size: 12px; font-weight: 700; cursor: pointer; }
+    .intro-ok { background: rgba(255,255,255,.16); color: #fff; border: none; border-radius: 7px;
+                padding: 7px 13px; font-size: 12px; font-weight: 700; cursor: pointer; }
     .cl { margin-top: 10px; border-top: 1px solid #eef2f7; padding-top: 8px; }
     .clbtn { border: none; background: #0f172a; color: #fff; border-radius: 6px;
              padding: 5px 10px; font-size: 12px; font-weight: 600; cursor: pointer; }
@@ -612,7 +652,48 @@ function renderBadge(a: SponsorAnalysis): HTMLElement {
   if (showCoverLetterInBadge) card.appendChild(buildCoverLetterSection());
   if (showResumeInBadge) card.appendChild(buildResumeSection());
 
-  card.appendChild(el('div', 'tag', 'Little AI Helper · auto-detected, double-check the posting'));
+  // Footer: brand tag + an always-available "turn the scanner off everywhere"
+  // link, so the global off-switch is reachable from the badge itself (not only
+  // the side-panel toggle a new user may never open).
+  const foot = document.createElement('div');
+  foot.className = 'tag';
+  foot.appendChild(el('span', '', 'Little AI Helper · auto-detected'));
+  const off = el('span', 'off', '⚙ Turn off on all sites');
+  off.title = 'Stop showing this badge on every page';
+  off.addEventListener('click', () => void disableScannerEverywhere());
+  foot.appendChild(off);
+  card.appendChild(foot);
+
+  // One-time coachmark: the first time the badge ever appears, explain what it is
+  // and offer a one-click global off. Removed (and never shown again) on dismissal.
+  if (!introSeen) {
+    const intro = document.createElement('div');
+    intro.className = 'intro';
+    intro.appendChild(el('div', 'intro-t', 'First time seeing this?'));
+    intro.appendChild(
+      el(
+        'div',
+        'intro-d',
+        "I flag visa / citizenship / clearance requirements on pages that look like job " +
+          "postings, so you don't waste time on a role you can't take.",
+      ),
+    );
+    const introRow = document.createElement('div');
+    introRow.className = 'intro-row';
+    const turnOff = el('button', 'intro-off', 'Turn off everywhere');
+    turnOff.addEventListener('click', () => {
+      markIntroSeen();
+      void disableScannerEverywhere();
+    });
+    const gotIt = el('button', 'intro-ok', 'Got it');
+    gotIt.addEventListener('click', () => {
+      markIntroSeen();
+      intro.remove();
+    });
+    introRow.append(turnOff, gotIt);
+    intro.appendChild(introRow);
+    card.appendChild(intro);
+  }
 
   root.appendChild(card);
   return host;


### PR DESCRIPTION
## Summary

Surfaces the eligibility-badge off-switch where users actually hit the friction. The badge appears on every page that looks like a job posting, but the only global toggle is buried in the side panel — new users don't find it, get annoyed, and may uninstall. This adds a one-click off on the badge itself plus a one-time explainer. Bumps to v1.1.1.

## What changed (all in `src/content/`)

- **Footer off-link:** the badge footer now reads `Little AI Helper · auto-detected` + a **⚙ Turn off on all sites** link. Clicking it persists `scanEnabled:false` via `saveProfile`; the existing `onProfileChanged` listener in `index.ts` removes the badge everywhere and the side-panel toggle updates in lockstep.
- **One-time coachmark:** the first time the badge ever appears, a navy callout explains what it is ("flags visa / citizenship / clearance on job postings") with **Turn off everywhere** / **Got it**. Stored under `badgeIntroSeen` in `chrome.storage.local` so it never shows again; the flag is loaded at content init before the first render so it doesn't flash.

## Why this approach (not a full tour)

The UI spans three surfaces (options page, side panel, Shadow-DOM badge on arbitrary pages); a multi-step tour can't span them cleanly and would add a dependency. The actual pain is the badge specifically, so the fix lives there — reusing `getProfile`/`saveProfile`/`onProfileChanged` and the existing `dismissed`/`setScannerEnabled` machinery. No new deps, no manifest change.

## Reviewer notes

- The badge's existing `×` (session dismiss) is unchanged; the coachmark persists across postings until explicitly acknowledged via **Got it** or **Turn off everywhere**.
- `npm run build` passes.
- Ships in the next store release (1.1.0 is still under review). After merge: `npm run package` + upload.

## Test
1. Reload unpacked + refresh a job page.
2. Coachmark: `chrome.storage.local.remove('badgeIntroSeen')` in the page console, open a Greenhouse/Lever posting → badge shows the coachmark → **Got it** removes it; next posting has no coachmark.
3. Off-switch: click **⚙ Turn off on all sites** → badge gone; another posting → no badge; side-panel "Scan every page…" toggle is OFF; re-enable there → badge returns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
