### PR TITLE
feat:add copy-to-clipboard button for cover letter and resume (#123)

### DIFF
--- a/src/popup/Popup.tsx
+++ b/src/popup/Popup.tsx
@@ -61,6 +61,9 @@ export function Popup() {
   const [company, setCompany] = useState('');
   const [role, setRole] = useState('');
   const fillMsgTimer = useRef<number | null>(null);
+const [copied, setCopied] = useState<'' | 'letter' | 'resume'>('');
+const copyTimer = useRef<number | null>(null);
+
 
   // Persist a boolean feature toggle and reflect it locally.
   async function toggleSetting(
@@ -72,6 +75,20 @@ export function Popup() {
     const profile = await getProfile();
     await saveProfile({ ...profile, [key]: value });
   }
+
+  async function copyToClipboard(text: string, target: 'letter' | 'resume') {
+  try {
+    await navigator.clipboard.writeText(text);
+    if (copyTimer.current !== null) clearTimeout(copyTimer.current);
+    setCopied(target);
+    copyTimer.current = window.setTimeout(() => {
+      setCopied('');
+      copyTimer.current = null;
+    }, 1500);
+  } catch {
+    setError('Could not copy to clipboard. Select the text and copy manually.');
+  }
+}
 
   function flashFillMsg(message: string) {
     if (fillMsgTimer.current !== null) {
@@ -170,6 +187,7 @@ export function Popup() {
       chrome.tabs.onActivated.removeListener(onActivated);
       chrome.tabs.onUpdated.removeListener(onUpdated);
       if (fillMsgTimer.current !== null) clearTimeout(fillMsgTimer.current);
+      if (copyTimer.current !== null) clearTimeout(copyTimer.current);
     };
   }, []);
 
@@ -450,23 +468,33 @@ export function Popup() {
         >
           {busy === 'letter' ? 'Generating…' : 'Generate cover letter'}
         </button>
+       
         {letter && (
-          <>
-            <textarea
-              style={{ marginTop: 8 }}
-              value={letter}
-              onChange={(e) => setLetter(e.target.value)}
-            />
-            <button
-              className="full"
-              style={{ marginTop: 8 }}
-              onClick={() => downloadLetter(letter, company, role)}
-            >
-              ⬇ Download cover letter (.pdf)
-            </button>
-          </>
-        )}
-
+  <>
+    <textarea
+      style={{ marginTop: 8 }}
+      value={letter}
+      onChange={(e) => setLetter(e.target.value)}
+    />
+    <div style={{ display: 'flex', gap: 6, marginTop: 8 }}>
+      <button
+        className="full"
+        style={{ flex: 1 }}
+        onClick={() => downloadLetter(letter, company, role)}
+      >
+        ⬇ Download cover letter (.pdf)
+      </button>
+      <button
+        className="full"
+        style={{ flex: 1 }}
+        onClick={() => copyToClipboard(letter, 'letter')}
+        aria-label="Copy cover letter to clipboard"
+      >
+        {copied === 'letter' ? '✓ Copied!' : '📋 Copy'}
+      </button>
+    </div>
+  </>
+)}
         <button
           className="primary"
           style={{ marginTop: 8 }}
@@ -476,22 +504,32 @@ export function Popup() {
         >
           {busy === 'resume' ? 'Tailoring…' : 'Generate tailored resume'}
         </button>
-        {resume && (
-          <>
-            <textarea
-              style={{ marginTop: 8 }}
-              value={resume}
-              onChange={(e) => setResume(e.target.value)}
-            />
-            <button
-              className="full"
-              style={{ marginTop: 8 }}
-              onClick={() => downloadResume(resume, company, role)}
-            >
-              ⬇ Download resume (.pdf)
-            </button>
-          </>
-        )}
+       {resume && (
+  <>
+    <textarea
+      style={{ marginTop: 8 }}
+      value={resume}
+      onChange={(e) => setResume(e.target.value)}
+    />
+    <div style={{ display: 'flex', gap: 6, marginTop: 8 }}>
+      <button
+        className="full"
+        style={{ flex: 1 }}
+        onClick={() => downloadResume(resume, company, role)}
+      >
+        ⬇ Download resume (.pdf)
+      </button>
+      <button
+        className="full"
+        style={{ flex: 1 }}
+        onClick={() => copyToClipboard(resume, 'resume')}
+        aria-label="Copy resume to clipboard"
+      >
+        {copied === 'resume' ? '✓ Copied!' : '📋 Copy'}
+      </button>
+    </div>
+  </>
+)}
       </div>
 
       {error && <div className="status warn">{error}</div>}


### PR DESCRIPTION
<!-- Thanks for contributing! Keep PRs small and focused — one change per PR. -->

## What & why

Adds a 📋 Copy to clipboard button next to the Download button for both the
cover letter and tailored resume result blocks, with a temporary "✓ Copied!"
confirmation.

Previously the only way to reuse generated text was to download a PDF or
manually select-all inside the textarea — not an obvious affordance. This lets
users paste directly into an application form, email, or Google Doc.

Closes #123

## How I tested
- Manually verified copy + paste for both blocks, "Copied!" confirmation, and
  that Download still works.
- Confirmed layout stays within the popup width with both buttons side by side.
  
## Checklist

- [X] `npm run lint` passes
- [X] `npm run typecheck` passes
- [X] `npm test` passes
- [X] `npm run build` succeeds
- [X] Tests added/updated if behavior changed
- [X] No secrets, keys, or personal data committed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added copy-to-clipboard buttons for generated cover letters and tailored resumes.
  * Added visual confirmation when content is copied successfully.

* **Bug Fixes**
  * Added error feedback when copying content to the clipboard fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->