### PR TITLE
chore: bump version to 1.1.2 for Web Store release

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "job-autofill-extension",
   "private": true,
-  "version": "1.1.1",
+  "version": "1.1.2",
   "type": "module",
   "description": "Autofill job applications on Greenhouse, Lever & Workday and draft AI answers and tailored cover letters from your profile.",
   "scripts": {


### PR DESCRIPTION
Version bump for the Web Store upload. Bundles #17 (badge accuracy + YC) and #19 (experience false-positive fix) on top of the live 1.1.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)