### PR TITLE
fix: tolerate imperfect model JSON in resume + eligibility parsing

### DIFF
--- a/src/lib/jobEligibility.ts
+++ b/src/lib/jobEligibility.ts
@@ -1,4 +1,4 @@
-import { extractJsonObject } from './resumeImport';
+import { parseLooseJson } from './resumeImport';
 import type { SponsorAnalysis } from '../content/sponsorship';
 
 // Parses the AI's job-eligibility JSON into the same shape the rules pass uses,
@@ -14,9 +14,8 @@ interface RawEligibility {
 }
 
 export function parseEligibilityJson(raw: string): SponsorAnalysis {
-  const json = extractJsonObject(raw);
-  if (!json) throw new Error('The AI did not return readable JSON.');
-  const d = JSON.parse(json) as RawEligibility;
+  const d = parseLooseJson(raw) as RawEligibility | null;
+  if (!d) throw new Error('The AI did not return readable JSON.');
 
   const sponsorship = (d.sponsorship || '').toLowerCase();
   const citizenship = (d.citizenship || '').toLowerCase();

--- a/src/lib/resumeImport.test.ts
+++ b/src/lib/resumeImport.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from 'vitest';
+import { parseLooseJson, extractJsonObject, parseResumeJson } from './resumeImport';
+
+describe('parseLooseJson', () => {
+  it('parses clean JSON', () => {
+    expect(parseLooseJson('{"a":1}')).toEqual({ a: 1 });
+  });
+
+  it('strips code fences', () => {
+    expect(parseLooseJson('```json\n{"a":1}\n```')).toEqual({ a: 1 });
+  });
+
+  it('ignores prose before and after the object', () => {
+    expect(parseLooseJson('Sure! Here is the JSON:\n{"a":1}\nHope that helps.')).toEqual({ a: 1 });
+  });
+
+  it('recovers from an unescaped newline inside a string value', () => {
+    // Invalid strict JSON (raw newline in the string) — the classic model failure.
+    const raw = '{"summary":"line one\nline two"}';
+    expect(() => JSON.parse(raw)).toThrow();
+    expect(parseLooseJson(raw)).toEqual({ summary: 'line one line two' });
+  });
+
+  it('repairs a truncated response (cut off mid-string)', () => {
+    const raw = '{"work":[{"title":"Engineer","company":"Acme","description":"Did a lot of goo';
+    const out = parseLooseJson(raw) as { work: { title: string; company: string }[] };
+    expect(out.work[0].title).toBe('Engineer');
+    expect(out.work[0].company).toBe('Acme');
+  });
+
+  it('repairs truncation cut at a dangling key', () => {
+    const raw = '{"a":1,"b":2,"c":';
+    expect(parseLooseJson(raw)).toEqual({ a: 1, b: 2 });
+  });
+
+  it('returns null when nothing is parseable', () => {
+    expect(parseLooseJson('no json here at all')).toBeNull();
+  });
+});
+
+describe('extractJsonObject', () => {
+  it('returns the balanced object and drops trailing prose', () => {
+    expect(extractJsonObject('{"a":{"b":1}} trailing junk }')).toBe('{"a":{"b":1}}');
+  });
+
+  it('does not stop at a brace inside a string', () => {
+    expect(extractJsonObject('{"a":"has } brace"}')).toBe('{"a":"has } brace"}');
+  });
+});
+
+describe('parseResumeJson', () => {
+  it('maps a truncated resume response to partial data instead of throwing', () => {
+    const raw =
+      '{"personal":{"firstName":"Ada","lastName":"Lovelace","email":"ada@x.com"},' +
+      '"work":[{"title":"Engineer","company":"Acme","startDate":"2020","endDate":"present","descrip';
+    const parsed = parseResumeJson(raw);
+    expect(parsed.personal.firstName).toBe('Ada');
+    expect(parsed.work[0].company).toBe('Acme');
+  });
+});

--- a/src/lib/resumeImport.ts
+++ b/src/lib/resumeImport.ts
@@ -17,13 +17,9 @@ function str(v: unknown): string {
  * fences and stray prose around the JSON object.
  */
 export function parseResumeJson(raw: string): ParsedResume {
-  const json = extractJsonObject(raw);
-  if (!json) throw new Error('The AI did not return readable JSON. Try again.');
-
-  let data: unknown;
-  try {
-    data = JSON.parse(json);
-  } catch {
+  const data = parseLooseJson(raw);
+  if (data === null) {
+    console.warn('[resume import] unparseable AI response (first 400 chars):', raw.slice(0, 400));
     throw new Error('Could not parse the AI response as JSON. Try again.');
   }
 
@@ -74,11 +70,105 @@ export function parseResumeJson(raw: string): ParsedResume {
   return { personal, work, education, skills };
 }
 
-/** Pulls the first balanced {...} block out of a possibly-fenced string. */
+/**
+ * Extracts the JSON object from a model response that may be wrapped in code
+ * fences or surrounded by prose. Scans from the first `{` tracking string/escape
+ * state to find the matching close brace, so trailing commentary is dropped. If
+ * the response was truncated (never balances), returns everything from the first
+ * `{` onward and lets {@link parseLooseJson} repair it.
+ */
 export function extractJsonObject(raw: string): string | null {
   const cleaned = raw.replace(/```json/gi, '').replace(/```/g, '');
   const start = cleaned.indexOf('{');
-  const end = cleaned.lastIndexOf('}');
-  if (start === -1 || end === -1 || end <= start) return null;
-  return cleaned.slice(start, end + 1);
+  if (start === -1) return null;
+
+  const stack: string[] = [];
+  let inStr = false;
+  let esc = false;
+  for (let i = start; i < cleaned.length; i++) {
+    const c = cleaned[i];
+    if (inStr) {
+      if (esc) esc = false;
+      else if (c === '\\') esc = true;
+      else if (c === '"') inStr = false;
+      continue;
+    }
+    if (c === '"') inStr = true;
+    else if (c === '{' || c === '[') stack.push(c === '{' ? '}' : ']');
+    else if (c === '}' || c === ']') {
+      stack.pop();
+      if (stack.length === 0) return cleaned.slice(start, i + 1);
+    }
+  }
+  // Unbalanced → truncated response; hand the tail to the repair step.
+  return cleaned.slice(start);
+}
+
+/** Replaces raw control characters with spaces — models sometimes emit an
+ * unescaped newline/tab inside a string value, which is invalid JSON. Structural
+ * whitespace is unaffected (it's already insignificant between tokens). */
+function stripControlChars(s: string): string {
+  // eslint-disable-next-line no-control-regex
+  return s.replace(/[\u0000-\u001F]/g, ' ');
+}
+
+/** Balances an unterminated JSON fragment: closes a dangling string, drops a
+ * trailing comma/whitespace, then appends the missing `}`/`]` in the right order. */
+function closeOpen(s: string): string {
+  const stack: string[] = [];
+  let inStr = false;
+  let esc = false;
+  for (let i = 0; i < s.length; i++) {
+    const c = s[i];
+    if (inStr) {
+      if (esc) esc = false;
+      else if (c === '\\') esc = true;
+      else if (c === '"') inStr = false;
+      continue;
+    }
+    if (c === '"') inStr = true;
+    else if (c === '{' || c === '[') stack.push(c === '{' ? '}' : ']');
+    else if (c === '}' || c === ']') stack.pop();
+  }
+  let out = inStr ? `${s}"` : s;
+  out = out.replace(/[,\s]+$/, ''); // trailing comma / whitespace (keeps a closing quote)
+  for (let i = stack.length - 1; i >= 0; i--) out += stack[i];
+  return out;
+}
+
+/**
+ * Parses a JSON object out of a raw model response, tolerating the ways models
+ * break strict JSON: code fences, surrounding prose, unescaped control chars in
+ * string values, and truncation. For a truncated response it recovers as much as
+ * parses by closing the fragment and, if that still fails, trimming back to the
+ * last structural boundary and retrying. Returns null only when nothing is
+ * recoverable.
+ */
+export function parseLooseJson(raw: string): unknown | null {
+  const extracted = extractJsonObject(raw);
+  if (!extracted) return null;
+  const sanitized = stripControlChars(extracted);
+
+  try {
+    return JSON.parse(sanitized);
+  } catch {
+    // Fall through to truncation recovery.
+  }
+
+  let candidate = sanitized;
+  for (let attempt = 0; attempt < 60 && candidate.length; attempt++) {
+    try {
+      return JSON.parse(closeOpen(candidate));
+    } catch {
+      // Trim back to the last comma / closing bracket and try a shorter prefix.
+      const cut = Math.max(
+        candidate.lastIndexOf(','),
+        candidate.lastIndexOf('}'),
+        candidate.lastIndexOf(']'),
+      );
+      if (cut <= 0) break;
+      candidate = candidate.slice(0, cut);
+    }
+  }
+  return null;
 }


### PR DESCRIPTION
## Problem

Recurring **"Could not parse the AI response as JSON. Try again."** on resume import (and the same brittleness in the eligibility "AI check").

## Root cause

`extractJsonObject` used naive `indexOf('{')` / `lastIndexOf('}')` and the callers did a bare `JSON.parse`, which throws on the common ways models break *strict* JSON — even when the content is basically fine:

- **Unescaped control characters** — a raw newline/tab inside a string value (e.g. a multi-line work `description`). This is the most frequent culprit and fails even on a complete response.
- Surrounding prose or a stray/partial code fence.
- **Truncation** — the response cut off mid-object.

This is provider-agnostic (it bit Gemini, the proxy, and especially the on-device model, which doesn't support JSON mode at all).

## Fix

New `parseLooseJson()` used by both `parseResumeJson` and `parseEligibilityJson`:

- `extractJsonObject` now scans **string/escape-aware** for the *matching* close brace, so trailing prose is dropped and a `}` inside a string no longer ends the object early.
- Control characters are replaced with spaces before parsing (fixes the unescaped-newline case).
- Truncated responses are recovered by closing the open string/brackets, and if that still fails, trimming back to the last structural boundary and retrying — so **partial data comes through instead of a hard failure**.
- On a genuine miss, `parseResumeJson` logs the raw response (first 400 chars) to the console to aid future debugging.

**Client-only — no server redeploy needed.**

## Test plan
- [x] New `src/lib/resumeImport.test.ts`: fences, leading/trailing prose, unescaped newline in a value, truncation mid-string, truncation at a dangling key, and unrecoverable input → 10 cases.
- [x] `npm run lint` / `typecheck` clean; full suite **28 tests pass**; `npm run build` clean.
- [ ] Manual: import the resume that was failing → sections populate (was erroring before).

🤖 Generated with [Claude Code](https://claude.com/claude-code)