### PR TITLE
feat: warn the user when a saved posting is truncated

### DIFF
--- a/src/lib/savedJobs.test.ts
+++ b/src/lib/savedJobs.test.ts
@@ -1,5 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { addJob, isJobTextTruncated, MAX_TEXT } from './savedJobs';
+import { addJob, isJobTextTruncated, MAX_TEXT, type SavedJobsState } from './savedJobs';
+
+const STORAGE_KEY = 'savedJobs';
 
 describe('isJobTextTruncated — save cap boundary', () => {
   it('is false at or below the cap', () => {
@@ -39,18 +41,22 @@ describe('addJob — storage-side truncation', () => {
 
   it('caps persisted text at MAX_TEXT and warns, for input one char over', async () => {
     const longText = 'a'.repeat(MAX_TEXT + 1);
-    const state = await addJob({ company: 'Acme', role: 'Engineer', url: 'https://x', text: longText });
+    await addJob({ company: 'Acme', role: 'Engineer', url: 'https://x', text: longText });
 
-    expect(state.jobs[0].text).toHaveLength(MAX_TEXT);
+    // Assert what actually landed in storage, not just addJob's return value —
+    // a regression could return the right shape while persisting something else.
+    const persisted = store[STORAGE_KEY] as SavedJobsState;
+    expect(persisted.jobs[0].text).toBe(longText.slice(0, MAX_TEXT));
     expect(console.warn).toHaveBeenCalledWith(
       expect.stringContaining(`${MAX_TEXT + 1} to ${MAX_TEXT}`),
     );
   });
 
   it('does not warn and stores text unchanged when under the cap', async () => {
-    const state = await addJob({ company: 'Acme', role: 'Engineer', url: 'https://x', text: 'short posting' });
+    await addJob({ company: 'Acme', role: 'Engineer', url: 'https://x', text: 'short posting' });
 
-    expect(state.jobs[0].text).toBe('short posting');
+    const persisted = store[STORAGE_KEY] as SavedJobsState;
+    expect(persisted.jobs[0].text).toBe('short posting');
     expect(console.warn).not.toHaveBeenCalled();
   });
 });

--- a/src/lib/savedJobs.test.ts
+++ b/src/lib/savedJobs.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from 'vitest';
+import { isJobTextTruncated, MAX_TEXT } from './savedJobs';
+
+describe('isJobTextTruncated — save cap boundary', () => {
+  it('is false at or below the cap', () => {
+    expect(isJobTextTruncated('')).toBe(false);
+    expect(isJobTextTruncated('a'.repeat(MAX_TEXT - 1))).toBe(false);
+    expect(isJobTextTruncated('a'.repeat(MAX_TEXT))).toBe(false);
+  });
+
+  it('is true one character past the cap', () => {
+    expect(isJobTextTruncated('a'.repeat(MAX_TEXT + 1))).toBe(true);
+  });
+});

--- a/src/lib/savedJobs.test.ts
+++ b/src/lib/savedJobs.test.ts
@@ -1,5 +1,5 @@
-import { describe, expect, it } from 'vitest';
-import { isJobTextTruncated, MAX_TEXT } from './savedJobs';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { addJob, isJobTextTruncated, MAX_TEXT } from './savedJobs';
 
 describe('isJobTextTruncated — save cap boundary', () => {
   it('is false at or below the cap', () => {
@@ -10,5 +10,47 @@ describe('isJobTextTruncated — save cap boundary', () => {
 
   it('is true one character past the cap', () => {
     expect(isJobTextTruncated('a'.repeat(MAX_TEXT + 1))).toBe(true);
+  });
+});
+
+describe('addJob — storage-side truncation', () => {
+  // Minimal in-memory chrome.storage.local: enough for get/set with one key.
+  let store: Record<string, unknown>;
+
+  beforeEach(() => {
+    store = {};
+    vi.stubGlobal('chrome', {
+      storage: {
+        local: {
+          get: vi.fn(async (key: string) => ({ [key]: store[key] })),
+          set: vi.fn(async (items: Record<string, unknown>) => {
+            Object.assign(store, items);
+          }),
+        },
+      },
+    });
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it('caps persisted text at MAX_TEXT and warns, for input one char over', async () => {
+    const longText = 'a'.repeat(MAX_TEXT + 1);
+    const state = await addJob({ company: 'Acme', role: 'Engineer', url: 'https://x', text: longText });
+
+    expect(state.jobs[0].text).toHaveLength(MAX_TEXT);
+    expect(console.warn).toHaveBeenCalledWith(
+      expect.stringContaining(`${MAX_TEXT + 1} to ${MAX_TEXT}`),
+    );
+  });
+
+  it('does not warn and stores text unchanged when under the cap', async () => {
+    const state = await addJob({ company: 'Acme', role: 'Engineer', url: 'https://x', text: 'short posting' });
+
+    expect(state.jobs[0].text).toBe('short posting');
+    expect(console.warn).not.toHaveBeenCalled();
   });
 });

--- a/src/lib/savedJobs.ts
+++ b/src/lib/savedJobs.ts
@@ -6,7 +6,13 @@
 
 const STORAGE_KEY = 'savedJobs';
 const MAX_JOBS = 20;
-const MAX_TEXT = 12_000;
+/** Captured posting text is capped at this many characters before storage. */
+export const MAX_TEXT = 12_000;
+
+/** True when `text` is longer than the cap and would be trimmed on save. */
+export function isJobTextTruncated(text: string): boolean {
+  return text.length > MAX_TEXT;
+}
 
 export interface SavedJob {
   id: string;
@@ -53,6 +59,11 @@ export async function addJob(
   partial: Omit<SavedJob, 'id' | 'savedAt'>,
 ): Promise<SavedJobsState> {
   const state = await getSavedJobs();
+  if (isJobTextTruncated(partial.text)) {
+    console.warn(
+      `[Little AI Helper] Saved posting trimmed from ${partial.text.length} to ${MAX_TEXT} chars for AI context.`,
+    );
+  }
   const job: SavedJob = {
     ...partial,
     text: partial.text.slice(0, MAX_TEXT),

--- a/src/popup/Popup.tsx
+++ b/src/popup/Popup.tsx
@@ -6,6 +6,8 @@ import {
   setActiveJob,
   deleteJob,
   onSavedJobsChanged,
+  isJobTextTruncated,
+  MAX_TEXT,
   type SavedJob,
 } from '../lib/savedJobs';
 import { sendToBackground, sendToTab } from '../lib/messages';
@@ -246,6 +248,11 @@ export function Popup() {
         url: cap.url,
         text: cap.text,
       });
+      flashFillMsg(
+        isJobTextTruncated(cap.text)
+          ? `Saved — the posting was long, so it was trimmed to ${MAX_TEXT.toLocaleString()} characters for AI context.`
+          : 'Job saved.',
+      );
     } catch {
       setError('Could not read this page. Reload it and try again.');
     } finally {


### PR DESCRIPTION
Closes #28.

`addJob` trimmed captured posting text to `MAX_TEXT` (12,000 chars) with no signal. This surfaces it at both levels, keeping the stored shape identical (still just the capped `text`):

- **`savedJobs.ts`**: export `MAX_TEXT` and a pure `isJobTextTruncated(text)` helper; `addJob` now `console.warn`s with the original → capped length when it trims.
- **Popup**: the save flow flashes a note when the posting was trimmed ("Saved — the posting was long, so it was trimmed to 12,000 characters for AI context."), and a plain "Job saved." otherwise.
- **Test**: `savedJobs.test.ts` covers the boundary — `== MAX_TEXT` → not truncated, `MAX_TEXT + 1` → truncated. (This file is the natural home for the broader #94 suite too; a future PR can extend it.)

`npm run lint` / `typecheck` / `test` (66) / `build` — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added clearer messaging after saving a job when the posting text is automatically trimmed to the supported limit.
  * Saved job posting text is capped at 12,000 characters.
* **Bug Fixes**
  * Improved oversized job handling by warning when truncation occurs and ensuring the stored value is capped.
* **Tests**
  * Added coverage for truncation boundary behavior and for persistence to verify trimmed storage and warning behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->