### PR TITLE
feat: show extension version in options footer

### DIFF
--- a/src/options/Options.tsx
+++ b/src/options/Options.tsx
@@ -514,6 +514,9 @@ function OptionsView({
           On a job page, the popup substitutes the company/role/date placeholders.
         </div>
       </section>
+      <footer className="help" style={{ marginTop: 16, textAlign: 'center' }}>
+        Little AI Helper v{chrome.runtime.getManifest().version}
+      </footer>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- display the installed extension version at the bottom of the options page
- read the version directly from the runtime manifest
- keep the change limited to the options UI

Closes #117

## Validation
- `npm run lint`
- `npm run typecheck`
- `npm test` (81 passed)
- `npm run build`
