### PR TITLE
fix: read same-origin iframes in the eligibility scan

### DIFF
--- a/src/content/analyze.test.ts
+++ b/src/content/analyze.test.ts
@@ -58,6 +58,17 @@ describe('analyze — eligibility verdict', () => {
     expect(a.verdict).toBe('no');
     expect(a.restrictions).toContain('ITAR / export-controlled');
   });
+
+  it('flags a citizenship + clearance qualification bullet as NO', () => {
+    // Real-world DoD-contractor phrasing (iCIMS posting). The rules must catch
+    // this whenever the scan can read it — the historical miss on iCIMS was the
+    // posting living in an iframe the scan never saw, not a rules gap.
+    const a = analyze(
+      'Must be a U.S. citizen, eligible for U.S. Department of Defense (DoD) SECRET security clearance*',
+    );
+    expect(a.verdict).toBe('no');
+    expect(a.restrictions).toContain('U.S. citizenship required');
+  });
 });
 
 describe('analyze — experience extraction', () => {

--- a/src/content/sponsorship.ts
+++ b/src/content/sponsorship.ts
@@ -296,6 +296,27 @@ function pickMainContent(): string | null {
 }
 
 /**
+ * Text from the largest same-origin iframe document, '' when none is readable.
+ * ATSes like iCIMS render the posting in a same-origin frame, which innerText
+ * on the top document never includes — so without this the scan (rules AND AI)
+ * reads only the outer branding chrome and misses the real requirements.
+ * Cross-origin frames throw / return null on contentDocument access and are
+ * skipped, which also keeps ad frames out.
+ */
+function sameOriginFrameText(): string {
+  let best = '';
+  for (const f of document.querySelectorAll('iframe')) {
+    try {
+      const t = f.contentDocument?.body?.innerText?.trim() || '';
+      if (t.length > best.length) best = t;
+    } catch {
+      // Cross-origin — skip.
+    }
+  }
+  return best;
+}
+
+/**
  * Most robust LinkedIn description read: anchor on the "About the job" section
  * heading. That label text is stable across ALL of LinkedIn's job layouts —
  * including the newer ones whose CSS classes are hashed/obfuscated (`_243b3f31`
@@ -416,10 +437,15 @@ export function getScanText(): string {
   }
   // Other sites (Greenhouse, Lever, Ashby, Workday, company pages): read just the
   // description block, not the whole body, so the eligibility read isn't diluted.
-  const main = pickMainContent();
-  if (main) return main.slice(0, MAX_CHARS);
   // Badge text lives in a Shadow DOM, so innerText excludes it (no feedback loop).
-  return (document.body?.innerText || '').slice(0, MAX_CHARS);
+  const local = pickMainContent() ?? (document.body?.innerText || '');
+  // The posting may live in a same-origin iframe (iCIMS et al.) that innerText on
+  // this document can't see — merge the frame's text in. Concatenating (rather
+  // than picking one) keeps this recall-only: everything the scan saw before is
+  // still present, so no existing site regresses.
+  const frame = sameOriginFrameText();
+  const combined = frame ? `${local}\n\n${frame}` : local;
+  return combined.slice(0, MAX_CHARS);
 }
 
 function hash(s: string): number {


### PR DESCRIPTION
## Problem
On an iCIMS posting stating "Must be a U.S. citizen, eligible for U.S. DoD SECRET security clearance*", the badge showed gray "unknown" — from **both** the rules pass and the AI check.

## Diagnosis (verified)
- **The rules are accurate:** the exact bullet matches `/\bmust be (a |an )?(u\.?s\.?|united states) citizen/i` → would flag NO "U.S. citizenship required".
- **The scan never saw the text:** the page's top-level document contains only branding chrome (verified by fetching it — no qualifications anywhere). iCIMS renders the posting in a **same-origin iframe**, and `innerText` never crosses frame boundaries. The badge scans the top frame only, so rules and AI both read nav/footer text. The AI's own reason — "This is a job posting for Sonalysts, Inc." — matches exactly what the outer document contains.

## Fix (deliberately generic — no site-specific selectors)
- New `sameOriginFrameText()`: largest readable same-origin iframe body text; cross-origin frames (ads, third-party embeds) throw on `contentDocument` access and are skipped.
- `getScanText()`'s generic branch concatenates the local read with the frame text. **Recall-only:** everything the scan previously saw is still present, so no existing site can regress. LinkedIn's dedicated branch is untouched.
- Bonus: 💾 "Save this job" works on these sites now too — `captureJob`/`captureJobWhenReady` read through the same `getScanText()`.

## Known limitation (out of scope)
`getJobMeta()` (company/role prefill) still reads the top document; cross-**origin** embeds (e.g. a Greenhouse iframe on a company site) remain unreadable and would need frame-to-top messaging.

## Testing
- New rules test: the citizenship+clearance bullet → `no` + "U.S. citizenship required" (documents that the rules were never the gap).
- `npm run lint`, `npm run typecheck`, `npm test` (38 tests), `npm run build` — all clean.
- Manual check pending on the live iCIMS posting after reload (badge should flag NO from rules alone, no AI needed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)