### PR TITLE
chore(deps): bump github/codeql-action init+analyze to v4.37.1 together

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -21,13 +21,13 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4
+        uses: github/codeql-action/init@7188fc363630916deb702c7fdcf4e481b751f97a # v4
         with:
           languages: javascript-typescript
           queries: security-and-quality
 
       # JS/TS is interpreted — no build step needed before analysis.
       - name: Perform CodeQL analysis
-        uses: github/codeql-action/analyze@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4
+        uses: github/codeql-action/analyze@7188fc363630916deb702c7fdcf4e481b751f97a # v4
         with:
           category: '/language:javascript-typescript'


### PR DESCRIPTION
Combines Dependabot's #100 (`init`) and #101 (`analyze`) into one PR.

The two `github/codeql-action/*` steps must use the **same** version — the Analyze job fails on a mismatch, which is why #100 and #101 each fail individually. This bumps both `init` and `analyze` to the v4.37.1 SHA (`7188fc3`) in a single change.

Closes #100, closes #101.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the security scanning workflow to use newer CodeQL action versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->