### PR TITLE
fix: re-scan when an iframe finishes loading

### DIFF
--- a/src/content/sponsorship.ts
+++ b/src/content/sponsorship.ts
@@ -702,6 +702,23 @@ export function startSponsorshipWatch(): void {
   document.addEventListener('visibilitychange', () => {
     if (!document.hidden) tick();
   });
+  // An iframe finishing to load is invisible to the top-document MutationObserver
+  // (its content mutates inside its own document), but ATSes like iCIMS deliver
+  // the posting exactly that way — the scan reads it via sameOriginFrameText(),
+  // so a late-loading frame must count as a content change or the badge sticks
+  // on the pre-frame verdict. `load` doesn't bubble, but capture-phase listeners
+  // on window still see subresource loads.
+  window.addEventListener(
+    'load',
+    (e) => {
+      if (e.target instanceof HTMLIFrameElement) {
+        mutationDirty = true;
+        window.clearTimeout(debounceTimer);
+        debounceTimer = window.setTimeout(tick, 600);
+      }
+    },
+    true,
+  );
 }
 
 // --- Badge rendering ---


### PR DESCRIPTION
## Problem
Follow-up to #83 (merge same-origin iframe text into the scan). On the same Sonalysts iCIMS posting the badge could still stay gray: the perf gating from #73 makes `tick()` skip all work unless the **top document** mutated or the URL changed. iCIMS injects its content iframe via JS — the injection mutation is consumed immediately, but the frame's **document content arrives later**, and mutations inside an iframe's own document never fire the top document's `MutationObserver`. If the posting lands after the last forced scan (1.8s), the scanner never re-reads, so the badge sticks on the pre-frame "unknown" verdict even though `sameOriginFrameText()` could now read the posting. ("Save this job" was unaffected — `captureJobWhenReady` polls `getScanText()` directly.)

## Fix
One capture-phase `load` listener in `startSponsorshipWatch()`: `load` doesn't bubble, but capture-phase listeners on `window` see subresource loads, so an iframe finishing to load marks the scanner dirty and schedules the same debounced `tick` the MutationObserver uses. No new state — reuses the #73 plumbing.

Cost bounds: cross-origin/ad iframes trigger at most one extra debounced scan each, and `renderFrom`'s render-signature skip suppresses no-op re-renders, so mutation-happy pages don't flicker.

## Verification
- `npm run lint`, `npm run typecheck`, `npm test` (38 tests), `npm run build` — all clean.
- Manual (after build + **extension reload**): open the Sonalysts iCIMS posting fresh → badge flags **NO — U.S. citizenship required** with no interaction, even when the content iframe loads late; LinkedIn/Greenhouse behavior unchanged.

Extension-only, no proxy redeploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)