### PR TITLE
fix(options): restore label association for wrapped form controls

### DIFF
--- a/src/options/Field.test.tsx
+++ b/src/options/Field.test.tsx
@@ -1,0 +1,114 @@
+import { describe, expect, it } from 'vitest';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { Field } from './Field';
+
+// renderToStaticMarkup needs no DOM, so these stay in the default node env.
+// Assert on the rendered HTML rather than internals: what matters is that the
+// <label for> and the control's id actually agree in the output.
+const html = (node: React.ReactElement): string => renderToStaticMarkup(node);
+
+/** The `for` on the rendered <label>, or null when it has none. */
+function labelFor(markup: string): string | null {
+  return /<label[^>]*\bfor="([^"]*)"/.exec(markup)?.[1] ?? null;
+}
+
+/** The id of the first element carrying one, or null. */
+function firstId(markup: string): string | null {
+  return /\bid="([^"]*)"/.exec(markup)?.[1] ?? null;
+}
+
+/** True when the label points at a control that exists with that exact id. */
+function isAssociated(markup: string): boolean {
+  const target = labelFor(markup);
+  if (target === null) return false;
+  return new RegExp(`<(?:input|select|textarea)[^>]*\\bid="${target}"`).test(markup);
+}
+
+describe('Field — label/control association', () => {
+  it('associates a bare input child', () => {
+    const markup = html(
+      <Field label="Email">
+        <input value="" readOnly />
+      </Field>,
+    );
+    expect(isAssociated(markup)).toBe(true);
+    expect(labelFor(markup)).toBe(firstId(markup));
+  });
+
+  it('associates an input wrapped in a layout div beside a button', () => {
+    // Regression guard: the secret-field Show/Hide toggles wrap the input in a
+    // flex row. A top-node-only check sees a <div>, drops the htmlFor, and the
+    // field silently loses its label — clicking it no longer focuses the input.
+    const markup = html(
+      <Field label="Gemini API key">
+        <div style={{ display: 'flex', gap: 8 }}>
+          <input type="password" value="" readOnly />
+          <button type="button" aria-label="Show API key">
+            Show
+          </button>
+        </div>
+        <div className="help">Get a free key…</div>
+      </Field>,
+    );
+    expect(isAssociated(markup)).toBe(true);
+  });
+
+  it('associates select and textarea too', () => {
+    const select = html(
+      <Field label="Provider">
+        <select value="gemini" onChange={() => {}}>
+          <option value="gemini">Gemini</option>
+        </select>
+      </Field>,
+    );
+    expect(isAssociated(select)).toBe(true);
+
+    const textarea = html(
+      <Field label="Template">
+        <textarea value="" readOnly />
+      </Field>,
+    );
+    expect(isAssociated(textarea)).toBe(true);
+  });
+
+  it('targets the first control when the wrapper holds several', () => {
+    const markup = html(
+      <Field label="Range">
+        <div>
+          <input name="from" value="" readOnly />
+          <input name="to" value="" readOnly />
+        </div>
+      </Field>,
+    );
+    const target = labelFor(markup);
+    expect(new RegExp(`<input[^>]*name="from"[^>]*id="${target}"`).test(markup)).toBe(true);
+  });
+
+  it('leaves the label unassociated when there is no form control', () => {
+    // The Account field is a div of status text + buttons; forcing an htmlFor
+    // at nothing would be worse than omitting it.
+    const markup = html(
+      <Field label="Account">
+        <div>
+          <span>Signed in</span>
+          <button type="button">Sign out</button>
+        </div>
+      </Field>,
+    );
+    expect(labelFor(markup)).toBeNull();
+    expect(markup).toContain('Sign out');
+  });
+
+  it('keeps the trailing help siblings in the output', () => {
+    const markup = html(
+      <Field label="Admin token">
+        <div>
+          <input value="" readOnly />
+        </div>
+        <div className="help">Leave blank for normal use.</div>
+      </Field>,
+    );
+    expect(isAssociated(markup)).toBe(true);
+    expect(markup).toContain('Leave blank for normal use.');
+  });
+});

--- a/src/options/Field.tsx
+++ b/src/options/Field.tsx
@@ -1,0 +1,60 @@
+// Labelled form row for the options page. Kept in its own module so it can be
+// unit-tested without pulling in the rest of Options.tsx (which imports the PDF
+// text extractor and therefore needs browser globals).
+
+import { Children, cloneElement, isValidElement, useId } from 'react';
+
+const LABELABLE_TAGS = new Set(['input', 'select', 'textarea']);
+
+/**
+ * Returns `node` with `id` set on the first labelable element in its tree, or
+ * null when it contains none. Searching the whole tree (not just the top node)
+ * means wrapping a control — e.g. putting an input in a flex row next to a
+ * Show/Hide button — keeps it associated with its <label> instead of silently
+ * dropping the htmlFor.
+ */
+function withControlId(node: React.ReactNode, id: string): React.ReactElement | null {
+  if (!isValidElement(node)) return null;
+  const el = node as React.ReactElement<{ children?: React.ReactNode; id?: string }>;
+
+  if (typeof el.type === 'string' && LABELABLE_TAGS.has(el.type)) {
+    return cloneElement(el, { id });
+  }
+
+  const kids = Children.toArray(el.props.children);
+  for (let i = 0; i < kids.length; i++) {
+    const replaced = withControlId(kids[i], id);
+    if (replaced === null) continue;
+    const next = [...kids];
+    next[i] = replaced;
+    return cloneElement(el, undefined, ...next);
+  }
+  return null;
+}
+
+export function Field({ label, children }: { label: string; children: React.ReactNode }) {
+  const id = useId();
+  const childArray = Children.toArray(children);
+  const [first, ...rest] = childArray;
+
+  const associated = withControlId(first, id);
+
+  if (associated === null) {
+    // No form control in here (e.g. a div of buttons like the Account field) —
+    // keep the plain label rather than force an incorrect htmlFor.
+    return (
+      <div className="field">
+        <label>{label}</label>
+        {children}
+      </div>
+    );
+  }
+
+  return (
+    <div className="field">
+      <label htmlFor={id}>{label}</label>
+      {associated}
+      {rest}
+    </div>
+  );
+}

