### PR TITLE
docs: remove stale scripting permission justification

### DIFF
--- a/STORE_LISTING.md
+++ b/STORE_LISTING.md
@@ -73,7 +73,6 @@ English
 | --- | --- |
 | `storage` | Save the user's profile, resume, documents, and settings locally in the browser. |
 | `activeTab` | Read and fill fields on the job-application page the user is currently on, when they click the extension. |
-| `scripting` | Inject the autofill logic that populates form fields on supported application pages. |
 | `sidePanel` | The extension's main UI is a side panel that stays open while the user works through an application. |
 | `identity` | Optional Google sign-in (OpenID/email/profile) so users can authenticate to the managed AI proxy, which meters usage per user. |
 | Host access to Greenhouse, Lever, Workday (`*.greenhouse.io`, `jobs.lever.co`, `*.myworkdayjobs.com`, etc.) | Run the autofill content script on supported job-application sites. |


### PR DESCRIPTION
The \`scripting\` permission was dropped from the manifest in #73 (the autofill logic never actually called \`chrome.scripting\`). \`STORE_LISTING.md\`'s permission-justification table still had a row for it — removed so the doc matches the current manifest ahead of the next Web Store submission.

Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Removed the outdated justification for the scripting permission from the store listing.
  * Updated the permissions table while leaving all other listing content unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->