### PR TITLE
fix(popup): add aria-labels to Company and Role inputs (#25)

### DIFF
--- a/src/popup/Popup.tsx
+++ b/src/popup/Popup.tsx
@@ -409,12 +409,14 @@ export function Popup() {
         <div style={{ display: 'flex', gap: 6, marginBottom: 10 }}>
           <input
             style={{ flex: 1, minWidth: 0 }}
+            aria-label="Company"
             placeholder="Company"
             value={company}
             onChange={(e) => setCompany(e.target.value)}
           />
           <input
             style={{ flex: 1, minWidth: 0 }}
+            aria-label="Role"
             placeholder="Role"
             value={role}
             onChange={(e) => setRole(e.target.value)}


### PR DESCRIPTION
The Company and Role text inputs relied only on a placeholder, which disappears on focus and is not exposed as an accessible name to assistive tech. Add aria-label=Company / aria-label=Role so each input has a stable accessible name. Placeholders and the flex layout are unchanged, so the visual appearance is identical.

Closes #25

<!-- Thanks for contributing! Keep PRs small and focused — one change per PR. -->

## What & why

<!-- What does this change do, and what problem does it solve? Link any related issue: "Closes #123". -->

## How I tested

<!-- e.g. loaded the unpacked extension and reproduced the fix on a real job page, added/updated tests. -->

## Checklist

- [ ] `npm run lint` passes
- [ ] `npm run typecheck` passes
- [ ] `npm test` passes
- [ ] `npm run build` succeeds
- [ ] Tests added/updated if behavior changed
- [ ] No secrets, keys, or personal data committed
