### PR TITLE
fix(server): harden proxy — error sanitization, cache cap, body guards, configurable CORS

### DIFF
--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -158,12 +158,27 @@ gcloud billing accounts add-iam-policy-binding "${BILLING_ACCT#billingAccounts/}
   Google accounts in a short window = Sybil signal). Today you'd only notice via the bill.
 - **Cloud Armor** per-IP rate limiting — needs an external HTTPS load balancer in front of
   Cloud Run; heavier setup. Optional unless abuse is observed.
-- **CORS:** currently `Access-Control-Allow-Origin: *`. Low risk (every call still needs a
-  token whose audience is our OAuth client), but tightening to the extension origin reduces
-  drive-by attempts.
+- **CORS:** ✅ configurable via `ALLOWED_ORIGIN` (default `*` for dev). In production set
+  it to the extension origin so a web page can't call the proxy from a browser context:
+  `gcloud run services update ai-proxy --set-env-vars ALLOWED_ORIGIN=chrome-extension://<EXTENSION_ID>`
+  (the ID is stable because the manifest pins `key`). Non-browser clients are unaffected —
+  abuse still requires a valid bearer token.
 - **Least privilege:** confirm the Cloud Run runtime SA holds only `aiplatform.user` +
   `datastore.user` (+ `secretmanager.secretAccessor` after P1), nothing broader.
 - **Supply chain:** `npm audit` in `server/`, pin dependency versions, enable Dependabot.
+
+### P5 — Server hardening round 2 — ✅ DONE (needs redeploy)
+- **Error sanitization:** ✅ unexpected (5xx) errors now return a generic message; the raw
+  Vertex error (which can include project/region/quota detail) goes only to Cloud Logging.
+  Curated 4xx messages (401/413/429 quota) are unchanged.
+- **Token cache bound:** ✅ the per-instance verified-token cache is capped at 5000 entries
+  with oldest-first eviction, so a flood of distinct tokens can't grow memory unbounded.
+- **Body type-guards:** ✅ `model` must be an allowlisted *string*; `maxOutputTokens` must
+  be a finite positive number or it falls back to the default before the server cap.
+- **Firestore TTL check:** the `usage` docs carry `expireAt`; verify the TTL policy is
+  actually enabled so they get pruned:
+  `gcloud firestore fields ttls list --collection-group=usage` (should list `expireAt`;
+  if empty: `gcloud firestore fields ttls update expireAt --collection-group=usage --enable-ttl`).
 
 ### P4 — App correctness / privacy — ✅ DONE
 - **Prompt injection:** ✅ The three prompts that consume page-scraped text

--- a/server/index.js
+++ b/server/index.js
@@ -49,6 +49,12 @@ const GLOBAL_DAILY_LIMIT = Number(process.env.GLOBAL_DAILY_LIMIT || 2000);
 // 1 MB body cap) so one call can't be made arbitrarily expensive.
 const MAX_OUTPUT_TOKENS = Number(process.env.MAX_OUTPUT_TOKENS || 4096);
 const MAX_PROMPT_CHARS = Number(process.env.MAX_PROMPT_CHARS || 200_000);
+// Origin allowed to call this service from a browser context. Set it to the
+// extension's origin (chrome-extension://<id> — stable, the manifest pins a key)
+// so a random web page can't ride a user's session from the browser. '*' keeps
+// dev/self-hosted setups working out of the box; non-browser clients (curl)
+// aren't affected either way — real abuse still requires a valid bearer token.
+const ALLOWED_ORIGIN = process.env.ALLOWED_ORIGIN || '*';
 
 if (!PROJECT) console.warn('[proxy] GOOGLE_CLOUD_PROJECT is not set');
 if (!OAUTH_CLIENT_ID) console.warn('[proxy] OAUTH_CLIENT_ID is not set — Google sign-in will be rejected!');