--- a/src/options/Options.tsx
+++ b/src/options/Options.tsx
@@ -1,4 +1,5 @@
-import { Children, cloneElement, isValidElement, useEffect, useId, useState } from 'react';
+import { useEffect, useState } from 'react';
+import { Field } from './Field';
 import type { EducationEntry, Profile, WorkEntry } from '../lib/profile';
 import { useProfile } from '../ui/useProfile';
 import { extractText } from '../lib/documents';
@@ -536,38 +537,6 @@ function OptionsView({
           On a job page, the popup substitutes the company/role/date placeholders.
         </div>
       </section>
-    </div>
-  );
-}
-
-const LABELABLE_TAGS = new Set(['input', 'select', 'textarea']);
-
-function Field({ label, children }: { label: string; children: React.ReactNode }) {
-  const id = useId();
-  const childArray = Children.toArray(children);
-  const [first, ...rest] = childArray;
-
-  const canAssociate =
-    isValidElement(first) &&
-    typeof first.type === 'string' &&
-    LABELABLE_TAGS.has(first.type);
-
-  if (!canAssociate) {
-    // Not a single form control (e.g. a div of buttons like the Account
-    // field) — keep the plain label rather than force an incorrect htmlFor.
-    return (
-      <div className="field">
-        <label>{label}</label>
-        {children}
-      </div>
-    );
-  }
-
-  return (
-    <div className="field">
-      <label htmlFor={id}>{label}</label>
-      {cloneElement(first as React.ReactElement<{ id?: string }>, { id })}
-      {rest}
     </div>
   );
 }


### PR DESCRIPTION
## What & why

Follow-up to #138. That PR wrapped the two secret inputs in a flex `<div>` so the Show/Hide button could sit beside them — but that silently broke their label association.

`Field` only injected its generated id when the **first child was itself labelable**:

```js
const LABELABLE_TAGS = new Set(['input', 'select', 'textarea']);
const canAssociate = isValidElement(first) && typeof first.type === 'string'
  && LABELABLE_TAGS.has(first.type);
```

With the new wrapper, `first.type` is `'div'`, so `canAssociate` is false and the component falls into its unassociated branch: the `<label>` renders with no `htmlFor` and the input never receives an `id`.

Effect on `main` today, for both **Gemini API key** and **Admin token**:
- clicking the label no longer focuses the input;
- neither input has an `aria-label` of its own (#138 put those on the *buttons*), so assistive tech sees an unlabelled password field.

Nothing failed CI, because there was no test covering the association.

## Changes

- **`Field` now searches the child tree** for the first labelable element and sets the id there, so wrapping a control for layout can't drop the label. The genuine "no form control at all" case — the Account row of status text + buttons — still renders a plain `<label>` rather than pointing `htmlFor` at nothing.
- **Moved `Field` into `src/options/Field.tsx`.** Importing it from `Options.tsx` transitively pulls in the PDF text extractor (`pdfjs-dist`), which needs browser globals the node test environment doesn't provide — so the component wasn't testable in place.
- **Added `src/options/Field.test.tsx`** (6 tests) asserting the rendered `<label for>` matches a real control's `id`, via `renderToStaticMarkup` (no DOM needed, so the node env stays as-is). Covers: bare input, **input wrapped in a flex row next to a button** (the regression), select, textarea, first-of-several controls, and the no-control case.

## Verification

- `npm run lint`, `npm run typecheck`, `npm test` (**87 passed**, up from 81), `npm run build` — all green.
- **Confirmed the new tests actually catch the bug:** re-running them against the previous top-node-only logic fails 3 of 6, including the wrapped-input case. They aren't vacuous.
- Confirmed the fixed output directly — for the exact `#138` markup, the rendered `<label for>` and the `<input id>` are now the same value (`:R0:`), where before the label had no `for` at all.

## Checklist

- [x] `npm run lint` passes
- [x] `npm run typecheck` passes
- [x] `npm test` passes
- [x] `npm run build` succeeds
- [x] Tests added/updated if behavior changed
- [x] No secrets, keys, or personal data committed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added consistent label association for input, select, and textarea controls in options forms.
  * Labels now correctly target controls nested within layout containers.
  * Controls without an associated form element remain unlinked, preserving button-group behavior.
  * Additional help content and sibling elements continue to display correctly.

* **Tests**
  * Added coverage for label associations, nested controls, multiple controls, and unsupported content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->