### PR TITLE
fix: honor JSON mode for on-device AI

### DIFF
--- a/src/lib/ai/onDevice.test.ts
+++ b/src/lib/ai/onDevice.test.ts
@@ -1,0 +1,46 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { OnDeviceProvider } from './onDevice';
+
+function installLanguageModel(response = '{"ok":true}') {
+  const prompt = vi.fn().mockResolvedValue(response);
+  const destroy = vi.fn();
+  const create = vi.fn().mockResolvedValue({ prompt, destroy });
+  vi.stubGlobal('self', { LanguageModel: { create } });
+  return { create, destroy, prompt };
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('OnDeviceProvider', () => {
+  it('asks for JSON-only output when a caller requests JSON mode', async () => {
+    const { create, destroy, prompt } = installLanguageModel();
+
+    const result = await new OnDeviceProvider().generate({
+      system: 'Extract structured data.',
+      prompt: 'RESUME: Ada Lovelace',
+      json: true,
+    });
+
+    expect(result).toBe('{"ok":true}');
+    expect(create).toHaveBeenCalledWith({
+      initialPrompts: [{ role: 'system', content: 'Extract structured data.' }],
+    });
+    expect(prompt).toHaveBeenCalledWith(
+      'RESUME: Ada Lovelace\n\nReturn only valid JSON. Do not use Markdown code fences or include explanatory text.',
+    );
+    expect(destroy).toHaveBeenCalledOnce();
+  });
+
+  it('leaves plain-text requests unchanged', async () => {
+    const { prompt } = installLanguageModel('A tailored answer.');
+
+    await new OnDeviceProvider().generate({
+      system: 'Write an answer.',
+      prompt: 'Why are you interested in this role?',
+    });
+
+    expect(prompt).toHaveBeenCalledWith('Why are you interested in this role?');
+  });
+});

--- a/src/lib/ai/onDevice.ts
+++ b/src/lib/ai/onDevice.ts
@@ -17,6 +17,9 @@ interface LanguageModelLike {
   create(opts?: { initialPrompts?: Array<{ role: string; content: string }> }): Promise<PromptSession>;
 }
 
+const JSON_ONLY_INSTRUCTION =
+  '\n\nReturn only valid JSON. Do not use Markdown code fences or include explanatory text.';
+
 function getLanguageModel(): LanguageModelLike | null {
   const g = self as unknown as {
     LanguageModel?: LanguageModelLike;
@@ -46,7 +49,7 @@ export async function isOnDeviceAvailable(): Promise<boolean> {
 export class OnDeviceProvider implements AIProvider {
   readonly id = 'onDevice';
 
-  async generate({ system, prompt }: GenerateInput): Promise<string> {
+  async generate({ system, prompt, json }: GenerateInput): Promise<string> {
     const lm = getLanguageModel();
     if (!lm) {
       throw new AIError(
@@ -63,7 +66,11 @@ export class OnDeviceProvider implements AIProvider {
     }
 
     try {
-      const text = await session.prompt(prompt);
+      // The Prompt API has no native response MIME type. Put the format
+      // instruction after the untrusted page content so it is the model's most
+      // recent instruction and structured callers receive parseable output.
+      const request = json ? `${prompt}${JSON_ONLY_INSTRUCTION}` : prompt;
+      const text = await session.prompt(request);
       if (!text.trim()) throw new AIError('On-device model returned an empty response.');
       return text.trim();
     } finally {


### PR DESCRIPTION
## What & why

Closes #95.

`OnDeviceProvider` previously dropped `GenerateInput.json`, so structured resume parsing and eligibility checks could receive conversational text instead of parseable JSON. This change adds a JSON-only output guard to on-device requests while preserving all plain-text requests. It also adds contract coverage with a mocked Prompt API session.

## How I tested

- `npm run lint`
- `npm run typecheck`
- `npm test` (50 tests)
- `npm run build`
- Manual on-device smoke test not run: it requires a Chrome build with the on-device model available.

## Checklist

- [x] `npm run lint` passes
- [x] `npm run typecheck` passes
- [x] `npm test` passes
- [x] `npm run build` succeeds
- [x] Tests added/updated if behavior changed
- [x] No secrets, keys, or personal data committed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved on-device AI requests that require JSON responses by adding a JSON-only instruction after the prompt content.
  * Preserved existing prompt behavior for standard text responses.

* **Tests**
  * Added coverage verifying JSON formatting instructions and standard prompt handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->