### PR TITLE
fix: start the scanner with defaults when init storage reads fail

### DIFF
--- a/src/content/index.ts
+++ b/src/content/index.ts
@@ -178,13 +178,23 @@ const scannerGlobal = window as unknown as { __jafScannerStarted?: boolean };
 if (window.top === window.self && !scannerGlobal.__jafScannerStarted) {
   scannerGlobal.__jafScannerStarted = true;
   (async () => {
-    const profile = await getProfile();
-    // Seed the one-time badge coachmark flag before enabling the scanner, so the
-    // first badge render knows whether to show it.
-    const { badgeIntroSeen } = await chrome.storage.local.get('badgeIntroSeen');
-    setBadgeIntroSeen(Boolean(badgeIntroSeen));
-    setBadgeFeatures({ coverLetter: profile.coverLetterEnabled, resume: profile.tailoredResumeEnabled });
-    setScannerEnabled(profile.scanEnabled);
+    try {
+      const profile = await getProfile();
+      // Seed the one-time badge coachmark flag before enabling the scanner, so the
+      // first badge render knows whether to show it.
+      const { badgeIntroSeen } = await chrome.storage.local.get('badgeIntroSeen');
+      setBadgeIntroSeen(Boolean(badgeIntroSeen));
+      setBadgeFeatures({ coverLetter: profile.coverLetterEnabled, resume: profile.tailoredResumeEnabled });
+      setScannerEnabled(profile.scanEnabled);
+    } catch (e) {
+      // A failed storage read (e.g. an extension-update limbo) must not silently
+      // kill the scanner — fall back to defaults. scanEnabled defaults ON in
+      // withDefaults, so this matches a fresh profile; force the coachmark to
+      // "seen" so a fallback never flashes the intro bubble.
+      console.warn('[Little AI Helper] scanner init failed; starting with defaults', e);
+      setBadgeIntroSeen(true);
+      setScannerEnabled(true);
+    }
     startSponsorshipWatch();
   })();
   onProfileChanged((profile) => {


### PR DESCRIPTION
## Context
Investigating "badge sometimes missing until I reload the extension" found three layers:
1. **Primary (workflow, no code change):** rebuilding `dist/` under the loaded unpacked extension invalidates Chrome's memorized content-script filenames (they're content-hashed per build), so injection fails silently on new pages until the extension is reloaded. Fix is workflow: reload the extension after every `npm run build`, or use `npm run dev` (crxjs auto-reload).
2. **Secondary:** already-open tabs are orphaned after an extension reload/update ("Extension context invalidated") and need a page refresh.
3. **Amplifier (this PR):** the scanner init IIFE in `src/content/index.ts` awaited `getProfile()` + `chrome.storage.local.get('badgeIntroSeen')` with **no `.catch`** — any storage failure silently skipped `startSponsorshipWatch()`: no badge, no diagnostic anywhere.

## Change
Wrap the init body in try/catch. On failure: `console.warn` (so the failure is finally visible in the page console), fall back to defaults — scanner **on** (matches the `withDefaults` stored default), coachmark forced to "seen" so a fallback context never flashes the intro bubble — and start the watch either way. Success path is byte-identical in behavior.

## Verification
- `npm run lint`, `npm run typecheck`, `npm test` (35 tests), `npm run build` — all clean.
- Manual: load unpacked → badge behavior unchanged on the success path; the catch path calls the same functions the success path ends with, reviewed by reading.

Extension-only, no proxy redeploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)