### PR TITLE
fix(content): keep the dragged badge on-screen and always snap on release

### DIFF
--- a/src/content/analyze.test.ts
+++ b/src/content/analyze.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest';
 import {
   addBadgeDismissListener,
   analyze,
+  clampAxis,
   isBadgeDismissKey,
   nearestCorner,
   shouldDismissBadge,
@@ -19,6 +20,29 @@ describe('nearestCorner — badge drag snapping', () => {
     // Center is not < half, so ties resolve to bottom/right — deterministic,
     // and matches the badge's historical right-side home.
     expect(nearestCorner(500, 400, 1000, 800)).toBe('br');
+  });
+});
+
+describe('clampAxis — keep the dragged badge on-screen', () => {
+  it('leaves an in-range position unchanged', () => {
+    expect(clampAxis(100, 200, 1000)).toBe(100);
+  });
+
+  it('clamps a negative position to the near edge', () => {
+    expect(clampAxis(-50, 200, 1000)).toBe(0);
+  });
+
+  it('clamps past the far edge to viewport - len', () => {
+    // 200-wide badge in a 1000 viewport can sit at most at 800.
+    expect(clampAxis(950, 200, 1000)).toBe(800);
+    expect(clampAxis(800, 200, 1000)).toBe(800);
+  });
+
+  it('pins to 0 when the badge is larger than the viewport', () => {
+    // viewport - len is negative; the badge pins to the top/left edge instead
+    // of being pushed off-screen by a negative upper bound.
+    expect(clampAxis(100, 1200, 1000)).toBe(0);
+    expect(clampAxis(-100, 1200, 1000)).toBe(0);
   });
 });
 

--- a/src/content/sponsorship.ts
+++ b/src/content/sponsorship.ts
@@ -527,6 +527,13 @@ export function nearestCorner(cx: number, cy: number, vw: number, vh: number): B
   return `${cy < vh / 2 ? 't' : 'b'}${cx < vw / 2 ? 'l' : 'r'}` as BadgeCorner;
 }
 
+/** Clamp one axis so a size-`len` badge stays within a `viewport`-long axis. */
+export function clampAxis(pos: number, len: number, viewport: number): number {
+  // Inner max guards a badge larger than the viewport: pin it to the top/left
+  // edge (0) rather than letting a negative upper bound push it off-screen.
+  return Math.max(0, Math.min(pos, Math.max(0, viewport - len)));
+}
+
 /** Persists a new corner; must never throw in an orphaned extension context. */
 function saveCorner(corner: BadgeCorner): void {
   badgeCorner = corner;
@@ -1187,13 +1194,14 @@ function renderBadge(a: SponsorAnalysis): HTMLElement {
   head.setAttribute('role', 'button');
   head.setAttribute('aria-label', 'Move badge: drag it, or press an arrow key');
 
-  let dragFrom: { x: number; y: number; left: number; top: number } | null = null;
+  let dragFrom: { x: number; y: number; left: number; top: number; w: number; h: number } | null =
+    null;
   let dragging = false;
   head.addEventListener('pointerdown', (e) => {
     // The × close (and any other control) keeps its normal click behavior.
     if ((e.target as HTMLElement).closest('button, a')) return;
     const r = wrap.getBoundingClientRect();
-    dragFrom = { x: e.clientX, y: e.clientY, left: r.left, top: r.top };
+    dragFrom = { x: e.clientX, y: e.clientY, left: r.left, top: r.top, w: r.width, h: r.height };
     // Capture so moves keep streaming to us even over iframes / out of the card.
     // A failed capture (stale pointer id) just means a less-sticky drag.
     try {
@@ -1212,8 +1220,10 @@ function renderBadge(a: SponsorAnalysis): HTMLElement {
     const st = wrap.style;
     st.right = 'auto';
     st.bottom = 'auto';
-    st.left = `${dragFrom.left + dx}px`;
-    st.top = `${dragFrom.top + dy}px`;
+    // Clamp to the viewport so the badge can never be dragged fully off-screen
+    // (and thus stranded, since its handle would go with it).
+    st.left = `${clampAxis(dragFrom.left + dx, dragFrom.w, innerWidth)}px`;
+    st.top = `${clampAxis(dragFrom.top + dy, dragFrom.h, innerHeight)}px`;
     st.userSelect = 'none';
     head.style.cursor = 'grabbing';
   });
@@ -1230,6 +1240,9 @@ function renderBadge(a: SponsorAnalysis): HTMLElement {
   };
   head.addEventListener('pointerup', endDrag);
   head.addEventListener('pointercancel', endDrag);
+  // Safety net: if the pointer is released outside the window, pointerup /
+  // pointercancel can be dropped — losing capture still fires, so snap here too.
+  head.addEventListener('lostpointercapture', endDrag);
 
   head.addEventListener('keydown', (e) => {
     // Only navigate when the header handle itself has focus — an arrow key


### PR DESCRIPTION
## What & why

The eligibility badge is draggable and snaps to the nearest corner on release. But it could be dragged **fully out of the viewport** and get stranded — "disappeared and never comes back until I reload."

**Root cause:** `pointermove` wrote `wrap.style.left/top` straight from the pointer delta with no clamping, so the badge could leave the visible window. Recovery relied on `endDrag` (which snaps back to a 14px corner inset) firing on `pointerup`/`pointercancel` — but when the pointer is released **outside the browser window**, those events can be dropped even with `setPointerCapture`. When that happened `endDrag` never ran, the badge kept its off-screen position, and its drag handle went with it, so it couldn't be grabbed again. ("Sometimes it pulls back" = the releases that landed inside the window, where the snap did fire.)

## Changes

- **Clamp the drag to the viewport** so the badge can never be dragged off-screen. Captures the wrap's `w`/`h` at `pointerdown` and clamps `left`/`top` via a new pure, exported `clampAxis(pos, len, viewport)` helper (next to `nearestCorner`). Corner snapping is unaffected — the badge's center can still reach any quadrant while fully visible. The helper pins to the near edge when the badge is larger than the viewport.
- **Snap on `lostpointercapture`** as a safety net, so a missed `pointerup`/`pointercancel` outside the window can't skip the snap-and-reset. `endDrag` is idempotent, so a later `pointerup` is a harmless no-op.
- **Unit tests** for `clampAxis`: in-range unchanged, clamps negative to `0`, clamps past the far edge to `viewport - len`, and pins to `0` when `len > viewport`.

## How I tested

- `npm run lint`, `npm run typecheck`, `npm test` (81 passed, +4 new), `npm run build` — all green.
- Manual (rebuild + reload extension + reload a job page with the badge): dragging the badge hard past each edge keeps it fully visible against the edge and snaps to the nearest corner on release; releasing the mouse **outside** the browser window now snaps it back instead of vanishing; plain header clicks, × dismiss, Escape, and arrow-key corner moves all unchanged.

Closes the drag-off-screen bug reported for the draggable badge.

## Checklist

- [x] `npm run lint` passes
- [x] `npm run typecheck` passes
- [x] `npm test` passes
- [x] `npm run build` succeeds
- [x] Tests added/updated if behavior changed
- [x] No secrets, keys, or personal data committed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Constrained the draggable badge to remain within the visible screen.
  * Improved drag completion handling when pointer capture is lost.
  * Added coverage for badge positioning at viewport boundaries and oversized badges.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->