### PR TITLE
chore: add deployable billing kill-switch (P2)

### DIFF
--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -78,34 +78,27 @@ gcloud pubsub topics create billing-killswitch
 #   "Connect a Pub/Sub topic to this budget" → projects/$PROJECT_ID/topics/billing-killswitch
 ```
 
-Function (`infra/billing-killswitch/index.js` — deploy with the snippet below):
-
-```js
-const { CloudBillingClient } = require('@google-cloud/billing');
-const billing = new CloudBillingClient();
-exports.killSwitch = async (event) => {
-  const data = JSON.parse(Buffer.from(event.data, 'base64').toString());
-  if ((data.costAmount ?? 0) <= (data.budgetAmount ?? Infinity)) return; // under budget
-  const project = `projects/${process.env.GCLOUD_PROJECT}`;
-  const [info] = await billing.getProjectBillingInfo({ name: project });
-  if (!info.billingEnabled) return;
-  await billing.updateProjectBillingInfo({
-    name: project,
-    projectBillingInfo: { billingAccountName: '' }, // detach = stop all spend
-  });
-  console.log('Billing disabled for', project);
-};
-```
+The function lives in [`infra/billing-killswitch/`](../infra/billing-killswitch/) (deployable
+as-is). Deploy it (2nd-gen, Pub/Sub-triggered) and grant its SA permission to change billing:
 
 ```bash
-gcloud functions deploy billing-killswitch --runtime nodejs20 --trigger-topic billing-killswitch \
-  --entry-point killSwitch --region us-central1 --set-env-vars GCLOUD_PROJECT=$PROJECT_ID
-# Grant the function's SA permission to change billing (Billing Account Administrator on the
-# billing account). Detaching billing stops Vertex/Cloud Run spend immediately.
+gcloud functions deploy billing-killswitch --gen2 --region us-central1 \
+  --runtime nodejs20 --source infra/billing-killswitch --entry-point killSwitch \
+  --trigger-topic billing-killswitch --set-env-vars GCLOUD_PROJECT=$PROJECT_ID
+
+# The function's runtime SA must be Billing Account Administrator on the billing account
+# (detaching billing is a billing-account operation, not a project one):
+BILLING_ACCT="$(gcloud billing projects describe $PROJECT_ID --format='value(billingAccountName)')"
+RUNTIME_SA="$(gcloud functions describe billing-killswitch --gen2 --region us-central1 \
+  --format='value(serviceConfig.serviceAccountEmail)')"
+gcloud billing accounts add-iam-policy-binding "${BILLING_ACCT#billingAccounts/}" \
+  --member="serviceAccount:$RUNTIME_SA" --role="roles/billing.admin"
 ```
 
 > Trade-off: detaching billing takes the whole project offline (including the proxy). That
-> is the point — it caps the damage. Re-attach billing to bring it back.
+> is the point — it caps the damage. Re-attach billing in the console to bring it back.
+> **Test safely** by publishing an *under-budget* payload first (see runbook), which is a
+> no-op — never test with an over-budget payload unless you mean to disable billing.
 
 ### P3 — Defense in depth — ⏳ TODO (mostly optional)
 - **Alerting:** log-based metric + alert on 429 spikes and **new-`sub` velocity** (many new

--- a/infra/billing-killswitch/index.js
+++ b/infra/billing-killswitch/index.js
@@ -1,0 +1,42 @@
+// Cloud Billing kill-switch (denial-of-wallet backstop).
+//
+// A Cloud Billing budget publishes spend updates to a Pub/Sub topic; this
+// function detaches the billing account from the project once actual spend
+// exceeds the budget, which immediately stops all billable usage (Vertex AI,
+// Cloud Run). Re-attach billing in the console to bring the project back.
+//
+// Triggered by the budget's Pub/Sub topic. Deploy from this folder — see
+// ../../docs/SECURITY.md (P2) for the full setup.
+
+const functions = require('@google-cloud/functions-framework');
+const { CloudBillingClient } = require('@google-cloud/billing');
+
+const billing = new CloudBillingClient();
+const PROJECT_ID = process.env.GCLOUD_PROJECT || process.env.GOOGLE_CLOUD_PROJECT;
+
+functions.cloudEvent('killSwitch', async (cloudEvent) => {
+  // The budget notification is a base64-encoded JSON Pub/Sub message.
+  const raw = cloudEvent?.data?.message?.data;
+  const msg = raw ? JSON.parse(Buffer.from(raw, 'base64').toString()) : {};
+  const cost = msg.costAmount ?? 0;
+  const budget = msg.budgetAmount ?? Infinity;
+
+  if (cost <= budget) {
+    console.log(`Under budget (${cost} <= ${budget}) — no action.`);
+    return;
+  }
+
+  const name = `projects/${PROJECT_ID}`;
+  const [info] = await billing.getProjectBillingInfo({ name });
+  if (!info.billingEnabled) {
+    console.log('Billing already disabled — no action.');
+    return;
+  }
+
+  // Detaching the billing account stops all billable spend immediately.
+  await billing.updateProjectBillingInfo({
+    name,
+    projectBillingInfo: { billingAccountName: '' },
+  });
+  console.warn(`BILLING DISABLED for ${name} (cost ${cost} > budget ${budget}).`);
+});

--- a/infra/billing-killswitch/package.json
+++ b/infra/billing-killswitch/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "billing-killswitch",
+  "version": "1.0.0",
+  "description": "Detaches billing when a Cloud Billing budget is exceeded (denial-of-wallet backstop).",
+  "main": "index.js",
+  "dependencies": {
+    "@google-cloud/billing": "^4.2.0",
+    "@google-cloud/functions-framework": "^3.4.0"
+  }
+}


### PR DESCRIPTION
Adds `infra/billing-killswitch/` — a Pub/Sub-triggered Cloud Function that detaches the billing account when a Cloud Billing budget is exceeded (the denial-of-wallet backstop). Updates `docs/SECURITY.md` P2 to point at the real files with the gen2 deploy command, the `billing.admin` grant on the function's SA, and a safe-test note.

Infra/docs only — no extension or proxy change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)