### PR TITLE
fix: stop rules badge flagging export-control screening questions as NO

### DIFF
--- a/src/content/analyze.test.ts
+++ b/src/content/analyze.test.ts
@@ -36,6 +36,28 @@ describe('analyze — eligibility verdict', () => {
     const a = analyze('Are you authorized to work without sponsorship?');
     expect(a.verdict).not.toBe('no');
   });
+
+  it('does not flag the export-control citizenship SCREENING QUESTION as NO', () => {
+    // Imperative form prompt (no "?", not "are you…") that mentions "export
+    // control" — carried by nearly every US application. It must be stripped so
+    // it doesn't trip the ITAR rule into a false NO.
+    const a = analyze(
+      'Solely for the purpose of determining if an export control license is needed, ' +
+        'please indicate "Yes" if you are currently a citizen of any of the following ' +
+        'countries: Iran, Syria, N. Korea, Cuba, Ukraine, People’s Republic of China, ' +
+        'Hong Kong (China), Macau (China) or Russia.',
+    );
+    expect(a.verdict).not.toBe('no');
+    expect(a.restrictions).not.toContain('ITAR / export-controlled');
+  });
+
+  it('still flags a GENUINE export-control restriction in the posting prose as NO', () => {
+    // Regression guard: only the form's screening question is dropped — a real
+    // employer-stated ITAR restriction must still be a hard NO.
+    const a = analyze('This position is subject to ITAR; only U.S. persons are eligible.');
+    expect(a.verdict).toBe('no');
+    expect(a.restrictions).toContain('ITAR / export-controlled');
+  });
 });
 
 describe('analyze — experience extraction', () => {

--- a/src/content/sponsorship.ts
+++ b/src/content/sponsorship.ts
@@ -126,6 +126,13 @@ function stripQuestions(text: string): string {
       const t = seg.trim();
       if (/\?\s*\*?$/.test(t)) return false; // ends with ? (optionally a required-* marker)
       if (/^(are|do|does|did|will|can|have|has|had|would|is)\s+you\b/i.test(t)) return false;
+      // Imperative application-form prompts describe the FORM, not the employer's
+      // stance — e.g. "please indicate 'Yes' if you are a citizen of…" or "Solely
+      // for the purpose of determining if an export control license is needed…".
+      // These must be dropped too, or the export-control screening question every
+      // US application carries would trip the ITAR rule into a false NO.
+      if (/\bplease (indicate|select|answer|confirm|specify|check|state|provide)\b/i.test(t)) return false;
+      if (/\bfor the (sole )?purpose of determining\b/i.test(t)) return false;
       return true;
     })
     .join(' ');


### PR DESCRIPTION
Closes #69.

## Problem
The eligibility badge's **rules-based** verdict (before the "AI check" button is clicked) showed **NO · "ITAR / export-controlled"** purely because the application form contained the standard compliance screening question nearly every US application carries:

> "Solely for the purpose of determining if an export control license is needed, please indicate 'Yes' if you are currently a citizen of … Iran, Syria, N. Korea …"

That's data collection, not the employer's stance — a false positive.

## Root cause
`analyze()` matches eligibility on "prose" after `stripQuestions()` removes screening questions. `stripQuestions()` only dropped segments that end with `?` or start with "are/do/does you". This screen is phrased as an **imperative** ("Solely for the purpose of determining … please indicate 'Yes' if you are …"), so it survived, and the intentionally-broad ITAR rule `/\b(itar|export[- ]control)/i` matched "export control license" → hard NO.

## Fix
Broaden `stripQuestions()` with two more drop rules for imperative application-form prompts (both describe the form, never the employer's stance):
- `/\bplease (indicate|select|answer|confirm|specify|check|state|provide)\b/i`
- `/\bfor the (sole )?purpose of determining\b/i`

The **ITAR rule is deliberately left unchanged** — a genuine employer restriction ("subject to ITAR; only U.S. persons are eligible") should still be a hard NO for a sponsorship-needing applicant. Only the form's screening question is dropped. `stripQuestions()` also pre-cleans the AI eligibility input, so both the rules and AI paths benefit.

## Tests
Two new cases in `analyze.test.ts` (alongside the existing screening-question test):
1. The export-control screening question → verdict is NOT `no` and restrictions omits "ITAR / export-controlled".
2. **Regression guard:** "This position is subject to ITAR; only U.S. persons are eligible." → still `no` with the ITAR restriction present.

## Verification
`npm run lint`, `npm run typecheck`, `npm test` (37 tests, analyze suite 9→11), `npm run build` — all clean.

Extension-only (content script), no proxy redeploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)