### PR TITLE
Associate Field labels with their inputs (htmlFor/id)

### DIFF
--- a/src/options/Options.tsx
+++ b/src/options/Options.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { Children, cloneElement, isValidElement, useEffect, useId, useState } from 'react';
 import type { EducationEntry, Profile, WorkEntry } from '../lib/profile';
 import { useProfile } from '../ui/useProfile';
 import { extractText } from '../lib/documents';
@@ -518,11 +518,34 @@ function OptionsView({
   );
 }
 
+const LABELABLE_TAGS = new Set(['input', 'select', 'textarea']);
+
 function Field({ label, children }: { label: string; children: React.ReactNode }) {
+  const id = useId();
+  const childArray = Children.toArray(children);
+  const [first, ...rest] = childArray;
+
+  const canAssociate =
+    isValidElement(first) &&
+    typeof first.type === 'string' &&
+    LABELABLE_TAGS.has(first.type);
+
+  if (!canAssociate) {
+    // Not a single form control (e.g. a div of buttons like the Account
+    // field) — keep the plain label rather than force an incorrect htmlFor.
+    return (
+      <div className="field">
+        <label>{label}</label>
+        {children}
+      </div>
+    );
+  }
+
   return (
     <div className="field">
-      <label>{label}</label>
-      {children}
+      <label htmlFor={id}>{label}</label>
+      {cloneElement(first as React.ReactElement<{ id?: string }>, { id })}
+      {rest}
     </div>
   );
 }


### PR DESCRIPTION
Closes #107

Field now generates a stable id via useId() and attaches it via 
htmlFor on the label, cloning it onto the first child if that child 
is an <input>/<select>/<textarea>.

No changes needed at any of the ~31 call sites. Field safely detects 
cases where children isn't a single form control:
- Fields with a control + trailing help text (Model, Gemini API key, 
  Admin token) still get the id/htmlFor on the actual control, help 
  text renders unchanged after it.
- The Account field (sign-in/sign-out buttons, no real input) falls 
  back to the original plain label, per the issue's own guidance.

Verified: tsc --noEmit and vite build both pass clean. Manually 
tested clicking labels focuses the right input; Account section 
buttons still work normally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility Improvements**
  * Improved form field labeling by automatically linking labels to supported input, select, and textarea controls.
  * Added a safe fallback for unsupported field content to prevent incorrect label associations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->