### PR TITLE
chore: add CodeRabbit config for automated PR review

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,35 @@
+# CodeRabbit configuration — https://docs.coderabbit.ai
+# Repo-level tuning for the AI PR reviewer. CodeRabbit works with no config;
+# this just tailors it to a Manifest V3 extension + Cloud Run proxy.
+# yaml-language-server: $schema=https://storage.googleapis.com/coderabbit_public_assets/schema.v2.json
+language: en-US
+tone_instructions: >-
+  This is a Manifest V3 Chrome extension (TypeScript, React, Vite) with a small
+  Cloud Run proxy under server/. Prioritize: content-script safety on <all_urls>,
+  host-permission and DOM-injection scope, whether the change matches its PR
+  description and linked issue, and test coverage for changed pure functions.
+reviews:
+  profile: chill                    # quiet | chill | assertive — chill = balanced signal/noise
+  high_level_summary: true          # PR summary comment
+  poem: false                       # skip the novelty verse
+  request_changes_workflow: false   # advise only; merge gating stays with branch protection
+  auto_review:
+    enabled: true                   # review on PR open + push
+    drafts: false                   # skip draft PRs
+    base_branches:
+      - main
+    ignore_usernames:               # skip bot PRs — lockfile/version bumps aren't worth an AI pass
+      - "dependabot[bot]"
+  path_filters:                     # keep review on source, not build output / vendored noise
+    - "!dist/**"
+    - "!**/*.min.js"
+  path_instructions:
+    - path: "src/content/**"
+      instructions: >-
+        Content scripts run on every page. Flag any innerHTML/insertAdjacentHTML with
+        non-static input, un-scoped host checks (endsWith without a dot-boundary), and
+        new broad DOM reads that could leak into the eligibility scan.
+    - path: "server/**"
+      instructions: >-
+        This proxy is internet-facing. Flag unsanitized error passthrough, missing
+        input validation, and any secret/token logging.

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -4,10 +4,10 @@
 # yaml-language-server: $schema=https://storage.googleapis.com/coderabbit_public_assets/schema.v2.json
 language: en-US
 tone_instructions: >-
-  This is a Manifest V3 Chrome extension (TypeScript, React, Vite) with a small
-  Cloud Run proxy under server/. Prioritize: content-script safety on <all_urls>,
-  host-permission and DOM-injection scope, whether the change matches its PR
-  description and linked issue, and test coverage for changed pure functions.
+  Manifest V3 Chrome extension (TypeScript, React, Vite) + a Cloud Run proxy.
+  Prioritize: content-script <all_urls> safety, host-permission/DOM-injection
+  scope, PR-vs-description alignment, and test coverage for changed pure
+  functions.
 reviews:
   profile: chill                    # quiet | chill | assertive — chill = balanced signal/noise
   high_level_summary: true          # PR summary comment


### PR DESCRIPTION
Adds `.coderabbit.yaml` to configure the [CodeRabbit](https://coderabbit.ai) AI PR reviewer — a first-pass "is this worth a look" review on each PR, complementing (not replacing) the existing CI gates.

## What this does
- **`profile: chill`** — balanced signal/noise; advises, doesn't block (`request_changes_workflow: false`), so merge gating stays with the branch-protection ruleset.
- **Skips noise** — draft PRs, Dependabot PRs (`ignore_usernames: ["dependabot[bot]"]`), and `dist/`/min.js diffs.
- **Path-scoped guidance** — extra review focus on `src/content/**` (DOM-injection / host-check safety) and `server/**` (error passthrough, secret logging).
- Tone note orienting the reviewer to a Manifest V3 extension + Cloud Run proxy.

## Requires a one-time install (owner, browser)
This config is inert until the CodeRabbit GitHub App is installed:
1. Install [github.com/apps/coderabbitai](https://github.com/apps/coderabbitai) → **Only select repositories** → this repo.
2. Approve permissions (read code/PRs, write PR comments). **No API key or secret** — the service holds its own model credentials; free on the public/OSS tier.

Once installed, this PR itself becomes CodeRabbit's first live review. No API key, no cost, no CI change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a repository-level automated code review configuration for a Manifest V3 Chrome extension using a Cloud Run proxy.
  * Enabled standardized review guidance (language/voice and high-level summaries) with selected workflow messaging disabled.
  * Set automatic reviews for non-draft pull requests targeting the main branch, excluding generated/minified files.
  * Added path-specific checks to improve DOM safety and strengthen input validation and handling of sensitive data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->