### PR TITLE
fix: bound eligibility badge height so it scrolls instead of overflowing

### DIFF
--- a/src/content/sponsorship.ts
+++ b/src/content/sponsorship.ts
@@ -841,6 +841,7 @@ function renderBadge(a: SponsorAnalysis): HTMLElement {
     .wrap {
       position: fixed; top: 14px; right: 14px; z-index: 2147483646;
       display: flex; flex-direction: column; align-items: flex-end; gap: 10px;
+      max-height: calc(100vh - 28px);
       font: 13px/1.4 ui-sans-serif, system-ui, -apple-system, 'Segoe UI', Roboto, sans-serif;
     }
     .card {
@@ -848,6 +849,11 @@ function renderBadge(a: SponsorAnalysis): HTMLElement {
       background: #fff; color: #0f172a; border: 1px solid #e2e8f0;
       border-left: 6px solid ${s.color}; border-radius: 10px;
       box-shadow: 0 6px 24px rgba(0,0,0,.16);
+      /* .wrap bounds the whole column to the viewport; the card is the flex
+         item that shrinks and scrolls internally so a tall card can't push
+         the coachmark (or itself) off-screen. min-height: 0 overrides the
+         flex default that would otherwise keep it at its full content height. */
+      min-height: 0; overflow-y: auto;
     }
     .head { display: flex; align-items: center; gap: 8px; }
     .word { font-size: 20px; font-weight: 800; color: ${s.color}; letter-spacing: .5px; }


### PR DESCRIPTION
Fixes #47.

## Problem
The eligibility badge card (`position: fixed`, top-right) had no `max-height` and no scrolling. A tall card — long AI `reason`, several restriction/caution bullets, the experience line, plus both the cover-letter and tailored-resume generator sections — could run off the bottom of the viewport, making the Cover letter / Resume buttons completely unreachable.

## Fix
Two small CSS changes in `renderBadge()`'s injected `<style>` block ([sponsorship.ts](../blob/main/src/content/sponsorship.ts)):
- `.wrap` (the fixed, flex-column container holding the card and, on first use, the coachmark) gets `max-height: calc(100vh - 28px)`.
- `.card` gets `min-height: 0; overflow-y: auto`. The `min-height: 0` is required — flex items default to a minimum height equal to their content, which would otherwise still overflow `.wrap` even with `overflow-y: auto` set. With it, `.card` is the flex item that actually shrinks and scrolls, while the coachmark (no `min-height` override) keeps its full natural size and stays visible below it.

## Verification
- `npm run lint`, `npm run typecheck`, `npm test` (35 tests), `npm run build` — all clean.
- Built a standalone harness mirroring the real card/coachmark structure and drove it in a real browser at a constrained viewport (500px tall) to check the actual flexbox behavior rather than reasoning about it on paper:
  - Card is scrollable (`scrollHeight 636 > clientHeight 353`).
  - Coachmark's bottom edge lands at 486px in a 500px viewport (the intended 14px bottom margin) — **fully visible**, not pushed off-screen by the tall card.
  - Scrolled the card to bottom: **Cover letter and Tailored resume buttons are both fully visible and reachable** — the exact scenario the issue reported as broken.
  - Rounded corners and the `border-left` color accent render correctly through the scroll (border-radius clips scrolled content as expected in Chromium; the border itself is unaffected by `overflow-y` since it sits outside the scrollable content box).

CSS-only, no logic changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)