### PR TITLE
chore: add .editorconfig for consistent code formatting

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+indent_style = space
+indent_size = 2
+
+[*.md]
+trim_trailing_whitespace = false


### PR DESCRIPTION
## What & why
This PR adds a root `.editorconfig` to enforce consistent formatting across contributors' editors (2-space indentation, LF line endings, trailing newlines).

Closes #63

## How I tested
- Confirmed that 2-space indentation matches the existing `src/` code whitespace conventions.
- Ran all CI checks:
  1. `npm run lint` (passes)
  2. `npm run typecheck` (passes)
  3. `npm test` (passes)
  4. `npm run build` (succeeds)

## Checklist
- [x] `npm run lint` passes
- [x] `npm run typecheck` passes
- [x] `npm test` passes
- [x] `npm run build` succeeds