### PR TITLE
feat: drag the eligibility badge to any corner

### DIFF
--- a/src/content/analyze.test.ts
+++ b/src/content/analyze.test.ts
@@ -3,8 +3,24 @@ import {
   addBadgeDismissListener,
   analyze,
   isBadgeDismissKey,
+  nearestCorner,
   shouldDismissBadge,
 } from './sponsorship';
+
+describe('nearestCorner — badge drag snapping', () => {
+  it('maps each viewport quadrant to its corner', () => {
+    expect(nearestCorner(10, 10, 1000, 800)).toBe('tl');
+    expect(nearestCorner(990, 10, 1000, 800)).toBe('tr');
+    expect(nearestCorner(10, 790, 1000, 800)).toBe('bl');
+    expect(nearestCorner(990, 790, 1000, 800)).toBe('br');
+  });
+
+  it('breaks exact-center ties toward the bottom-right', () => {
+    // Center is not < half, so ties resolve to bottom/right — deterministic,
+    // and matches the badge's historical right-side home.
+    expect(nearestCorner(500, 400, 1000, 800)).toBe('br');
+  });
+});
 
 describe('eligibility badge keyboard dismissal', () => {
   it('dismisses only for Escape', () => {

--- a/src/content/index.ts
+++ b/src/content/index.ts
@@ -16,6 +16,7 @@ import {
   setScannerEnabled,
   setBadgeFeatures,
   setBadgeIntroSeen,
+  setBadgeCorner,
   getScanText,
   captureJobWhenReady,
 } from './sponsorship';
@@ -223,10 +224,14 @@ if (window.top === window.self && !scannerGlobal.__jafScannerStarted) {
   (async () => {
     try {
       const profile = await getProfile();
-      // Seed the one-time badge coachmark flag before enabling the scanner, so the
-      // first badge render knows whether to show it.
-      const { badgeIntroSeen } = await chrome.storage.local.get('badgeIntroSeen');
+      // Seed the one-time badge coachmark flag and the user's badge corner before
+      // enabling the scanner, so the first badge render is already correct.
+      const { badgeIntroSeen, badgeCorner } = await chrome.storage.local.get([
+        'badgeIntroSeen',
+        'badgeCorner',
+      ]);
       setBadgeIntroSeen(Boolean(badgeIntroSeen));
+      setBadgeCorner(badgeCorner);
       setBadgeFeatures({ coverLetter: profile.coverLetterEnabled, resume: profile.tailoredResumeEnabled });
       setScannerEnabled(profile.scanEnabled);
     } catch (e) {

--- a/src/content/sponsorship.ts
+++ b/src/content/sponsorship.ts
@@ -509,6 +509,51 @@ function markIntroSeen(): void {
   chrome.storage.local.set({ [INTRO_SEEN_KEY]: true });
 }
 
+// Which viewport corner the badge sits in. The user can drag the badge (or use
+// arrow keys on its header) to any corner; the choice is persisted so every page
+// renders it where they put it. Loaded at content init (index.ts calls
+// setBadgeCorner), defaulting to the historical top-right.
+export type BadgeCorner = 'tl' | 'tr' | 'bl' | 'br';
+const CORNER_KEY = 'badgeCorner';
+let badgeCorner: BadgeCorner = 'tr';
+
+/** Seeds the badge corner from storage (called once from the content init). */
+export function setBadgeCorner(value: unknown): void {
+  if (value === 'tl' || value === 'tr' || value === 'bl' || value === 'br') badgeCorner = value;
+}
+
+/** Pure: the corner nearest to a point (the badge's center) in a vw×vh viewport. */
+export function nearestCorner(cx: number, cy: number, vw: number, vh: number): BadgeCorner {
+  return `${cy < vh / 2 ? 't' : 'b'}${cx < vw / 2 ? 'l' : 'r'}` as BadgeCorner;
+}
+
+/** Persists a new corner; must never throw in an orphaned extension context. */
+function saveCorner(corner: BadgeCorner): void {
+  badgeCorner = corner;
+  try {
+    void chrome.storage.local.set({ [CORNER_KEY]: corner });
+  } catch {
+    // Extension context invalidated — keep the in-page move working anyway.
+  }
+}
+
+/** Positions the badge column in a corner and flips stacking/arrow direction. */
+function applyCorner(wrap: HTMLElement, corner: BadgeCorner): void {
+  const st = wrap.style;
+  const left = corner === 'tl' || corner === 'bl';
+  const top = corner === 'tl' || corner === 'tr';
+  st.left = left ? '14px' : 'auto';
+  st.right = left ? 'auto' : '14px';
+  st.top = top ? '14px' : 'auto';
+  st.bottom = top ? 'auto' : '14px';
+  st.alignItems = left ? 'flex-start' : 'flex-end';
+  // Bottom corners stack in reverse so the card hugs the corner and the
+  // coachmark floats above it instead of running off-screen.
+  st.flexDirection = top ? 'column' : 'column-reverse';
+  wrap.classList.toggle('wrap--above', !top);
+  wrap.classList.toggle('wrap--left', left);
+}
+
 /**
  * Turns the eligibility scanner off everywhere by persisting scanEnabled=false.
  * The profile-change listener in index.ts then removes the badge and the
@@ -972,7 +1017,9 @@ function renderBadge(a: SponsorAnalysis): HTMLElement {
          flex default that would otherwise keep it at its full content height. */
       min-height: 0; overflow-y: auto;
     }
-    .head { display: flex; align-items: center; gap: 8px; }
+    .head { display: flex; align-items: center; gap: 8px;
+            cursor: grab; touch-action: none; }
+    .head:focus-visible { outline: 2px solid #44506b; outline-offset: 2px; border-radius: 4px; }
     .word { font-size: 20px; font-weight: 800; color: ${s.color}; letter-spacing: .5px; }
     .title { font-weight: 700; flex: 1; }
     .x { border: none; background: transparent; cursor: pointer; font-size: 18px;
@@ -999,6 +1046,10 @@ function renderBadge(a: SponsorAnalysis): HTMLElement {
              box-shadow: 0 10px 30px rgba(15,23,42,.3); }
     .coach::before { content: ''; position: absolute; top: -6px; right: 34px;
                      width: 14px; height: 14px; background: #44506b; transform: rotate(45deg); }
+    /* Corner variants: bottom corners stack the coachmark ABOVE the card (arrow
+       points down at it); left corners anchor the arrow on the left side. */
+    .wrap--above .coach::before { top: auto; bottom: -6px; }
+    .wrap--left .coach::before { right: auto; left: 34px; }
     .coach-t { font-weight: 700; font-size: 14px; margin-bottom: 5px; }
     .coach-d { font-size: 12px; line-height: 1.5; color: #dbe1ec; }
     .coach-row { display: flex; gap: 8px; margin-top: 12px; }
@@ -1120,11 +1171,76 @@ function renderBadge(a: SponsorAnalysis): HTMLElement {
   foot.appendChild(off);
   card.appendChild(foot);
 
-  // Stack the card and (optionally) the coachmark in a fixed, right-aligned
-  // column so the coachmark floats as a separate bubble below the badge.
+  // Stack the card and (optionally) the coachmark in a fixed column anchored to
+  // the user's chosen corner (default top-right).
   const wrap = document.createElement('div');
   wrap.className = 'wrap';
   wrap.appendChild(card);
+  applyCorner(wrap, badgeCorner);
+
+  // --- Move the badge: drag the header to any corner (or use arrow keys). ---
+  head.title = 'Drag to move this badge to another corner';
+  head.setAttribute('tabindex', '0');
+  head.setAttribute('role', 'button');
+  head.setAttribute('aria-label', 'Move badge: drag it, or press an arrow key');
+
+  let dragFrom: { x: number; y: number; left: number; top: number } | null = null;
+  let dragging = false;
+  head.addEventListener('pointerdown', (e) => {
+    // The × close (and any other control) keeps its normal click behavior.
+    if ((e.target as HTMLElement).closest('button, a')) return;
+    const r = wrap.getBoundingClientRect();
+    dragFrom = { x: e.clientX, y: e.clientY, left: r.left, top: r.top };
+    // Capture so moves keep streaming to us even over iframes / out of the card.
+    // A failed capture (stale pointer id) just means a less-sticky drag.
+    try {
+      head.setPointerCapture(e.pointerId);
+    } catch {
+      // proceed uncaptured
+    }
+  });
+  head.addEventListener('pointermove', (e) => {
+    if (!dragFrom) return;
+    const dx = e.clientX - dragFrom.x;
+    const dy = e.clientY - dragFrom.y;
+    // A real drag needs ~5px of travel; below that it's just a sloppy click.
+    if (!dragging && Math.hypot(dx, dy) < 5) return;
+    dragging = true;
+    const st = wrap.style;
+    st.right = 'auto';
+    st.bottom = 'auto';
+    st.left = `${dragFrom.left + dx}px`;
+    st.top = `${dragFrom.top + dy}px`;
+    st.userSelect = 'none';
+    head.style.cursor = 'grabbing';
+  });
+  const endDrag = (): void => {
+    if (dragging) {
+      const r = wrap.getBoundingClientRect();
+      saveCorner(nearestCorner(r.left + r.width / 2, r.top + r.height / 2, innerWidth, innerHeight));
+      applyCorner(wrap, badgeCorner);
+    }
+    wrap.style.userSelect = '';
+    head.style.cursor = '';
+    dragFrom = null;
+    dragging = false;
+  };
+  head.addEventListener('pointerup', endDrag);
+  head.addEventListener('pointercancel', endDrag);
+
+  head.addEventListener('keydown', (e) => {
+    const c = badgeCorner;
+    const next: BadgeCorner | null =
+      e.key === 'ArrowLeft' ? (c === 'tr' ? 'tl' : c === 'br' ? 'bl' : null)
+      : e.key === 'ArrowRight' ? (c === 'tl' ? 'tr' : c === 'bl' ? 'br' : null)
+      : e.key === 'ArrowUp' ? (c === 'bl' ? 'tl' : c === 'br' ? 'tr' : null)
+      : e.key === 'ArrowDown' ? (c === 'tl' ? 'bl' : c === 'tr' ? 'br' : null)
+      : null;
+    if (!next) return;
+    e.preventDefault(); // moving the badge, not scrolling the page
+    saveCorner(next);
+    applyCorner(wrap, next);
+  });
 
   // One-time coachmark: a separate bubble below the badge the first time it ever
   // appears, explaining what it is with a one-click global off. Removed (and never


### PR DESCRIPTION
## What & why

The badge is pinned to the top-right and can cover content the user wants to read — the only recourse was dismissing it (which kills it for that posting). Now the card **header is a drag handle**: drag the badge anywhere and on release it **snaps to the nearest viewport corner** (14px inset). The corner persists (`chrome.storage.local.badgeCorner`) and is seeded at content init, so every page renders the badge where you left it.

## Details
- **Drag**: pointer capture (keeps tracking over iframes), ~5px travel threshold so plain clicks — including the × close — behave exactly as before; interactive descendants never start a drag.
- **Bottom corners**: the flex column reverses so the card hugs the corner and the (one-time) coachmark floats above it; the coachmark arrow flips via CSS modifiers.
- **Keyboard**: the handle is focusable (`role="button"`, aria-label); arrow keys hop the badge corner-to-corner. `cursor: grab/grabbing` affordance + focus-visible outline.
- **Persistence**: saved fire-and-forget on snap (try/catch so an orphaned extension context can't throw); loaded in the init IIFE alongside `badgeIntroSeen`. Other tabs pick it up on their next render.
- Pure `nearestCorner()` exported and unit-tested (4 quadrants + center tie → bottom-right).

## How I tested
- `npm run lint` / `typecheck` / `npm test` (**52 tests**, 2 new) / `npm run build` — all green.
- Live-DOM harness mirroring the badge structure + exact drag/keyboard wiring, driven in a browser: drag moves + snaps, threshold holds, × click preserved (no drag hijack), keyboard transitions match the table, bottom corners apply `column-reverse` presets.
- Manual check on a real posting recommended after merge (build + **reload the extension**): drag to each corner, reload page → badge reappears in the saved corner.

Extension-only, no proxy redeploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added draggable badge positioning, allowing the badge to snap to any viewport corner.
  * Added keyboard arrow-key navigation for repositioning the badge.
  * Badge position is now saved and restored automatically.
  * Improved coachmark placement for different badge corners.
  * Added visible keyboard focus styling for improved accessibility.

* **Tests**
  * Added coverage for corner snapping across viewport quadrants and center-position tie handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->