### PR TITLE
Show exact saved date on hover

### DIFF
--- a/src/popup/Popup.tsx
+++ b/src/popup/Popup.tsx
@@ -427,7 +427,12 @@ const copyTimer = useRef<number | null>(null);
                     <div className="jobpreview">
                       <div className="jobmeta">
                         <span>{j.text.length.toLocaleString()} chars</span>
-                        <span>saved {timeAgo(j.savedAt)}</span>
+                        <time
+                          dateTime={new Date(j.savedAt).toISOString()}
+                          title={new Date(j.savedAt).toLocaleString()}
+                        >
+                          saved {timeAgo(j.savedAt)}
+                        </time>
                         {j.url?.trim() ? (
                           <a
                             href={j.url}


### PR DESCRIPTION
## Summary

- render the saved-job timestamp as a semantic `<time>` element
- expose the exact localized save date on hover
- preserve the existing relative timestamp text

Closes #136

## Validation

- `npm run lint`
- `npm run typecheck`
- `npm test -- --run` (81 passed)
- `npm run build`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility Improvements**
  * Saved-job timestamps now use semantic time elements with precise date information and localized full timestamps available on hover.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->