### PR TITLE
fix: Add unit tests for the PDF text encoder (src/lib/pdf.ts) #109

### DIFF
--- a/src/lib/pdf.test.ts
+++ b/src/lib/pdf.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect } from 'vitest';
+import { glyph, wrapLine, encodeText } from './pdf';
+
+describe('PDF Helpers', () => {
+  describe('glyph', () => {
+    it('returns correct byte and Helvetica width for printable ASCII characters', () => {
+      // Space (ASCII 32): width should be 278
+      expect(glyph(' ')).toEqual({ byte: 32, width: 278 });
+
+      // 'A' (ASCII 65): width should be 667
+      expect(glyph('A')).toEqual({ byte: 65, width: 667 });
+
+      // 'a' (ASCII 97): width should be 556
+      expect(glyph('a')).toEqual({ byte: 97, width: 556 });
+    });
+
+    it('maps typographic Unicode characters to WinAnsi bytes and correct widths', () => {
+      // Left single quote (0x2018) -> 0x91, width 222
+      expect(glyph('‘')).toEqual({ byte: 0x91, width: 222 });
+
+      // Right single quote (0x2019) -> 0x92, width 222
+      expect(glyph('’')).toEqual({ byte: 0x92, width: 222 });
+
+      // Left double quote (0x201c) -> 0x93, width 333
+      expect(glyph('“')).toEqual({ byte: 0x93, width: 333 });
+
+      // Right double quote (0x201d) -> 0x94, width 333
+      expect(glyph('”')).toEqual({ byte: 0x94, width: 333 });
+
+      // Bullet (0x2022) -> 0x95, width 350
+      expect(glyph('•')).toEqual({ byte: 0x95, width: 350 });
+
+      // En dash (0x2013) -> 0x96, width 556
+      expect(glyph('–')).toEqual({ byte: 0x96, width: 556 });
+
+      // Em dash (0x2014) -> 0x97, width 1000
+      expect(glyph('—')).toEqual({ byte: 0x97, width: 1000 });
+
+      // Ellipsis (0x2026) -> 0x85, width 1000
+      expect(glyph('…')).toEqual({ byte: 0x85, width: 1000 });
+    });
+
+    it('maps non-breaking space to standard space', () => {
+      // nbsp (U+00A0) -> 0x20, width 278
+      expect(glyph('\u00A0')).toEqual({ byte: 0x20, width: 278 });
+    });
+
+    it('falls back to code for other characters below 256', () => {
+      // newline (ASCII 10) -> byte 10, width 556
+      expect(glyph('\n')).toEqual({ byte: 10, width: 556 });
+    });
+
+    it('returns fallback "?" (0x3F) for unsupported Unicode characters', () => {
+      // Emoji
+      expect(glyph('😊')).toEqual({ byte: 0x3f, width: 556 });
+
+      // Chinese character
+      expect(glyph('中')).toEqual({ byte: 0x3f, width: 556 });
+    });
+  });
+
+  describe('encodeText', () => {
+    it('leaves a plain ASCII string unchanged', () => {
+      const ascii = 'Hello World 123!';
+      expect(encodeText(ascii)).toBe(ascii);
+    });
+
+    it('escapes parentheses and backslashes', () => {
+      // '(' -> '\(', ')' -> '\)', '\' -> '\\'
+      expect(encodeText('hello (world) \\')).toBe('hello \\(world\\) \\\\');
+    });
+
+    it('correctly maps smart quotes and non-breaking spaces during encoding', () => {
+      // '“' maps to 0x93, '”' maps to 0x94, nbsp maps to 0x20 (space)
+      const encoded = encodeText('“hello”\u00A0world');
+      expect(encoded).toBe(
+        String.fromCharCode(0x93) +
+        'hello' +
+        String.fromCharCode(0x94) +
+        ' ' +
+        'world'
+      );
+    });
+  });
+
+  describe('wrapLine', () => {
+    it('returns single empty string for empty or whitespace-only lines', () => {
+      expect(wrapLine('', 12, 100)).toEqual(['']);
+      expect(wrapLine('   ', 12, 100)).toEqual(['']);
+    });
+
+    it('does not wrap a short line that fits within the maximum width', () => {
+      // "Hello World" is about 62 points at 12pt font.
+      expect(wrapLine('Hello World', 12, 100)).toEqual(['Hello World']);
+    });
+
+    it('wraps a long line into multiple lines when it exceeds the maximum width', () => {
+      // "Hello World" exceeds 50 points, so it should split at the space
+      expect(wrapLine('Hello World', 12, 50)).toEqual(['Hello', 'World']);
+    });
+
+    it('handles a single word that is wider than the maximum width without breaking it', () => {
+      // "Supercalifragilisticexpialidocious" is very long.
+      // Even if maxW is small, the single word should not be split internally, but subsequent words should wrap.
+      expect(wrapLine('Supercalifragilisticexpialidocious abc', 12, 50)).toEqual([
+        'Supercalifragilisticexpialidocious',
+        'abc'
+      ]);
+    });
+  });
+});

