### PR TITLE
fix: stop AI-answer buttons multiplying on re-rendering forms

### DIFF
--- a/src/content/index.ts
+++ b/src/content/index.ts
@@ -24,7 +24,6 @@ const ADAPTERS: SiteAdapter[] = [greenhouseAdapter, leverAdapter, workdayAdapter
 const adapter = ADAPTERS.find((a) => a.matches(new URL(location.href))) ?? null;
 
 const BUTTON_CLASS = 'jaf-ai-btn';
-const MARK_ATTR = 'data-jaf-bound';
 
 // --- Messaging from popup ---
 const isTopFrame = window.top === window.self;
@@ -74,12 +73,39 @@ chrome.runtime.onMessage.addListener((msg: ContentMessage, _sender, sendResponse
 });
 
 // --- AI answer buttons ---
+// Reconcile the page to exactly one button immediately after each open question.
+// We do NOT mark the textarea (an attribute or node identity the host framework
+// would strip on re-render): Oracle/Workday-style forms re-render the field
+// continuously, which previously made every observer cycle append another button
+// while the old ones orphaned — a runaway pile-up. Keying on structure instead
+// (button right after its textarea) is churn-proof: strays are removed, gaps are
+// filled, and the count can't exceed the number of current questions.
 function injectQuestionButtons(): void {
-  for (const q of findOpenQuestions()) {
-    if (q.el.getAttribute(MARK_ATTR)) continue;
-    q.el.setAttribute(MARK_ATTR, '1');
-    addButtonFor(q);
+  // Suspend the observer so our own DOM writes below don't re-trigger this pass.
+  const wasObserving = questionsOn;
+  if (wasObserving) observer.disconnect();
+
+  const questions = findOpenQuestions();
+  const wanted = new Set<Element>(questions.map((q) => q.el));
+
+  // Drop orphaned / duplicate buttons: keep a button only if it sits right after
+  // a current open-question textarea that hasn't already been credited this pass.
+  const credited = new Set<Element>();
+  for (const btn of document.querySelectorAll(`.${BUTTON_CLASS}`)) {
+    const prev = btn.previousElementSibling;
+    if (prev && wanted.has(prev) && !credited.has(prev)) {
+      credited.add(prev);
+    } else {
+      btn.remove();
+    }
   }
+
+  // Add a button for any open question that doesn't already have one after it.
+  for (const q of questions) {
+    if (!credited.has(q.el)) addButtonFor(q);
+  }
+
+  if (wasObserving) observer.observe(document.body, { childList: true, subtree: true });
 }
 
 function addButtonFor(q: OpenQuestion): void {
@@ -159,9 +185,8 @@ function setQuestionButtons(on: boolean): void {
   } else {
     observer.disconnect();
     window.clearTimeout(pending); // cancel any debounced re-inject still queued
-    // Remove the buttons and unmark their textareas so they can re-bind later.
+    // Remove the buttons; a later re-enable rebuilds them from scratch.
     document.querySelectorAll(`.${BUTTON_CLASS}`).forEach((n) => n.remove());
-    document.querySelectorAll(`[${MARK_ATTR}]`).forEach((el) => el.removeAttribute(MARK_ATTR));
   }
 }
 

--- a/src/content/index.ts
+++ b/src/content/index.ts
@@ -24,6 +24,11 @@ const ADAPTERS: SiteAdapter[] = [greenhouseAdapter, leverAdapter, workdayAdapter
 const adapter = ADAPTERS.find((a) => a.matches(new URL(location.href))) ?? null;
 
 const BUTTON_CLASS = 'jaf-ai-btn';
+// Buttons WE created. Reconciliation and cleanup only ever touch members of this
+// set, so a host page element that happens to share our class can never mark a
+// question as handled or get deleted by us. A WeakSet (not a DOM attribute) means
+// the host can't forge membership by copying an attribute.
+const ownedButtons = new WeakSet<HTMLButtonElement>();
 
 // --- Messaging from popup ---
 const isTopFrame = window.top === window.self;
@@ -88,16 +93,26 @@ function injectQuestionButtons(): void {
   const questions = findOpenQuestions();
   const wanted = new Set<Element>(questions.map((q) => q.el));
 
-  // Drop orphaned / duplicate buttons: keep a button only if it sits right after
-  // a current open-question textarea that hasn't already been credited this pass.
-  const credited = new Set<Element>();
-  for (const btn of document.querySelectorAll(`.${BUTTON_CLASS}`)) {
+  // Group OUR buttons by the current open-question textarea they sit right after.
+  // Anything else — a button orphaned by a re-render, or a stray — is dropped.
+  const byQuestion = new Map<Element, HTMLButtonElement[]>();
+  for (const btn of document.querySelectorAll<HTMLButtonElement>(`.${BUTTON_CLASS}`)) {
+    if (!ownedButtons.has(btn)) continue; // ignore host elements sharing the class
     const prev = btn.previousElementSibling;
-    if (prev && wanted.has(prev) && !credited.has(prev)) {
-      credited.add(prev);
+    if (prev && wanted.has(prev)) {
+      (byQuestion.get(prev) ?? byQuestion.set(prev, []).get(prev)!).push(btn);
     } else {
       btn.remove();
     }
+  }
+
+  // Keep exactly one button per question, preferring an in-flight one (disabled
+  // while its answer generates) so a pending fill still targets a live node.
+  const credited = new Set<Element>();
+  for (const [el, btns] of byQuestion) {
+    const keep = btns.find((b) => b.disabled) ?? btns[0];
+    for (const b of btns) if (b !== keep) b.remove();
+    credited.add(el);
   }
 
   // Add a button for any open question that doesn't already have one after it.
@@ -113,6 +128,7 @@ function addButtonFor(q: OpenQuestion): void {
   btn.type = 'button';
   btn.className = BUTTON_CLASS;
   btn.textContent = '✨ AI answer';
+  ownedButtons.add(btn);
   btn.addEventListener('click', () => generateAnswer(q, btn));
 
   // Place the button right after the textarea.
@@ -185,8 +201,10 @@ function setQuestionButtons(on: boolean): void {
   } else {
     observer.disconnect();
     window.clearTimeout(pending); // cancel any debounced re-inject still queued
-    // Remove the buttons; a later re-enable rebuilds them from scratch.
-    document.querySelectorAll(`.${BUTTON_CLASS}`).forEach((n) => n.remove());
+    // Remove only OUR buttons; a later re-enable rebuilds them from scratch.
+    document
+      .querySelectorAll<HTMLButtonElement>(`.${BUTTON_CLASS}`)
+      .forEach((n) => ownedButtons.has(n) && n.remove());
   }
 }
 


### PR DESCRIPTION
## Problem
On an Oracle Recruiting Cloud application page (with a saved job active, so the AI-answer feature runs on non-adapter sites), the "✨ AI answer" button multiplies — dozens stack under each textarea and keep growing the longer the page is open.

## Root cause
Button de-duplication keyed on a `data-jaf-bound` attribute written onto the textarea. `injectQuestionButtons` re-runs on every DOM mutation (a `MutationObserver` on the whole `document.body` subtree). Oracle's framework re-renders the field region continuously (live char-counter, validation, plus Grammarly injecting into the same fields), and each re-render **replaces the textarea node / strips the attribute**. So every observer cycle saw an "unmarked" textarea and appended another button via `insertAdjacentElement('afterend', …)`, while the previously-inserted buttons — now orphaned siblings the framework doesn't manage — were never cleaned up. Stable pages (Greenhouse/Lever) were unaffected because the node/attribute persists.

## Fix (`src/content/index.ts`, injection only)
Replace the attribute marker with **structural reconciliation** that churn can't defeat:
- Remove any `.jaf-ai-btn` that isn't sitting immediately after a *current* open-question textarea, and any duplicate for the same textarea.
- Add a button only where an open question doesn't already have one.
- Suspend the observer around the pass so our own writes don't re-trigger it.

This bounds the button count to exactly one per current question regardless of how aggressively the host re-renders. An in-flight button (user clicked "AI answer", generation pending) is preserved — it stays correctly positioned, so reconciliation keeps it; only orphans/duplicates are removed. Drops the now-unused `MARK_ATTR`.

## Verification
- `npm run lint`, `npm run typecheck`, `npm test` (50 tests), `npm run build` — all clean.
- Manual (after reload) pending on the reported Oracle URL: one button per question, stable over 30s; Greenhouse/Lever regression check; save-job flow on a plain site.

Extension-only, no proxy redeploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where multiple “✨ AI answer” buttons could appear after host re-renders or form updates.
  * Improved reconciliation of the button UI to ensure exactly one button is placed after each relevant textarea.
  * Enhanced cleanup of outdated/orphaned buttons, including more precise removal during the disable flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->