@@ -70,7 +76,10 @@ function safeEqual(a, b) {
 
 // tokeninfo is ~1 network call; access tokens live ~1h. Cache the verified
 // identity by token so we resolve a user at most once per token lifetime per
-// instance instead of on every /generate call.
+// instance instead of on every /generate call. Capped so a flood of distinct
+// tokens can't grow the map without bound on a long-lived instance; honest
+// traffic (one entry per signed-in user per hour) never gets near the cap.
+const TOKEN_CACHE_MAX = 5000;
 const tokenCache = new Map(); // accessToken -> { sub, email, exp(ms) }
 
 /**
@@ -100,6 +109,10 @@ async function verifyGoogleToken(accessToken) {
   if (expMs <= Date.now()) return null;
 
   const identity = { sub: info.sub, email: info.email || '', exp: expMs };
+  // Evict the oldest entry when full (Map iterates in insertion order).
+  if (tokenCache.size >= TOKEN_CACHE_MAX) {
+    tokenCache.delete(tokenCache.keys().next().value);
+  }
   tokenCache.set(accessToken, identity);
   return identity;
 }
@@ -140,7 +153,7 @@ async function checkAndIncrementQuota(sub, email) {
 }
 
 const CORS_HEADERS = {
-  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Origin': ALLOWED_ORIGIN,
   'Access-Control-Allow-Methods': 'POST, OPTIONS',
   'Access-Control-Allow-Headers': 'Authorization, Content-Type',
 };
@@ -163,16 +176,23 @@ function readBody(req) {
 }
 
 async function generate({ system, prompt, maxOutputTokens, json, thinking, model: requested }) {
-  // Honor the client's model only if it's allowlisted; otherwise use the default.
-  const modelId = requested && MODEL_ALLOWLIST.has(requested) ? requested : MODEL;
+  // Honor the client's model only if it's an allowlisted string; otherwise use
+  // the default. The body is attacker-controlled JSON, so never trust its types.
+  const modelId =
+    typeof requested === 'string' && MODEL_ALLOWLIST.has(requested) ? requested : MODEL;
+  const requestedTokens = Number(maxOutputTokens);
   const model = vertex.getGenerativeModel({
     model: modelId,
     systemInstruction: system ? { role: 'system', parts: [{ text: system }] } : undefined,
     generationConfig: {
       temperature: 0.7,
       // Clamp to the server cap regardless of what the client requests, so a
-      // crafted body can't make one call arbitrarily expensive.
-      maxOutputTokens: Math.min(Number(maxOutputTokens) || 1024, MAX_OUTPUT_TOKENS),
+      // crafted body can't make one call arbitrarily expensive. Non-numeric or
+      // non-positive values fall back to the default rather than reaching Vertex.
+      maxOutputTokens: Math.min(
+        Number.isFinite(requestedTokens) && requestedTokens > 0 ? requestedTokens : 1024,
+        MAX_OUTPUT_TOKENS,
+      ),
       // Thinking on (dynamic budget) only when asked — better open-ended
       // answers. Off by default: 2.5 Flash otherwise spends the output budget
       // on hidden reasoning and truncates/empties short requests. 2.5 Pro can't
@@ -260,9 +280,14 @@ const server = http.createServer(async (req, res) => {
     if (!text) return send(res, 502, { error: 'Empty response from Vertex AI' });
     return send(res, 200, { text });
   } catch (err) {
+    // Full detail goes to Cloud Logging only. Vertex error messages can carry
+    // internal detail (project/region/quota specifics), so the client gets a
+    // generic message — the curated 4xx responses above are unaffected.
     console.error('[proxy] error', err);
-    const status = err?.code === 429 ? 429 : 500;
-    return send(res, status, { error: String(err?.message || err) });
+    if (err?.code === 429) {
+      return send(res, 429, { error: 'The AI service is busy right now. Try again shortly.' });
+    }
+    return send(res, 500, { error: 'Generation failed. Try again.' });
   }
 });
 


### PR DESCRIPTION
Second hardening round on the Cloud Run proxy, from a security audit.

## Changes
- **Sanitize 5xx errors**: unexpected errors now return a generic message; the raw Vertex error (which can include project/region/quota detail) goes only to Cloud Logging. Curated 4xx messages (401 / 413 / 429 quota) unchanged.
- **Bound the token cache**: capped at 5000 entries with oldest-first eviction, so a flood of distinct bearer tokens can't grow instance memory unbounded.
- **Type-guard the request body**: `model` must be an allowlisted *string*; `maxOutputTokens` must be a finite positive number, else the default applies before the server cap.
- **Configurable CORS**: `Access-Control-Allow-Origin` now reads `ALLOWED_ORIGIN` (default `*` keeps dev working). Production can pin the extension origin — documented in `docs/SECURITY.md`.
- `docs/SECURITY.md`: new **P5** section recording these, marks the P3 CORS item addressed, and adds the Firestore TTL verification command for the `usage` collection.

## Deploy note
Server-only — takes effect on the next `gcloud run deploy`. Optionally set `ALLOWED_ORIGIN=chrome-extension://<EXTENSION_ID>` at the same time.

## Verification
- `node --check server/index.js` passes.
- No client-side changes; extension behavior is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)