--- a/src/lib/pdf.ts
+++ b/src/lib/pdf.ts
@@ -24,7 +24,7 @@ const EXTRA_W: Record<number, number> = {
   0x91: 222, 0x92: 222, 0x93: 333, 0x94: 333, 0x95: 350, 0x96: 556, 0x97: 1000, 0x85: 1000,
 };
 
-function glyph(ch: string): { byte: number; width: number } {
+export function glyph(ch: string): { byte: number; width: number } {
   let code = ch.charCodeAt(0);
   if (UNI_TO_WIN[code] !== undefined) code = UNI_TO_WIN[code];
   if (code >= 32 && code <= 126) return { byte: code, width: HELV[code - 32] };
@@ -41,7 +41,7 @@ function measure(s: string, fontSize: number): number {
 }
 
 /** Greedy word-wrap a single logical line to a max width (in points). */
-function wrapLine(line: string, fontSize: number, maxW: number): string[] {
+export function wrapLine(line: string, fontSize: number, maxW: number): string[] {
   if (line.trim() === '') return [''];
   const out: string[] = [];
   let cur = '';
@@ -59,7 +59,7 @@ function wrapLine(line: string, fontSize: number, maxW: number): string[] {
 }
 
 /** Escapes a string into PDF WinAnsi bytes (handling ( ) \ and high bytes). */
-function encodeText(s: string): string {
+export function encodeText(s: string): string {
   let out = '';
   for (const ch of s) {
     const { byte } = glyph(ch);


### PR DESCRIPTION
<!-- Thanks for contributing! Keep PRs small and focused — one change per PR. -->

## What & why
In pdf.test.ts, we tested the three exported helpers across 12 test cases:

1. glyph() Test Cases Printable ASCII: Verified characters like ' ' (space), 'A', and 'a' map to their standard ASCII bytes and correct Helvetica font widths (e.g. 278, 667, 556). Typographic Unicode: Verified special characters in the UNI_TO_WIN map return their WinAnsi byte translations and designated widths: Left/Right single quotes (‘, ’)
Left/Right double quotes (“, ”)
Bullet points (•)
En/Em dashes (–, —)
Ellipses (…)
Non-Breaking Spaces (nbsp): Verified \u00A0 maps to standard space (0x20, width 278). Low-byte codes: Verified low character codes (e.g., \n linebreaks) return their respective character codes. Unsupported Characters: Verified unsupported/high Unicode characters (like the 😊 emoji or Chinese character 中) return the fallback ? (byte 0x3f, width 556).
2. encodeText() Test Cases ASCII Preservation: Verified plain text is unchanged during encoding. Escaping: Verified special PDF chars like (, ), and \ are backslash-escaped to prevent PDF syntax corruption. Char Mapping: Verified smart quotes and non-breaking spaces are correctly translated into their corresponding WinAnsi byte sequence.
3. wrapLine() Test Cases
Empty/Whitespace Lines: Verified empty ("") and whitespace-only ("   ") inputs yield [""].
Short Lines: Verified lines that fit within the specified maximum width remain as a single wrapped element.
Long Lines: Verified lines exceeding the maximum width wrap at space boundaries.
Oversized Words: Verified single words wider than the maximum width are not sliced character-by-character, but kept intact on their own line with subsequent words wrapped correctly.

<!-- What does this change do, and what problem does it solve? Link any related issue: "Closes #123". -->
Choses #109 
## How I tested
created and ran the new test cases : ✓ src/lib/pdf.test.ts (12 tests) 7ms
<!-- e.g. loaded the unpacked extension and reproduced the fix on a real job page, added/updated tests. -->

## Checklist

- [x] `npm run lint` passes
- [x] `npm run typecheck` passes
- [x] `npm test` passes
- [x] `npm run build` succeeds
- [x] Tests added/updated if behavior changed
- [x] No secrets, keys, or personal data committed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added automated coverage for PDF text encoding, character handling, and line wrapping.
  * Verified support for punctuation, spaces, escaping, fallback characters, empty lines, and long words.
* **Refactor**
  * Improved internal PDF text utilities for testability without changing runtime behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->