### PR TITLE
chore: bump version to 1.1.7 for Web Store release

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "job-autofill-extension",
-  "version": "1.1.6",
+  "version": "1.1.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "job-autofill-extension",
-      "version": "1.1.6",
+      "version": "1.1.7",
       "dependencies": {
         "react": "^18.3.1",
         "react-dom": "^18.3.1"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "job-autofill-extension",
   "private": true,
-  "version": "1.1.6",
+  "version": "1.1.7",
   "type": "module",
   "description": "Autofill job applications on Greenhouse, Lever & Workday and draft AI answers and tailored cover letters from your profile.",
   "scripts": {


### PR DESCRIPTION
Version bump for the next Web Store upload. Bundles all shipped-code changes merged since the 1.1.6 package (Jul 1), notably:

- Same-origin iframe eligibility scan + iframe-load re-scan (iCIMS fix) (#83, #88)
- Resilient AI JSON parsing (#46), concise AI answers (#59)
- Badge overflow scroll fix (#68), Escape-dismiss (#89), keyboard-accessible controls (#71, #91)
- Export-control screening false-positive fix (#72)
- Scanner perf + **dropped the unused `scripting` permission** (#73) — manifest permission change
- Gemini key moved to header + message-sender validation (#52), host-check hardening

Version-only change (`package.json` + lockfile). CI validates the build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the extension to version 1.1.7.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->