### PR TITLE
docs: add contributing guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,71 @@
+# Contributing to Little AI Helper
+
+Thanks for helping improve Little AI Helper. This project is a Manifest V3
+Chrome extension built with TypeScript, React, Vite, and Vitest.
+
+## Dev Setup
+
+Install dependencies:
+
+```bash
+npm install
+```
+
+Start the Vite dev server:
+
+```bash
+npm run dev
+```
+
+Then load the extension in Chrome:
+
+1. Open `chrome://extensions`.
+2. Enable Developer mode.
+3. Click Load unpacked.
+4. Select the generated `dist/` folder.
+
+For a production-style bundle, run:
+
+```bash
+npm run build
+```
+
+The build script typechecks first, then writes the extension bundle to `dist/`.
+
+## Before Opening a PR
+
+Run the full local check set:
+
+```bash
+npm run lint
+npm run typecheck
+npm test
+npm run build
+```
+
+If you change icons, regenerate them from `assets/icon-source.png`:
+
+```bash
+python3 scripts/make-icons.py
+```
+
+## Project Conventions
+
+- Keep pull requests small and focused.
+- TypeScript is strict; avoid `any` unless there is no safer type.
+- Add or update tests when behavior changes.
+- Keep extension permissions narrow and explain any permission change.
+- Do not commit secrets, API keys, resumes, job-application data, or other
+  personal data.
+- Keep AI-provider changes behind the provider interfaces in `src/lib/ai/`.
+- Put site-specific autofill behavior in `src/content/adapters/`.
+
+## Where to Start
+
+Look for issues labeled
+[`good first issue`](https://github.com/ritsth/job-autofill-extension/labels/good%20first%20issue).
+Good starter changes are usually docs improvements, focused adapter fixes,
+tests for existing helpers, or small UI polish.
+
+When you open a PR, include a short summary, link the issue, and list the local
+commands you ran.

--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ and deploy the server with `OAUTH_CLIENT_ID` + `DAILY_LIMIT`.
 
 ## Contributing
 
-Issues and pull requests are welcome — see the [good first issues](https://github.com/ritsth/job-autofill-extension/labels/good%20first%20issue) to get started. Before opening a PR, run `npm run lint`, `npm run typecheck`, `npm test`, and `npm run build`.
+Issues and pull requests are welcome. See [CONTRIBUTING.md](CONTRIBUTING.md) for setup, local checks, and project conventions, then browse the [good first issues](https://github.com/ritsth/job-autofill-extension/labels/good%20first%20issue) to get started.
 
 ## License
 


### PR DESCRIPTION
Closes #29.

## Summary
- add a root `CONTRIBUTING.md` with setup, unpacked Chrome loading steps, pre-PR checks, conventions, and starter-issue guidance
- link the guide from the README contributing section

## Validation
- `npm install`
- `npm run lint`
- `npm run typecheck`
- `npm test` (3 files, 18 tests)
- `npm run build`
- `git diff --check`

## Notes
- `npm install` reported existing npm audit findings (3 moderate, 1 high, 1 critical). I left dependency versions unchanged because this PR is docs-only.