### PR TITLE
test(ai): fail CI when the model list and proxy allowlist drift

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -27,8 +27,10 @@ const LOCATION = process.env.VERTEX_LOCATION || 'us-central1';
 // gemini-2.5-flash is broadly available; older 1.5/2.0 IDs 404 on newer projects.
 const MODEL = process.env.VERTEX_MODEL || 'gemini-2.5-flash';
 // Models a client is allowed to request via the request body. Keep in sync with
-// the curated list in src/lib/ai/models.ts. Anything outside this set falls back
-// to MODEL, so a client can't bill the project against an arbitrary/expensive id.
+// the curated list in src/lib/ai/models.ts — src/lib/ai/modelAllowlist.test.ts
+// reads this declaration and fails CI if the two drift. Anything outside this set
+// falls back to MODEL, so a client can't bill the project against an
+// arbitrary/expensive id.
 const MODEL_ALLOWLIST = new Set([
   'gemini-2.5-pro',
   'gemini-2.5-flash',

--- a/src/lib/ai/modelAllowlist.test.ts
+++ b/src/lib/ai/modelAllowlist.test.ts
@@ -1,0 +1,67 @@
+// Cross-package contract test: the curated model list lives in this package
+// (GEMINI_MODELS) and is mirrored by MODEL_ALLOWLIST in server/index.js. They
+// can't share a module — Cloud Run deploys with `gcloud run deploy --source
+// server`, so only the server/ folder is uploaded and a shared file outside it
+// would not ship. This test is the guard instead: if the two drift, the proxy
+// would reject a model the Options dropdown offers, and CI fails here first.
+
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+import { DEFAULT_MODEL, GEMINI_MODELS } from './models';
+
+const SERVER_SOURCE = readFileSync(
+  fileURLToPath(new URL('../../../server/index.js', import.meta.url)),
+  'utf8',
+);
+
+/**
+ * Ids inside `const MODEL_ALLOWLIST = new Set([...])`. Throws rather than
+ * returning empty if the declaration moves, so a silent pass is impossible.
+ */
+function serverAllowlist(): string[] {
+  const block = /const MODEL_ALLOWLIST = new Set\(\[([\s\S]*?)\]\)/.exec(SERVER_SOURCE);
+  if (!block) {
+    throw new Error(
+      'Could not find `const MODEL_ALLOWLIST = new Set([...])` in server/index.js — ' +
+        'update this test if the declaration was renamed or restructured.',
+    );
+  }
+  return [...block[1].matchAll(/'([^']+)'/g)].map((m) => m[1]);
+}
+
+/** The hardcoded fallback in `const MODEL = process.env.VERTEX_MODEL || '...'`. */
+function serverDefaultModel(): string {
+  const match = /const MODEL = process\.env\.VERTEX_MODEL \|\| '([^']+)'/.exec(SERVER_SOURCE);
+  if (!match) {
+    throw new Error(
+      'Could not find the VERTEX_MODEL fallback in server/index.js — ' +
+        'update this test if that declaration changed.',
+    );
+  }
+  return match[1];
+}
+
+describe('model list stays in sync with the proxy', () => {
+  it('server allowlist matches the curated client list exactly', () => {
+    // Sorted so ordering differences between the two files are not failures.
+    expect(serverAllowlist().sort()).toEqual(GEMINI_MODELS.map((m) => m.id).sort());
+  });
+
+  it("server's default model is one the client also offers", () => {
+    // A fallback outside the curated list would be unreachable from the UI.
+    expect(GEMINI_MODELS.map((m) => m.id)).toContain(serverDefaultModel());
+  });
+
+  it("server's default model is the client default", () => {
+    // Otherwise an unset `model` in the request body silently uses a different
+    // model than the dropdown shows as selected.
+    expect(serverDefaultModel()).toBe(DEFAULT_MODEL);
+  });
+
+  it('parses a non-empty allowlist', () => {
+    // Guards the regexes themselves: a parse that quietly yields [] would make
+    // the comparison above pass only when the client list is empty too.
+    expect(serverAllowlist().length).toBeGreaterThan(0);
+  });
+});

--- a/src/lib/ai/models.ts
+++ b/src/lib/ai/models.ts
@@ -2,7 +2,8 @@
 // truth for the dropdown and for default/normalization logic. All three ids exist
 // on both AI Studio (BYO key, src/lib/ai/gemini.ts) and Vertex AI (the managed
 // proxy, server/index.js). When this list changes, mirror it in the server's
-// MODEL_ALLOWLIST so the proxy accepts the new ids.
+// MODEL_ALLOWLIST so the proxy accepts the new ids — modelAllowlist.test.ts
+// fails if the two drift.
 
 export interface ModelOption {
   id: string;


### PR DESCRIPTION
## What & why

Closes #30.

`GEMINI_MODELS` (`src/lib/ai/models.ts`) and `MODEL_ALLOWLIST` (`server/index.js`) are maintained by hand. If they drift, the proxy rejects a model the Options dropdown offers — and nothing catches it until a user picks that model and generation fails.

## Which approach, and why

The issue offered two options. **Extracting a shared file isn't viable here:** the proxy deploys with `gcloud run deploy --source server` (see `server/README.md`), so only the `server/` folder is uploaded — a shared module at the repo root simply would not ship, and the proxy would crash on import at runtime. Moving the canonical list *into* `server/` would invert the dependency and make the extension build reach into the deploy artifact.

So this takes the **drift check** option: it runs in the existing `Lint · typecheck · test · build` job, adds no runtime coupling, and touches nothing that gets deployed.

## Changes

New `src/lib/ai/modelAllowlist.test.ts`, which reads `server/index.js` as text and asserts:

1. the server allowlist matches the curated client ids **exactly** (sorted, so ordering isn't a failure);
2. the `VERTEX_MODEL` fallback is a model the client actually offers;
3. that fallback **equals `DEFAULT_MODEL`** — otherwise a request that omits `model` silently runs on a different model than the dropdown shows as selected;
4. the parse yields a non-empty list — guarding the regexes themselves, since a parse that quietly returned `[]` would make check 1 pass only when the client list is also empty.

Both extractors **throw with a pointed message** if their declaration moves or is renamed, so the check can't degrade into a silent pass.

Also refreshed the two stale "keep in sync by hand" comments to point at the guard that now enforces it.

## Verification

- `npm run lint`, `npm run typecheck`, `npm test` (**85 passed**), `npm run build`, and `node --check server/index.js` — all green.
- **Confirmed it catches all three drift directions**, each failing exactly the right assertion:
  - id added to the server allowlist only → *"server allowlist matches the curated client list exactly"* fails
  - id added to `GEMINI_MODELS` only → same test fails
  - server's `VERTEX_MODEL` fallback changed to another model → *"server's default model is the client default"* fails

## Checklist

- [x] `npm run lint` passes
- [x] `npm run typecheck` passes
- [x] `npm test` passes
- [x] `npm run build` succeeds
- [x] Tests added/updated if behavior changed
- [x] No secrets, keys, or personal data committed