### PR TITLE
ci/docs: pin actions to SHAs, add security policy, document release process

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,9 +18,9 @@ jobs:
     name: Lint · typecheck · test · build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: 20
           cache: npm
@@ -39,7 +39,7 @@ jobs:
 
       - name: Upload Web Store zip
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: web-store-package
           path: web-store-package.zip
@@ -49,8 +49,8 @@ jobs:
     name: Server syntax check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
-      - uses: actions/setup-node@v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: 20
       # The proxy is a single ESM file with no build step — a syntax check is the

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -18,16 +18,16 @@ jobs:
     name: Analyze (javascript-typescript)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v4
+        uses: github/codeql-action/init@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4
         with:
           languages: javascript-typescript
           queries: security-and-quality
 
       # JS/TS is interpreted — no build step needed before analysis.
       - name: Perform CodeQL analysis
-        uses: github/codeql-action/analyze@v4
+        uses: github/codeql-action/analyze@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4
         with:
           category: '/language:javascript-typescript'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -110,6 +110,17 @@ npm run build        # full production build
    before it can merge. A maintainer will review; please respond to feedback by pushing
    follow-up commits to the same branch.
 
+## Releases (maintainers)
+
+Releases are manual and follow the version in `package.json`:
+
+1. Bump `version` in `package.json` on `main` (via PR like any other change).
+2. Build the store package: `npm run package` (produces `web-store-package.zip`).
+3. Tag and publish: `git tag vX.Y.Z && git push origin vX.Y.Z`, then create a
+   GitHub Release for the tag attaching the zip
+   (`gh release create vX.Y.Z web-store-package.zip --title "vX.Y.Z" --notes "..."`),
+   and upload the same zip to the Chrome Web Store dashboard.
+
 ## Questions
 
 Open an issue or start a discussion. Thanks for helping make the project better!

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,31 @@
+# Security Policy
+
+## Supported versions
+
+Only the latest release of the extension (the version currently on the
+[Chrome Web Store](https://chromewebstore.google.com/detail/Little%20AI%20Helper/iibpijacaghdcckphindbaijjgcbaoll))
+and the current `main` branch receive security fixes.
+
+## Reporting a vulnerability
+
+Please **do not open a public issue for security vulnerabilities.**
+
+Use GitHub's private vulnerability reporting instead:
+**[Report a vulnerability](https://github.com/ritsth/job-autofill-extension/security/advisories/new)**
+(Security tab → "Report a vulnerability"). Include steps to reproduce, the
+affected component (extension, or the Cloud Run proxy in `server/`), and the
+impact you see.
+
+You can expect an acknowledgment within a few days. Please give us a
+reasonable window to ship a fix before any public disclosure.
+
+## Scope notes
+
+- The extension stores all profile/resume data locally
+  (`chrome.storage.local`); there is no account system or server-side user
+  data. See [PRIVACY.md](PRIVACY.md).
+- The managed proxy (`server/`) holds no user data — only per-user daily
+  request counters. Its threat model, hardening status, and accepted risks
+  are documented in [docs/SECURITY.md](docs/SECURITY.md).
+- BYO-key mode sends requests directly from your browser to Google's Gemini
+  API; your key never touches any server we run.


### PR DESCRIPTION
Workflow/docs hardening from a security audit.

## Changes
- **Pin GitHub Actions to commit SHAs** in `ci.yml` and `codeql.yml` (was mutable `@v7`/`@v6`/`@v4` tags). The tag stays as a trailing comment for readability; Dependabot's `github-actions` ecosystem updates SHA pins automatically.
- **Root `SECURITY.md`** — a user-facing disclosure policy (supported versions, private vulnerability reporting link, scope) that GitHub surfaces under the Security tab. The existing `docs/SECURITY.md` stays as the internal technical audit; this links to it.
- **Release process documented** in `CONTRIBUTING.md` (maintainer section): bump `package.json` → `npm run package` → tag + GitHub Release + Web Store upload.

Note: the SECURITY.md report link assumes **private vulnerability reporting** is enabled in repo settings (Settings → Advanced Security) — flip it on if it isn't yet.

## Verification
- CI running on this PR proves the SHA pins resolve correctly.
- Docs-only otherwise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)