### PR TITLE
Fix LinkedIn job capture reliability and Gemini 2.5 Pro answer truncation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "job-autofill-extension",
-  "version": "1.1.2",
+  "version": "1.1.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "job-autofill-extension",
-      "version": "1.1.2",
+      "version": "1.1.6",
       "dependencies": {
         "react": "^18.3.1",
         "react-dom": "^18.3.1"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "job-autofill-extension",
   "private": true,
-  "version": "1.1.2",
+  "version": "1.1.6",
   "type": "module",
   "description": "Autofill job applications on Greenhouse, Lever & Workday and draft AI answers and tailored cover letters from your profile.",
   "scripts": {

--- a/server/index.js
+++ b/server/index.js
@@ -176,9 +176,10 @@ async function generate({ system, prompt, maxOutputTokens, json, thinking, model
       // Thinking on (dynamic budget) only when asked — better open-ended
       // answers. Off by default: 2.5 Flash otherwise spends the output budget
       // on hidden reasoning and truncates/empties short requests. 2.5 Pro can't
-      // disable thinking (budget 0 → 400 INVALID_ARGUMENT), so always give it a
-      // dynamic budget.
-      thinkingConfig: { thinkingBudget: thinking || modelId.includes('2.5-pro') ? -1 : 0 },
+      // disable thinking (budget 0 → 400 INVALID_ARGUMENT), so give it a small
+      // BOUNDED budget (1024) instead of dynamic -1 — dynamic thinking would
+      // otherwise eat the output budget and truncate the answer mid-sentence.
+      thinkingConfig: { thinkingBudget: thinking ? -1 : modelId.includes('2.5-pro') ? 1024 : 0 },
       // JSON mode for structured extraction (e.g. resume parsing) so the model
       // returns parseable JSON with no markdown fences or prose.
       ...(json ? { responseMimeType: 'application/json' } : {}),

--- a/src/content/adapters/greenhouse.ts
+++ b/src/content/adapters/greenhouse.ts
@@ -1,4 +1,5 @@
 import { type SiteAdapter, textOf, titleCaseSlug } from './types';
+import { hostMatches } from '../../lib/host';
 
 // Handles both the classic boards.greenhouse.io and the newer
 // job-boards.greenhouse.io application pages.
@@ -6,7 +7,7 @@ export const greenhouseAdapter: SiteAdapter = {
   id: 'greenhouse',
 
   matches(url) {
-    return url.hostname.endsWith('greenhouse.io');
+    return hostMatches(url.hostname, 'greenhouse.io');
   },
 
   getPageInfo() {

--- a/src/content/adapters/workday.ts
+++ b/src/content/adapters/workday.ts
@@ -1,4 +1,5 @@
 import { type SiteAdapter, textOf, titleCaseSlug } from './types';
+import { hostMatches } from '../../lib/host';
 
 // Workday application forms (*.myworkdayjobs.com, *.myworkday.com). Unlike
 // Greenhouse/Lever, Workday identifies fields with data-automation-id attributes
@@ -11,9 +12,9 @@ export const workdayAdapter: SiteAdapter = {
   matches(url) {
     const h = url.hostname;
     return (
-      h.endsWith('myworkdayjobs.com') ||
-      h.endsWith('myworkday.com') ||
-      h.endsWith('myworkdaysite.com')
+      hostMatches(h, 'myworkdayjobs.com') ||
+      hostMatches(h, 'myworkday.com') ||
+      hostMatches(h, 'myworkdaysite.com')
     );
   },
 

--- a/src/content/index.ts
+++ b/src/content/index.ts
@@ -3,6 +3,7 @@
 
 import { getProfile, onProfileChanged } from '../lib/profile';
 import { getSavedJobs, onSavedJobsChanged } from '../lib/savedJobs';
+import { hostMatches } from '../lib/host';
 import { applyStandardFills, findOpenQuestions, fillInput, type OpenQuestion } from './adapters/shared';
 import { greenhouseAdapter } from './adapters/greenhouse';
 import { leverAdapter } from './adapters/lever';
@@ -39,7 +40,7 @@ const JOB_HOSTS = [
   'linkedin.com', 'joinhandshake.com', 'greenhouse.io', 'lever.co',
   'myworkdayjobs.com', 'myworkday.com', 'myworkdaysite.com', 'ashbyhq.com', 'ycombinator.com',
 ];
-const answersCapture = isTopFrame || JOB_HOSTS.some((h) => location.hostname.endsWith(h));
+const answersCapture = isTopFrame || JOB_HOSTS.some((h) => hostMatches(location.hostname, h));
 
 chrome.runtime.onMessage.addListener((msg: ContentMessage, _sender, sendResponse) => {
   if (msg.type === 'CAPTURE_JOB') {

--- a/src/content/index.ts
+++ b/src/content/index.ts
@@ -16,7 +16,7 @@ import {
   setBadgeFeatures,
   setBadgeIntroSeen,
   getScanText,
-  captureJob,
+  captureJobWhenReady,
 } from './sponsorship';
 
 const ADAPTERS: SiteAdapter[] = [greenhouseAdapter, leverAdapter, workdayAdapter];
@@ -26,23 +26,37 @@ const BUTTON_CLASS = 'jaf-ai-btn';
 const MARK_ATTR = 'data-jaf-bound';
 
 // --- Messaging from popup ---
-// Only the top frame answers the popup. With all_frames enabled, registering this
-// in every sub-frame would make several frames race to sendResponse (the iframe
-// could win and shadow the real page), so the listener is top-frame-only.
 const isTopFrame = window.top === window.self;
-if (isTopFrame)
-  chrome.runtime.onMessage.addListener((msg: ContentMessage, _sender, sendResponse) => {
+
+// "Save this job" must read the frame that actually holds the posting. On some
+// SPA / prerendered LinkedIn views the visible job renders in a SUB-FRAME, not the
+// top document, so a top-frame-only capture reads an empty page. So CAPTURE_JOB is
+// answered by the top frame AND any job-board sub-frame: empty frames poll the full
+// timeout and reply last, so whichever frame really holds the posting wins the
+// sendMessage race. Ad / tracker sub-frames are excluded by host so they can't
+// answer with their own body text. PAGE_INFO / PAGE_FILL stay top-frame only.
+const JOB_HOSTS = [
+  'linkedin.com', 'joinhandshake.com', 'greenhouse.io', 'lever.co',
+  'myworkdayjobs.com', 'myworkday.com', 'myworkdaysite.com', 'ashbyhq.com', 'ycombinator.com',
+];
+const answersCapture = isTopFrame || JOB_HOSTS.some((h) => location.hostname.endsWith(h));
+
+chrome.runtime.onMessage.addListener((msg: ContentMessage, _sender, sendResponse) => {
+  if (msg.type === 'CAPTURE_JOB') {
+    if (!answersCapture) return false;
+    // Async: also waits a beat for SPA detail panes to paint before snapshotting.
+    captureJobWhenReady().then(({ company, role, text }) => {
+      const captured: CapturedJob = { company, role, text, url: location.href, title: document.title };
+      sendResponse(captured);
+    });
+    return true;
+  }
+  if (!isTopFrame) return false;
   if (msg.type === 'PAGE_INFO') {
     const info: PageInfo = adapter
       ? { supported: true, site: adapter.id, ...adapter.getPageInfo(), jobText: getScanText() }
       : { supported: false, site: null, company: '', role: '', jobText: '' };
     sendResponse(info);
-    return false;
-  }
-  if (msg.type === 'CAPTURE_JOB') {
-    const { company, role, text } = captureJob();
-    const captured: CapturedJob = { company, role, text, url: location.href, title: document.title };
-    sendResponse(captured);
     return false;
   }
   if (msg.type === 'PAGE_FILL') {

--- a/src/content/sponsorship.ts
+++ b/src/content/sponsorship.ts
@@ -10,6 +10,7 @@ import { parseEligibilityJson } from '../lib/jobEligibility';
 import { downloadLetter } from '../lib/coverLetter';
 import { downloadResume } from '../lib/resume';
 import { getProfile, saveProfile } from '../lib/profile';
+import { hostMatches } from '../lib/host';
 
 export type Verdict = 'yes' | 'no' | 'caution' | 'unknown';
 
@@ -252,7 +253,7 @@ function isExpandLabel(raw: string): boolean {
 
 /** Clicks any collapsed-description expander within `root` (once per element). */
 function autoExpandDescription(root: ParentNode): void {
-  if (!EXPAND_HOSTS.some((d) => location.hostname.endsWith(d))) return;
+  if (!EXPAND_HOSTS.some((d) => hostMatches(location.hostname, d))) return;
   for (const el of root.querySelectorAll<HTMLElement>('button, a, [role="button"]')) {
     if (el.getAttribute('data-jaf-expanded')) continue;
     if (!isExpandLabel(el.textContent || '')) continue;
@@ -354,7 +355,7 @@ interface YcJob {
  * "1+ years", "Any (new grads ok)"), so this is more reliable than prose anyway.
  */
 function getYcJobText(): string | null {
-  if (!location.hostname.endsWith('ycombinator.com')) return null;
+  if (!hostMatches(location.hostname, 'ycombinator.com')) return null;
   if (!/\/jobs\/[A-Za-z0-9]/.test(location.pathname)) return null; // job detail only
   const raw = document.querySelector('[data-page]')?.getAttribute('data-page');
   if (!raw) return null;
@@ -385,7 +386,7 @@ export function getScanText(): string {
   const yc = getYcJobText();
   if (yc) return yc.slice(0, MAX_CHARS);
   const host = location.hostname;
-  const key = Object.keys(DETAIL_SELECTORS).find((d) => host.endsWith(d));
+  const key = Object.keys(DETAIL_SELECTORS).find((d) => hostMatches(host, d));
   if (key) {
     autoExpandDescription(document); // reveal collapsed descriptions before reading
     for (const sel of DETAIL_SELECTORS[key]) {
@@ -397,7 +398,7 @@ export function getScanText(): string {
     // known containers matched (an unfamiliar layout), try the layout-agnostic
     // title-anchored read before giving up. Still never fall back to the whole
     // page — that captures nav + profile rail + footer chrome.
-    if (location.hostname.endsWith('linkedin.com')) {
+    if (hostMatches(location.hostname, 'linkedin.com')) {
       // "About the job" section — survives LinkedIn's class-hashed layouts.
       const desc = linkedInDescription();
       if (desc.trim().length > 80) return desc.slice(0, MAX_CHARS);
@@ -669,7 +670,7 @@ function getJobMeta(): { company: string; role: string } {
   // one — on collections/split views it picks the left column's page heading
   // ("Top job picks for you"). Scope to the selected job's detail pane and read
   // its stable top-card containers instead.
-  if (location.hostname.endsWith('linkedin.com')) {
+  if (hostMatches(location.hostname, 'linkedin.com')) {
     const pick = (sels: string[]): string => {
       for (const sel of sels) {
         const t = clean(document.querySelector<HTMLElement>(sel)?.textContent || '');

--- a/src/content/sponsorship.ts
+++ b/src/content/sponsorship.ts
@@ -204,8 +204,22 @@ function extractExperience(text: string): { required: string | null; preferred: 
 // boards check the posting you're viewing rather than the whole page.
 const DETAIL_SELECTORS: Record<string, string[]> = {
   'linkedin.com': [
+    // Description body first, so we read the posting — not the whole detail
+    // pane (feedback widget, "how you compare" upsell, applicant insights).
+    '.jobs-description-content__text',
+    '.jobs-box__html-content',
     '#job-details',
     '.jobs-description__content',
+    // Attribute-contains variants catch the SPA (in-app nav) render, whose
+    // wrapper classes differ from the server-rendered (post-reload) DOM.
+    '[class*="jobs-description__container"]',
+    '[class*="jobs-description"]',
+    // Detail-pane wrapper: on split/collections views this scopes to the
+    // SELECTED job (title + description) and keeps the left job-list, nav, and
+    // profile rail out when the description-specific classes above miss.
+    '.jobs-details__main-content',
+    '[class*="jobs-details__main-content"]',
+    '.jobs-search__job-details--wrapper',
     '.jobs-search__job-details',
     '.job-view-layout',
   ],
@@ -217,6 +231,9 @@ const MAX_CHARS = 200_000;
 // Boards that collapse the job description behind a "More"/"Show more" toggle
 // which only injects the full text into the DOM once expanded — so eligibility
 // wording stays hidden until then. We auto-click it (scoped to the detail pane).
+// NB: LinkedIn is intentionally NOT here — its full description is already in the
+// DOM (visually clamped, but innerText reads it whole), and auto-clicking its
+// "see more" toggles a company link that navigates the tab away from the posting.
 const EXPAND_HOSTS = ['joinhandshake.com'];
 const EXPAND_LABELS = new Set([
   'more',
@@ -268,6 +285,56 @@ function pickMainContent(): string | null {
     if (t && t.length > 200) return t;
   }
   return null;
+}
+
+/**
+ * Most robust LinkedIn description read: anchor on the "About the job" section
+ * heading. That label text is stable across ALL of LinkedIn's job layouts —
+ * including the newer ones whose CSS classes are hashed/obfuscated (`_243b3f31`
+ * …), where no semantic selector like `#job-details` or `.jobs-description`
+ * exists at all. Find the heading by its text, then return the smallest enclosing
+ * block that holds the description. Returns '' when there's no such section.
+ */
+function linkedInDescription(): string {
+  const heading = [...document.querySelectorAll<HTMLElement>('h1,h2,h3,[role="heading"]')].find(
+    (h) => /^(about the job|job description)\b/i.test((h.innerText || '').trim()),
+  );
+  if (!heading) return '';
+  // Climb to the first ancestor that also contains the description text (the
+  // section wrapping the heading), then stop — don't balloon into other sections.
+  let node: HTMLElement | null = heading.parentElement;
+  for (let i = 0; node && i < 6; i++, node = node.parentElement) {
+    const t = node.innerText?.trim() ?? '';
+    if (t.length >= 120 && t.length <= 20_000) return t.slice(0, MAX_CHARS);
+  }
+  return '';
+}
+
+/**
+ * Layout-agnostic LinkedIn read. LinkedIn's job surfaces (collections, /jobs/search,
+ * /jobs/view, email `/comm/` links, public pages) each use different container
+ * classes, so instead of chasing every one, anchor on the job-title element —
+ * matched loosely and case-insensitively by the stable "job-title" / "topcard"
+ * fragments — and climb to the smallest ancestor that also holds the description.
+ * Returns '' on a genuine miss so the caller can fail cleanly rather than grab
+ * page chrome. Runs per-frame, so with the all-frames CAPTURE_JOB responder the
+ * frame that actually holds the posting is the one that answers.
+ */
+function linkedInPostingText(): string {
+  const title = document.querySelector<HTMLElement>(
+    '[class*="top-card__job-title" i], [class*="topcard__title" i], h1[class*="job" i]',
+  );
+  if (!title) return '';
+  let best = '';
+  let node: HTMLElement | null = title;
+  for (let i = 0; node && i < 12; i++, node = node.parentElement) {
+    const t = node.innerText?.trim() ?? '';
+    // Keep the largest ancestor that's still posting-scale; once it balloons past
+    // ~40k it has folded in the left job-list / page chrome, so stop.
+    if (t.length >= 400 && t.length <= 40_000) best = t;
+    else if (t.length > 40_000) break;
+  }
+  return best.slice(0, MAX_CHARS);
 }
 
 interface YcJob {
@@ -325,6 +392,18 @@ export function getScanText(): string {
       const el = document.querySelector<HTMLElement>(sel);
       const t = el?.innerText?.trim();
       if (t && t.length > 80) return t.slice(0, MAX_CHARS);
+    }
+    // LinkedIn: the job detail pane is the ONLY valid source. If none of the
+    // known containers matched (an unfamiliar layout), try the layout-agnostic
+    // title-anchored read before giving up. Still never fall back to the whole
+    // page — that captures nav + profile rail + footer chrome.
+    if (location.hostname.endsWith('linkedin.com')) {
+      // "About the job" section — survives LinkedIn's class-hashed layouts.
+      const desc = linkedInDescription();
+      if (desc.trim().length > 80) return desc.slice(0, MAX_CHARS);
+      // Title-anchored posting block — classic top-card layouts.
+      const anchored = linkedInPostingText();
+      return anchored.trim().length > 80 ? anchored.slice(0, MAX_CHARS) : '';
     }
   }
   // Other sites (Greenhouse, Lever, Ashby, Workday, company pages): read just the
@@ -411,6 +490,30 @@ export function setBadgeFeatures(opts: { coverLetter: boolean; resume: boolean }
 export function captureJob(): { company: string; role: string; text: string } {
   const { company, role } = getJobMeta();
   return { company, role, text: getScanText() };
+}
+
+/**
+ * Like captureJob(), but waits for the posting to actually be readable first.
+ * On SPA job boards (LinkedIn, Handshake) an in-app navigation mounts the detail
+ * pane a beat before it paints — the containers exist in the DOM but their
+ * `innerText` is still empty, so a capture fired the instant the user clicks
+ * "Save" comes back blank (and a full page reload "fixes" it only because the
+ * server-rendered text is painted immediately). Poll getScanText() briefly until
+ * it returns a substantial description, then snapshot. Returns whatever we have
+ * once the deadline passes, so a genuinely empty page still fails cleanly.
+ */
+export async function captureJobWhenReady(
+  timeoutMs = 8000,
+  minChars = 400,
+): Promise<{ company: string; role: string; text: string }> {
+  const deadline = Date.now() + timeoutMs;
+  let text = getScanText();
+  while (text.trim().length < minChars && Date.now() < deadline) {
+    await new Promise((resolve) => setTimeout(resolve, 150));
+    text = getScanText();
+  }
+  const { company, role } = getJobMeta();
+  return { company, role, text };
 }
 
 /** Forced scan (used on load / enable): renders regardless of the hash gate. */
@@ -560,6 +663,48 @@ function el(tag: string, cls: string, text: string): HTMLElement {
  */
 function getJobMeta(): { company: string; role: string } {
   const clean = (s: string): string => s.replace(/\s+/g, ' ').trim().slice(0, 120);
+
+  // LinkedIn renders several headings across the page (left job-list, feedback
+  // widgets, "how you compare" upsell), so a generic "first h1" grabs the wrong
+  // one — on collections/split views it picks the left column's page heading
+  // ("Top job picks for you"). Scope to the selected job's detail pane and read
+  // its stable top-card containers instead.
+  if (location.hostname.endsWith('linkedin.com')) {
+    const pick = (sels: string[]): string => {
+      for (const sel of sels) {
+        const t = clean(document.querySelector<HTMLElement>(sel)?.textContent || '');
+        if (t) return t;
+      }
+      return '';
+    };
+    // Most reliable + fully layout-independent: LinkedIn sets document.title to
+    // "Role | Company | LinkedIn" (sometimes "(N) Role | Company | LinkedIn") on
+    // every job surface, hashed-class layouts included.
+    let role = '';
+    let company = '';
+    const bits = document.title
+      .replace(/^\(\d+\)\s*/, '')
+      .split('|')
+      .map((s) => s.trim())
+      .filter(Boolean);
+    if (bits.length >= 3 && /linkedin/i.test(bits[bits.length - 1])) {
+      role = clean(bits[0]);
+      company = clean(bits[1]);
+    }
+    // DOM fallback (older top-card markup) if the title wasn't a job title.
+    if (!role) role = pick(['[class*="top-card__job-title" i]', '[class*="topcard__title" i]']);
+    if (!company) {
+      company = pick([
+        '[class*="top-card__company-name" i] a',
+        '[class*="top-card__company-name" i]',
+        '[class*="topcard__org-name" i]',
+      ]);
+    }
+    // Never fall through to the generic page reader on LinkedIn — it grabs nav
+    // headings (e.g. "0 notifications"). Empty meta is fine; the save is gated on
+    // getScanText() finding real detail text anyway.
+    return { company, role };
+  }
 
   // Role: the job-title heading in the detail pane.
   const titleEl =

--- a/src/lib/ai/gemini.ts
+++ b/src/lib/ai/gemini.ts
@@ -34,14 +34,16 @@ export class GeminiProvider implements AIProvider {
         temperature: 0.7,
         maxOutputTokens: maxOutputTokens ?? 1024,
         // Gemini 2.5 models default thinking ON over REST, which can eat the
-        // whole output budget and truncate the answer. Pin the budget (dynamic
-        // when asked, off otherwise). thinkingConfig only applies to 2.5 models.
-        // 2.5 Pro can't disable thinking (budget 0 is rejected), so it always
-        // gets a dynamic budget.
+        // whole output budget and truncate the answer. Pin the budget: dynamic
+        // (-1) when the caller opts in; otherwise off (0). thinkingConfig only
+        // applies to 2.5 models. 2.5 Pro can't disable thinking (budget 0 is
+        // rejected), so give it a small BOUNDED budget (1024) rather than the
+        // dynamic -1, which would otherwise consume the output and truncate the
+        // reply mid-sentence.
         ...(modelId.includes('2.5')
           ? {
               thinkingConfig: {
-                thinkingBudget: thinking || modelId.includes('2.5-pro') ? -1 : 0,
+                thinkingBudget: thinking ? -1 : modelId.includes('2.5-pro') ? 1024 : 0,
               },
             }
           : {}),

--- a/src/lib/ai/prompts.ts
+++ b/src/lib/ai/prompts.ts
@@ -32,8 +32,11 @@ export function buildAnswerPrompt(
     // 2.5's dynamic "thinking" can consume the entire output budget and truncate
     // the visible answer to a word or two ("Fellow"). Disabling it gives the full
     // budget to the answer — quality is unaffected for short open-ended replies.
+    // 2.5 Pro can't fully disable thinking (it gets a bounded 1024 budget), so
+    // this budget must cover that reasoning PLUS a full answer — hence 4096, which
+    // also matches the server's MAX_OUTPUT_TOKENS clamp.
     thinking: false,
-    maxOutputTokens: 2048,
+    maxOutputTokens: 4096,
     prompt:
       `APPLICANT PROFILE:\n${context}\n\n` +
       job +

--- a/src/lib/host.test.ts
+++ b/src/lib/host.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from 'vitest';
+import { hostMatches } from './host';
+
+describe('hostMatches', () => {
+  it('matches the exact domain', () => {
+    expect(hostMatches('linkedin.com', 'linkedin.com')).toBe(true);
+  });
+
+  it('matches a real subdomain', () => {
+    expect(hostMatches('www.linkedin.com', 'linkedin.com')).toBe(true);
+    expect(hostMatches('jobs.lever.co', 'lever.co')).toBe(true);
+  });
+
+  it('rejects a look-alike host that merely ends with the domain string', () => {
+    // The bug this guards against: "evillinkedin.com".endsWith("linkedin.com") is
+    // true, so a naive .endsWith() check would wrongly treat this as LinkedIn.
+    expect(hostMatches('evillinkedin.com', 'linkedin.com')).toBe(false);
+    expect(hostMatches('notmyworkday.com', 'myworkday.com')).toBe(false);
+  });
+
+  it('rejects an unrelated host', () => {
+    expect(hostMatches('example.com', 'linkedin.com')).toBe(false);
+  });
+});

--- a/src/lib/host.ts
+++ b/src/lib/host.ts
@@ -1,0 +1,6 @@
+// True when `hostname` IS `domain` or a subdomain of it. Plain `.endsWith(domain)`
+// is a classic host-check bug — "evilgreenhouse.io".endsWith("greenhouse.io") is
+// also true — so every exact-or-subdomain host comparison goes through this.
+export function hostMatches(hostname: string, domain: string): boolean {
+  return hostname === domain || hostname.endsWith(`.${domain}`);
+}

--- a/src/popup/Popup.tsx
+++ b/src/popup/Popup.tsx
@@ -14,6 +14,18 @@ import { downloadLetter } from '../lib/coverLetter';
 import { downloadResume } from '../lib/resume';
 import { signIn, reconcileAuthUser, onAuthChanged, type AuthUser } from '../lib/auth';
 
+/** Compact "saved N ago" label for a saved job's timestamp. */
+function timeAgo(ts: number): string {
+  const secs = Math.max(0, Math.round((Date.now() - ts) / 1000));
+  if (secs < 60) return 'just now';
+  const mins = Math.round(secs / 60);
+  if (mins < 60) return `${mins} min ago`;
+  const hrs = Math.round(mins / 60);
+  if (hrs < 24) return `${hrs} hr ago`;
+  const days = Math.round(hrs / 24);
+  return `${days} day${days === 1 ? '' : 's'} ago`;
+}
+
 export function Popup() {
   const [tabId, setTabId] = useState<number | null>(null);
   const [page, setPage] = useState<PageInfo | null>(null);
@@ -26,13 +38,16 @@ export function Popup() {
   const [fillMsg, setFillMsg] = useState('');
   const [letter, setLetter] = useState('');
   const [resume, setResume] = useState('');
-  const [busy, setBusy] = useState<'' | 'fill' | 'letter' | 'resume'>('');
+  const [busy, setBusy] = useState<'' | 'fill' | 'letter' | 'resume' | 'save'>('');
   const [error, setError] = useState('');
   const [scanEnabled, setScanEnabled] = useState(true);
   const [coverLetterEnabled, setCoverLetterEnabled] = useState(true);
   const [resumeEnabled, setResumeEnabled] = useState(true);
   const [jobs, setJobs] = useState<SavedJob[]>([]);
   const [activeJobId, setActiveJobId] = useState<string | null>(null);
+  // Which saved-job rows show their capture preview. Collapsed by default; the
+  // user expands a row (chevron) to verify what text was captured for the AI.
+  const [expandedJobs, setExpandedJobs] = useState<Set<string>>(new Set());
   // Editable company/role, shared by the cover letter + resume (pre-filled from
   // page detection).
   const [company, setCompany] = useState('');
@@ -47,6 +62,15 @@ export function Popup() {
     setLocal(value);
     const profile = await getProfile();
     await saveProfile({ ...profile, [key]: value });
+  }
+
+  function toggleJobExpanded(id: string) {
+    setExpandedJobs((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
   }
 
   // Re-read the active tab's job info. Runs on mount and whenever the user
@@ -187,6 +211,7 @@ export function Popup() {
   async function onSaveJob() {
     if (!tabId) return;
     setError('');
+    setBusy('save');
     try {
       const cap = await sendToTab<CapturedJob>(tabId, { type: 'CAPTURE_JOB' });
       if (!cap.text || cap.text.trim().length < 40) {
@@ -201,6 +226,8 @@ export function Popup() {
       });
     } catch {
       setError('Could not read this page. Reload it and try again.');
+    } finally {
+      setBusy('');
     }
   }
 
@@ -270,15 +297,11 @@ export function Popup() {
 
       <div className="block savedjob">
         <button className="full" onClick={onSaveJob} disabled={busy !== '' || !tabId}>
-          💾 Save this job
+          {busy === 'save' ? 'Saving…' : '💾 Save this job'}
         </button>
         {activeJob ? (
           <div className="jobusing">
-            Using saved job:{' '}
-            <strong>
-              {activeJob.role || 'saved posting'}
-              {activeJob.company ? ` · ${activeJob.company}` : ''}
-            </strong>{' '}
+            Using a saved job for AI answers &amp; documents.{' '}
             <button className="ghost jobclear" onClick={() => setActiveJob(null)}>
               use current page
             </button>
@@ -292,24 +315,48 @@ export function Popup() {
         )}
         {jobs.length > 0 && (
           <div className="joblist">
-            {jobs.map((j) => (
-              <div key={j.id} className={`jobrow${j.id === activeJobId ? ' active' : ''}`}>
-                <button
-                  className="jobpick"
-                  title="Use this posting as the context for AI answers & documents"
-                  onClick={() => setActiveJob(j.id === activeJobId ? null : j.id)}
-                >
-                  <span className="dot" />
-                  <span className="jobname">
-                    {j.role || 'Saved job'}
-                    {j.company ? ` · ${j.company}` : ''}
-                  </span>
-                </button>
-                <button className="jobdel" title="Delete" onClick={() => deleteJob(j.id)}>
-                  ×
-                </button>
-              </div>
-            ))}
+            {jobs.map((j) => {
+              const expanded = expandedJobs.has(j.id);
+              return (
+                <div key={j.id} className={`jobitem${j.id === activeJobId ? ' active' : ''}`}>
+                  <div className="jobrow">
+                    <button
+                      className="jobpick"
+                      title="Use this posting as the context for AI answers & documents"
+                      onClick={() => setActiveJob(j.id === activeJobId ? null : j.id)}
+                    >
+                      <span className="dot" />
+                      <span className="jobname">
+                        {j.role || 'Saved job'}
+                        {j.company ? ` · ${j.company}` : ''}
+                      </span>
+                    </button>
+                    <button
+                      className="jobtoggle"
+                      title={expanded ? 'Hide what was saved' : 'Show what was saved'}
+                      aria-expanded={expanded}
+                      onClick={() => toggleJobExpanded(j.id)}
+                    >
+                      {expanded ? '▴' : '▾'}
+                    </button>
+                    <button className="jobdel" title="Delete" onClick={() => deleteJob(j.id)}>
+                      ×
+                    </button>
+                  </div>
+                  {expanded && (
+                    <div className="jobpreview">
+                      <div className="jobmeta">
+                        <span>{j.text.length.toLocaleString()} chars</span>
+                        <span>saved {timeAgo(j.savedAt)}</span>
+                      </div>
+                      <div className="jobsnippet">
+                        {j.text.trim() || '(no text captured)'}
+                      </div>
+                    </div>
+                  )}
+                </div>
+              );
+            })}
           </div>
         )}
       </div>

--- a/src/ui/ui.css
+++ b/src/ui/ui.css
@@ -115,19 +115,29 @@ button:disabled { opacity: .6; cursor: default; }
 .jobusing.muted { color: var(--muted); }
 .jobclear { font-size: 11px; padding: 2px 4px; }
 .joblist { margin-top: 8px; display: flex; flex-direction: column; gap: 4px; }
-.jobrow { display: flex; align-items: center; gap: 4px; border: 1px solid var(--border);
-  border-radius: 8px; padding: 2px 4px 2px 8px; background: #fff; }
-.jobrow.active { border-color: var(--primary); background: #f5f3ff; }
+.jobitem { border: 1px solid var(--border); border-radius: 8px; background: #fff; }
+.jobitem.active { border-color: var(--primary); background: #f5f3ff; }
+.jobrow { display: flex; align-items: center; gap: 4px; padding: 2px 4px 2px 8px; }
 .jobpick { flex: 1; min-width: 0; display: flex; align-items: center; gap: 8px;
   background: transparent; border: none; padding: 6px 0; font-size: 12px; text-align: left;
   color: var(--text); font-weight: 500; }
 .jobpick .dot { flex: none; width: 9px; height: 9px; border-radius: 50%;
   border: 1.5px solid var(--muted); box-sizing: border-box; }
-.jobrow.active .jobpick .dot { background: var(--primary); border-color: var(--primary); }
+.jobitem.active .jobpick .dot { background: var(--primary); border-color: var(--primary); }
 .jobname { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.jobtoggle { flex: none; background: transparent; border: none; color: var(--muted);
+  font-size: 12px; line-height: 1; padding: 4px 6px; cursor: pointer; }
+.jobtoggle:hover { color: var(--primary); }
 .jobdel { flex: none; background: transparent; border: none; color: var(--muted);
   font-size: 16px; line-height: 1; padding: 4px 6px; cursor: pointer; }
 .jobdel:hover { color: var(--danger); }
+
+/* Saved-job capture preview (verify the exact text fed to AI) */
+.jobpreview { padding: 6px 10px 10px; border-top: 1px solid var(--border); }
+.jobmeta { display: flex; gap: 12px; font-size: 11px; color: var(--muted); margin-bottom: 6px; }
+.jobsnippet { max-height: 140px; overflow-y: auto; font-size: 11px; line-height: 1.5;
+  color: var(--text); background: #fff; border: 1px solid var(--border); border-radius: 6px;
+  padding: 8px; white-space: pre-wrap; word-break: break-word; }
 
 .toggles-title { margin: 0 0 2px; font-size: 11px; font-weight: 700; color: var(--muted);
   text-transform: uppercase; letter-spacing: .04em; }


### PR DESCRIPTION
## Summary

**LinkedIn save & AI-answer gating**
- LinkedIn's job posting could live in several different DOM shapes depending on how you got there (fresh load, in-app SPA nav, or a hashed-class layout on `/jobs/search-results/`), so `getJobMeta()` / `getScanText()` often grabbed the wrong heading ("Are these results helpful?", "Top job picks for you") or page chrome instead of the real posting.
- Fixed by anchoring on things that are stable across every LinkedIn layout instead of CSS classes: `document.title` (`"Role | Company | LinkedIn"`) for role/company, and the "About the job" heading text for the description.
- `CAPTURE_JOB` is now answered by any job-board frame (not just the top frame), since LinkedIn's SPA/prerender navigation renders the posting into a sub-frame.
- Added a short poll after "Save this job" so SPA panes that haven't painted yet still get captured, and a safety net that fails cleanly ("No job posting detected") instead of ever saving page chrome.
- Popup: saved jobs show a collapsible, scrollable preview of the exact captured text so you can verify what's feeding the AI. Dropped the job URL from the preview since it was frequently wrong on split-view/collections pages.
- This was blocking the "✨ AI answer" button in Easy Apply, since that button is gated on having a usable saved job.

**Gemini 2.5 Pro answer truncation**
- Gemini 2.5 Pro can't disable "thinking" (the API rejects budget `0`), so it was falling back to an unbounded dynamic budget (`-1`) that consumed most of the output token budget and cut answers off mid-sentence.
- Bounded Pro's thinking to `1024` tokens on both the BYO-key path (`src/lib/ai/gemini.ts`) and the managed-proxy path (`server/index.js`).
- Raised the AI-answer output budget from 2048 → 4096 so bounded thinking plus a full answer both fit.
- Flash/Flash-Lite behavior is unchanged (thinking off → budget `0`).

## Test plan
- [x] `npm run build` (tsc + vite) clean
- [x] `node --check server/index.js` clean
- [ ] Reload unpacked; on LinkedIn (fresh load, in-app nav, and `/jobs/search-results/`) click **Save this job** → correct role/company, real description, no page chrome
- [ ] Open Easy Apply on a saved LinkedIn job → **✨ AI answer** appears and generates
- [ ] With Gemini 2.5 Pro selected, generate a few AI answers → no mid-sentence truncation; Flash unaffected
- [ ] Non-LinkedIn boards (Greenhouse/Lever/Workday) still save and generate correctly (regression check)
- [ ] Managed-proxy path needs `gcloud run deploy` for the Pro fix to take effect server-side

🤖 Generated with [Claude Code](https://claude.com/claude-code)