### PR TITLE
fix(popup): label generated document fields

### DIFF
--- a/src/popup/Popup.tsx
+++ b/src/popup/Popup.tsx
@@ -492,6 +492,7 @@ const copyTimer = useRef<number | null>(null);
   <>
     <textarea
       style={{ marginTop: 8 }}
+      aria-label="Generated cover letter"
       value={letter}
       onChange={(e) => setLetter(e.target.value)}
     />
@@ -527,6 +528,7 @@ const copyTimer = useRef<number | null>(null);
   <>
     <textarea
       style={{ marginTop: 8 }}
+      aria-label="Generated tailored resume"
       value={resume}
       onChange={(e) => setResume(e.target.value)}
     />


### PR DESCRIPTION
## What & why

Adds accessible names to the two editable generated-document textareas in the popup. Screen-reader users can now distinguish the generated cover letter from the generated tailored resume while reviewing or editing them.

Closes #146.

## Changes

- label the cover-letter textarea as `Generated cover letter`
- label the resume textarea as `Generated tailored resume`
- keep the fix scoped to attributes only; no UI layout or behavior changes

## Validation

- `npm run lint`
- `npm run typecheck`
- `npm test` (81 tests passed)
- `npm run build`

## Checklist

- [x] The change is focused and matches the existing accessibility-label style
- [x] Lint, typecheck, tests, and production build pass
- [x] No dependencies or generated files changed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility Improvements**
  * Added clear labels to generated cover letter and tailored resume editing fields, improving support for assistive technologies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->