### PR TITLE
aria-labels to popup action buttons

### DIFF
--- a/src/popup/Popup.tsx
+++ b/src/popup/Popup.tsx
@@ -247,7 +247,12 @@ export function Popup() {
           <h1>Little AI Helper</h1>
           <p className="tagline">Autofill · cover letters · eligibility</p>
         </div>
-        <button className="ghost icon-btn" title="Refresh for the current tab" onClick={() => refresh()}>
+        <button
+          className="ghost icon-btn"
+          title="Refresh for the current tab"
+          aria-label="Refresh for the current tab"
+          onClick={() => refresh()}
+        >
           ↻
         </button>
       </header>
@@ -289,14 +294,24 @@ export function Popup() {
       )}
 
       <div className="block">
-        <button className="primary" disabled={!page?.supported || busy !== ''} onClick={onFill}>
+        <button
+          className="primary"
+          disabled={!page?.supported || busy !== ''}
+          onClick={onFill}
+          aria-label={busy === 'fill' ? 'Filling page' : 'Fill this page with profile data'}
+        >
           {busy === 'fill' ? 'Filling…' : 'Fill this page'}
         </button>
         {fillMsg && <div className="status">{fillMsg}</div>}
       </div>
 
       <div className="block savedjob">
-        <button className="full" onClick={onSaveJob} disabled={busy !== '' || !tabId}>
+        <button
+          className="full"
+          onClick={onSaveJob}
+          disabled={busy !== '' || !tabId}
+          aria-label={busy === 'save' ? 'Saving job details' : 'Save this job'}
+        >
           {busy === 'save' ? 'Saving…' : '💾 Save this job'}
         </button>
         {activeJob ? (
@@ -324,6 +339,7 @@ export function Popup() {
                       className="jobpick"
                       title="Use this posting as the context for AI answers & documents"
                       onClick={() => setActiveJob(j.id === activeJobId ? null : j.id)}
+                      aria-label={`${j.id === activeJobId ? 'Stop using' : 'Use'} ${j.role || 'saved job'}${j.company ? ` at ${j.company}` : ''} as AI context`}
                     >
                       <span className="dot" />
                       <span className="jobname">
@@ -335,11 +351,17 @@ export function Popup() {
                       className="jobtoggle"
                       title={expanded ? 'Hide what was saved' : 'Show what was saved'}
                       aria-expanded={expanded}
+                      aria-label={expanded ? `Hide saved details for ${j.role || 'job'}${j.company ? ` at ${j.company}` : ''}` : `Show saved details for ${j.role || 'job'}${j.company ? ` at ${j.company}` : ''}`}
                       onClick={() => toggleJobExpanded(j.id)}
                     >
                       {expanded ? '▴' : '▾'}
                     </button>
-                    <button className="jobdel" title="Delete" onClick={() => deleteJob(j.id)}>
+                    <button
+                      className="jobdel"
+                      title="Delete"
+                      aria-label={`Delete ${j.role || 'saved job'}${j.company ? ` at ${j.company}` : ''}`}
+                      onClick={() => deleteJob(j.id)}
+                    >
                       ×
                     </button>
                   </div>
@@ -377,7 +399,12 @@ export function Popup() {
           />
         </div>
 
-        <button className="primary" disabled={busy !== ''} onClick={onCoverLetter}>
+        <button
+          className="primary"
+          disabled={busy !== ''}
+          onClick={onCoverLetter}
+          aria-label={busy === 'letter' ? 'Generating cover letter' : 'Generate cover letter'}
+        >
           {busy === 'letter' ? 'Generating…' : 'Generate cover letter'}
         </button>
         {letter && (
@@ -402,6 +429,7 @@ export function Popup() {
           style={{ marginTop: 8 }}
           disabled={busy !== ''}
           onClick={onResume}
+          aria-label={busy === 'resume' ? 'Tailoring resume' : 'Generate tailored resume'}
         >
           {busy === 'resume' ? 'Tailoring…' : 'Generate tailored resume'}
         </button>


### PR DESCRIPTION
## What & why

I added descriptive aria-labels to: the refresh (↻) button, "Fill this page", "Save this job", the saved-job picker row, the expand/collapse chevron, the delete (×) button, and the "Generate cover letter"/"Generate tailored resume" buttons.

## How I tested

No tests needed - only UI fix.

## Checklist

- [✓ ] `npm run lint` passes
- [✓ ] `npm run typecheck` passes
- [ ✓] `npm test` passes
- [✓ ] `npm run build` succeeds
- [✓ ] Tests added/updated if behavior changed - UI/accessibility fix,no tests needed
- [✓ ] No secrets, keys, or personal data committed
