### PR TITLE
chore(deps-dev): bump @types/chrome to 0.2.2 (supersedes #40)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
       "devDependencies": {
         "@crxjs/vite-plugin": "^2.0.0-beta.28",
         "@eslint/js": "^9.39.4",
-        "@types/chrome": "^0.0.270",
+        "@types/chrome": "^0.2.2",
         "@types/node": "^22.19.21",
         "@types/react": "^18.3.12",
         "@types/react-dom": "^18.3.1",
@@ -1675,9 +1675,9 @@
       }
     },
     "node_modules/@types/chrome": {
-      "version": "0.0.270",
-      "resolved": "https://registry.npmjs.org/@types/chrome/-/chrome-0.0.270.tgz",
-      "integrity": "sha512-ADvkowV7YnJfycZZxL2brluZ6STGW+9oKG37B422UePf2PCXuFA/XdERI0T18wtuWPx0tmFeZqq6MOXVk1IC+Q==",
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@types/chrome/-/chrome-0.2.2.tgz",
+      "integrity": "sha512-8rSMZ4cvo2xmaSyQg0sN5yRL7oiDkntLoiHxUhfwQnv1mvnkrdoZ25SlNrKWmYKaeP50WvrfWj1pmc02+U9KKw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "devDependencies": {
     "@crxjs/vite-plugin": "^2.0.0-beta.28",
     "@eslint/js": "^9.39.4",
-    "@types/chrome": "^0.0.270",
+    "@types/chrome": "^0.2.2",
     "@types/node": "^22.19.21",
     "@types/react": "^18.3.12",
     "@types/react-dom": "^18.3.1",

--- a/src/lib/profile.ts
+++ b/src/lib/profile.ts
@@ -162,7 +162,9 @@ function withDefaults(stored: Partial<Profile> | undefined): Profile {
 
 export async function getProfile(): Promise<Profile> {
   const result = await chrome.storage.local.get(STORAGE_KEY);
-  return withDefaults(result[STORAGE_KEY]);
+  // @types/chrome now types storage values as `unknown`; we control what's written
+  // to this key, and withDefaults guards missing/partial data, so the assertion is safe.
+  return withDefaults(result[STORAGE_KEY] as Partial<Profile> | undefined);
 }
 
 export async function saveProfile(profile: Profile): Promise<void> {
@@ -176,7 +178,7 @@ export function onProfileChanged(cb: (profile: Profile) => void): () => void {
     area: string,
   ) => {
     if (area === 'local' && changes[STORAGE_KEY]) {
-      cb(withDefaults(changes[STORAGE_KEY].newValue));
+      cb(withDefaults(changes[STORAGE_KEY].newValue as Partial<Profile> | undefined));
     }
   };
   chrome.storage.onChanged.addListener(listener);

--- a/src/lib/savedJobs.ts
+++ b/src/lib/savedJobs.ts
@@ -33,7 +33,9 @@ function withDefaults(stored: Partial<SavedJobsState> | undefined): SavedJobsSta
 
 export async function getSavedJobs(): Promise<SavedJobsState> {
   const result = await chrome.storage.local.get(STORAGE_KEY);
-  return withDefaults(result[STORAGE_KEY]);
+  // @types/chrome now types storage values as `unknown`; we control this key's
+  // shape and withDefaults guards missing/partial data, so the assertion is safe.
+  return withDefaults(result[STORAGE_KEY] as Partial<SavedJobsState> | undefined);
 }
 
 async function setSavedJobs(state: SavedJobsState): Promise<void> {
@@ -85,7 +87,7 @@ export function onSavedJobsChanged(cb: (state: SavedJobsState) => void): () => v
     area: string,
   ) => {
     if (area === 'local' && changes[STORAGE_KEY]) {
-      cb(withDefaults(changes[STORAGE_KEY].newValue));
+      cb(withDefaults(changes[STORAGE_KEY].newValue as Partial<SavedJobsState> | undefined));
     }
   };
   chrome.storage.onChanged.addListener(listener);

--- a/src/popup/Popup.tsx
+++ b/src/popup/Popup.tsx
@@ -141,7 +141,7 @@ export function Popup() {
   useEffect(() => {
     refresh();
     const onActivated = () => refresh();
-    const onUpdated = (_id: number, change: chrome.tabs.TabChangeInfo, tab: chrome.tabs.Tab) => {
+    const onUpdated = (_id: number, change: chrome.tabs.OnUpdatedInfo, tab: chrome.tabs.Tab) => {
       if (tab.active && change.status === 'complete') refresh();
     };
     chrome.tabs.onActivated.addListener(onActivated);
@@ -150,7 +150,6 @@ export function Popup() {
       chrome.tabs.onActivated.removeListener(onActivated);
       chrome.tabs.onUpdated.removeListener(onUpdated);
     };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   async function onFill() {


### PR DESCRIPTION
Supersedes #40 (Dependabot), which failed CI. The `@types/chrome` `0.0.270 → 0.2.x` jump is the DefinitelyTyped → auto-generated (`chrome-types`) migration — stricter, with a couple of renamed members. This bumps the dep **and** fixes the 5 resulting typecheck errors so it lands green.

## Changes
- `chrome.storage.local.get()` / `StorageChange.newValue` are now typed `unknown` (were `any`). Asserted to the known stored shape at the 4 call sites in `src/lib/profile.ts` / `src/lib/savedJobs.ts` — we own those storage keys and `withDefaults` already guards missing/partial data.
- `chrome.tabs.TabChangeInfo` → `chrome.tabs.OnUpdatedInfo` (renamed) in the `onUpdated` listener in `src/popup/Popup.tsx`.
- Removed a now-dead `eslint-disable-next-line react-hooks/exhaustive-deps` in `Popup.tsx` (ESLint reported it as unused) → lint is now warning-free.

## Test plan
- [x] `npm run typecheck` clean
- [x] `npm run lint` clean (0 errors, 0 warnings)
- [x] `npm test` — 18 passed
- [x] `npm run build` clean

Closes #40

🤖 Generated with [Claude Code](https://claude.com/claude-code)