### PR TITLE
fix(extension): Gemini key via header + explicit sender check

### DIFF
--- a/src/background/service-worker.ts
+++ b/src/background/service-worker.ts
@@ -35,7 +35,11 @@ async function resolveProvider(ai: AISettings): Promise<AIProvider> {
   return getProvider(ai);
 }
 
-chrome.runtime.onMessage.addListener((msg: BackgroundMessage, _sender, sendResponse) => {
+chrome.runtime.onMessage.addListener((msg: BackgroundMessage, sender, sendResponse) => {
+  // Only our own pages/content scripts may drive the AI hub. No
+  // externally_connectable is declared, so this can't fire for web pages today —
+  // the check makes that boundary explicit rather than implicit.
+  if (sender.id !== chrome.runtime.id) return false;
   // Only handle our AI messages; ignore content-targeted ones.
   if (
     msg?.type !== 'AI_GENERATE_ANSWER' &&

--- a/src/lib/ai/gemini.ts
+++ b/src/lib/ai/gemini.ts
@@ -23,9 +23,7 @@ export class GeminiProvider implements AIProvider {
 
     // Per-request override (free-text answers) wins; otherwise the fast default.
     const modelId = model || this.model;
-    const url = `${ENDPOINT}/${encodeURIComponent(modelId)}:generateContent?key=${encodeURIComponent(
-      this.apiKey,
-    )}`;
+    const url = `${ENDPOINT}/${encodeURIComponent(modelId)}:generateContent`;
 
     const body = {
       systemInstruction: { parts: [{ text: system }] },
@@ -55,7 +53,9 @@ export class GeminiProvider implements AIProvider {
     try {
       res = await fetch(url, {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+        // The key travels as a header, not a `?key=` query param — URLs leak
+        // into logs and history; headers don't.
+        headers: { 'Content-Type': 'application/json', 'x-goog-api-key': this.apiKey },
         body: JSON.stringify(body),
       });
     } catch (e) {


### PR DESCRIPTION
Two small extension hardening fixes from a security audit.

## Changes
- **Gemini BYO key moves out of the URL** (`src/lib/ai/gemini.ts`): sent as the `x-goog-api-key` header (officially supported) instead of `?key=` query param. Keys in URLs can end up in proxy/access logs and history; headers don't.
- **Explicit sender validation** (`src/background/service-worker.ts`): the AI message hub early-returns unless `sender.id === chrome.runtime.id`. No `externally_connectable` is declared, so web pages can't message the extension today — this makes the boundary explicit rather than implicit.

## Verification
- `npm run lint`, `npm run typecheck`, `npm test` (18 tests), `npm run build` — all green.
- No behavior change for users; BYO-key requests carry the same key, just in a header.

🤖 Generated with [Claude Code](https://claude.com/claude-code)