### PR TITLE
feat: guard cover-letter / resume generation when Company or Role is empty

### DIFF
--- a/src/popup/Popup.tsx
+++ b/src/popup/Popup.tsx
@@ -254,6 +254,9 @@ export function Popup() {
   }
 
   const activeJob = jobs.find((j) => j.id === activeJobId) ?? null;
+  // Cover letter + tailored resume need both fields — a blank company/role
+  // produces a weak, generic result, so gate generation on them.
+  const canGenerate = company.trim() !== '' && role.trim() !== '';
   const openOptions = () => chrome.runtime.openOptionsPage();
   const geminiNeedsKey = aiProvider === 'gemini' && !apiKeySet;
   // Proxy mode needs a signed-in account (unless the owner set an admin token).
@@ -423,9 +426,14 @@ export function Popup() {
           />
         </div>
 
+        {!canGenerate && (
+          <div className="help" style={{ marginTop: 4 }}>
+            Enter a company and role above to generate a cover letter or tailored resume.
+          </div>
+        )}
         <button
           className="primary"
-          disabled={busy !== ''}
+          disabled={busy !== '' || !canGenerate}
           onClick={onCoverLetter}
           aria-label={busy === 'letter' ? 'Generating cover letter' : 'Generate cover letter'}
         >
@@ -451,7 +459,7 @@ export function Popup() {
         <button
           className="primary"
           style={{ marginTop: 8 }}
-          disabled={busy !== ''}
+          disabled={busy !== '' || !canGenerate}
           onClick={onResume}
           aria-label={busy === 'resume' ? 'Tailoring resume' : 'Generate tailored resume'}
         >

--- a/src/popup/Popup.tsx
+++ b/src/popup/Popup.tsx
@@ -14,6 +14,12 @@ import { downloadLetter } from '../lib/coverLetter';
 import { downloadResume } from '../lib/resume';
 import { signIn, reconcileAuthUser, onAuthChanged, type AuthUser } from '../lib/auth';
 
+/** Cover letter / tailored resume need both fields — blank or whitespace-only
+ * company/role produces a weak, generic result. */
+export function canGenerateDocuments(company: string, role: string): boolean {
+  return company.trim() !== '' && role.trim() !== '';
+}
+
 /** Compact "saved N ago" label for a saved job's timestamp. */
 function timeAgo(ts: number): string {
   const secs = Math.max(0, Math.round((Date.now() - ts) / 1000));
@@ -254,9 +260,7 @@ export function Popup() {
   }
 
   const activeJob = jobs.find((j) => j.id === activeJobId) ?? null;
-  // Cover letter + tailored resume need both fields — a blank company/role
-  // produces a weak, generic result, so gate generation on them.
-  const canGenerate = company.trim() !== '' && role.trim() !== '';
+  const canGenerate = canGenerateDocuments(company, role);
   const openOptions = () => chrome.runtime.openOptionsPage();
   const geminiNeedsKey = aiProvider === 'gemini' && !apiKeySet;
   // Proxy mode needs a signed-in account (unless the owner set an admin token).

--- a/src/popup/canGenerateDocuments.test.ts
+++ b/src/popup/canGenerateDocuments.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest';
+import { canGenerateDocuments } from './Popup';
+
+describe('canGenerateDocuments', () => {
+  it('is true only when both company and role have non-whitespace text', () => {
+    expect(canGenerateDocuments('Acme', 'Engineer')).toBe(true);
+  });
+
+  it('is false when either field is empty', () => {
+    expect(canGenerateDocuments('', 'Engineer')).toBe(false);
+    expect(canGenerateDocuments('Acme', '')).toBe(false);
+    expect(canGenerateDocuments('', '')).toBe(false);
+  });
+
+  it('treats whitespace-only input as blank', () => {
+    expect(canGenerateDocuments('   ', 'Engineer')).toBe(false);
+    expect(canGenerateDocuments('Acme', '\t\n')).toBe(false);
+  });
+});


### PR DESCRIPTION
Closes #26.

`onCoverLetter` / `onResume` would call the AI even with a blank Company or Role, silently producing a weaker, generic result. This gates generation on both fields:

- Derived `canGenerate = company.trim() !== '' && role.trim() !== ''`.
- Both "Generate cover letter" and "Generate tailored resume" buttons now `disabled={busy !== '' || !canGenerate}` — consistent with the existing busy guard.
- A short hint appears when the fields are empty: "Enter a company and role above to generate a cover letter or tailored resume." — so a greyed-out button isn't a mystery.

`npm run lint` / `typecheck` / `build` — all green. UI-only; worth a quick manual look in the popup (buttons disabled + hint when either field is blank, enabled once both are filled).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented cover-letter and tailored-resume generation when the company or role fields are blank (including whitespace-only input).
  * Added an on-screen prompt to complete both fields before generating documents.
  * Disabled the cover-letter and tailored-resume generate buttons until the required information is provided (while still honoring the existing busy state).
* **Tests**
  * Added automated test coverage for the company/role input validation logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->