### PR TITLE
fix: address CodeRabbit nits on the draggable badge

### DIFF
--- a/src/content/sponsorship.ts
+++ b/src/content/sponsorship.ts
@@ -531,7 +531,10 @@ export function nearestCorner(cx: number, cy: number, vw: number, vh: number): B
 function saveCorner(corner: BadgeCorner): void {
   badgeCorner = corner;
   try {
-    void chrome.storage.local.set({ [CORNER_KEY]: corner });
+    // Catch both a synchronous throw (context invalidated) and an async
+    // rejection (e.g. quota) so neither surfaces as an unhandled rejection —
+    // the in-page move still works regardless.
+    void chrome.storage.local.set({ [CORNER_KEY]: corner }).catch(() => {});
   } catch {
     // Extension context invalidated — keep the in-page move working anyway.
   }
@@ -1229,6 +1232,10 @@ function renderBadge(a: SponsorAnalysis): HTMLElement {
   head.addEventListener('pointercancel', endDrag);
 
   head.addEventListener('keydown', (e) => {
+    // Only navigate when the header handle itself has focus — an arrow key
+    // pressed while a child control (the × close) is focused bubbles here and
+    // must not move the badge.
+    if (e.target !== head) return;
     const c = badgeCorner;
     const next: BadgeCorner | null =
       e.key === 'ArrowLeft' ? (c === 'tr' ? 'tl' : c === 'br' ? 'bl' : null)


### PR DESCRIPTION
Follow-up to #98 — two minor issues CodeRabbit flagged (both quick wins), fixed after the merge:

1. **Arrow keys bubbling from the × close button** moved the badge unexpectedly. The header's keydown handler now navigates only when the handle itself is focused (`e.target === head`).
2. **Async storage rejection**: `saveCorner`'s try/catch caught only synchronous throws; `chrome.storage.local.set` returns a promise that could reject asynchronously (e.g. quota) and become an unhandled rejection. Added a `.catch(() => {})` alongside the existing try/catch.

`npm run lint` / `typecheck` / `test` (52) / `build` — all green. Extension-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability when saving badge corner-position preferences, even if storage writes fail.
  - Prevented arrow-key navigation from moving the badge when interacting with focused controls such as the close button.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->