### PR TITLE
fix: correct stale model-count comment in models.ts

### DIFF
--- a/src/lib/ai/models.ts
+++ b/src/lib/ai/models.ts
@@ -1,5 +1,5 @@
 // Curated Gemini models the user can pick from in Options. Single source of
-// truth for the dropdown and for default/normalization logic. All four ids exist
+// truth for the dropdown and for default/normalization logic. All three ids exist
 // on both AI Studio (BYO key, src/lib/ai/gemini.ts) and Vertex AI (the managed
 // proxy, server/index.js). When this list changes, mirror it in the server's
 // MODEL_ALLOWLIST so the proxy accepts the new ids.


### PR DESCRIPTION
## Summary
Trivial doc-comment fix, noticed while auditing the README's model-picker claims.

`src/lib/ai/models.ts`'s header comment said "All four ids exist on both AI Studio and Vertex AI," but `GEMINI_MODELS` only ever listed three (2.5 Pro, 2.5 Flash, 2.5 Flash-Lite). No behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)