### PR TITLE
fix: trim trailing hyphen from resume filenames

### DIFF
--- a/src/lib/resume.test.ts
+++ b/src/lib/resume.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from 'vitest';
+import { resumeFilename } from './resume';
+
+describe('resumeFilename', () => {
+  it('handles the normal case with both company and role', () => {
+    expect(resumeFilename('Acme Corp', 'Software Engineer')).toBe(
+      'resume-acme-corp-software-engineer'
+    );
+  });
+
+  it('collapses special characters to single hyphens and trims leading/trailing hyphens', () => {
+    expect(resumeFilename('Acme & Corp!!', 'Software   Engineer')).toBe(
+      'resume-acme-corp-software-engineer'
+    );
+    expect(resumeFilename('...Acme Corp...', '!!!Software Engineer!!!')).toBe(
+      'resume-acme-corp-software-engineer'
+    );
+  });
+
+  it('returns resume when both fields are empty', () => {
+    expect(resumeFilename('', '')).toBe('resume');
+  });
+
+  it('handles only company provided', () => {
+    expect(resumeFilename('Acme Corp', '')).toBe('resume-acme-corp');
+  });
+
+  it('handles only role provided', () => {
+    expect(resumeFilename('', 'Software Engineer')).toBe('resume-software-engineer');
+  });
+
+  it('caps the slug at 60 characters', () => {
+    const longCompany = 'a'.repeat(50);
+    const longRole = 'b'.repeat(50);
+    const result = resumeFilename(longCompany, longRole);
+
+    // Prefix "resume-" is 7 chars.
+    // The slug itself should be sliced at 60 chars.
+    // Expected slug: 50 'a's + 1 hyphen + 9 'b's = 60 chars.
+    expect(result).toHaveLength(67); // 7 + 60
+    expect(result).toBe(`resume-${'a'.repeat(50)}-${'b'.repeat(9)}`);
+  });
+
+  it('does not leave a trailing hyphen when the slice boundary falls on the join separator', () => {
+    // 59 'a's + '-' + 50 'b's = 110 chars; slice(0, 60) yields 'a'.repeat(59) + '-'.
+    // The fix removes the trailing hyphen.
+    expect(resumeFilename('a'.repeat(59), 'b'.repeat(50))).toBe(
+      `resume-${'a'.repeat(59)}`
+    );
+  });
+});

--- a/src/lib/resume.ts
+++ b/src/lib/resume.ts
@@ -12,7 +12,8 @@ export function resumeFilename(company: string, role: string): string {
     .toLowerCase()
     .replace(/[^a-z0-9]+/g, '-')
     .replace(/^-+|-+$/g, '')
-    .slice(0, 60);
+    .slice(0, 60)
+    .replace(/-+$/, '');
   return `resume${slug ? '-' + slug : ''}`;
 }
 


### PR DESCRIPTION
## What & why

Fixes #84.

`resumeFilename()` used the same slug construction as `letterFilename()`, but it did not trim trailing hyphens after the 60-character slice. When the slice boundary landed on the company/role separator, generated resume filenames could end with a stray hyphen before `.pdf`.

This mirrors the existing `letterFilename()` fix and adds a `resumeFilename()` test suite covering the shared filename cases plus the trailing-hyphen regression.

## How I tested

- `npm run lint`
- `npm run typecheck`
- `npm test`
- `npm run build`

Note: `npm install` emitted the existing engine warning that `pdfjs-dist@6.1.200` requires Node `>=22.13.0 || >=24` while this environment runs Node `v20.20.0`; the repository contribution guide lists Node 20+ and all checks above passed locally.

## Checklist

- [x] `npm run lint` passes
- [x] `npm run typecheck` passes
- [x] `npm test` passes
- [x] `npm run build` succeeds
- [x] Tests added/updated if behavior changed
- [x] No secrets, keys, or personal data committed
