### PR TITLE
feat(popup): tell the user when the oldest saved job is evicted

### DIFF
--- a/src/lib/savedJobs.test.ts
+++ b/src/lib/savedJobs.test.ts
@@ -5,6 +5,7 @@ import {
   getActiveJob,
   getSavedJobs,
   isJobTextTruncated,
+  MAX_JOBS,
   MAX_TEXT,
   setActiveJob,
   type SavedJob,
@@ -12,8 +13,6 @@ import {
 } from './savedJobs';
 
 const STORAGE_KEY = 'savedJobs';
-// Mirrors the module-private MAX_JOBS cap in savedJobs.ts.
-const MAX_JOBS = 20;
 
 // Minimal in-memory chrome.storage.local: enough for get/set with one key.
 // Shared by every suite below so each starts from empty storage.
@@ -147,6 +146,22 @@ describe('addJob — MAX_JOBS eviction cap', () => {
 
     expect(jobs).toHaveLength(2);
     expect(jobs.some((j) => j.id === 'a')).toBe(true);
+  });
+
+  it('reports the dropped job so the UI can say so', async () => {
+    const existing = Array.from({ length: MAX_JOBS }, (_, i) => job({ id: `old-${i}` }));
+    seed({ jobs: existing, activeId: 'old-0' });
+
+    const { evicted } = await addJob(partial('newest'));
+
+    // Without this the 21st save silently loses the oldest posting (#85).
+    expect(evicted.map((j) => j.id)).toEqual([`old-${MAX_JOBS - 1}`]);
+  });
+
+  it('reports nothing evicted while under the cap', async () => {
+    seed({ jobs: [job({ id: 'a' })], activeId: 'a' });
+
+    expect((await addJob(partial('newest'))).evicted).toEqual([]);
   });
 });
 

--- a/src/lib/savedJobs.ts
+++ b/src/lib/savedJobs.ts
@@ -5,7 +5,8 @@
 // + resume so they don't quietly lose the role.
 
 const STORAGE_KEY = 'savedJobs';
-const MAX_JOBS = 20;
+/** The saved-jobs list is capped here; adding past it drops the oldest. */
+export const MAX_JOBS = 20;
 /** Captured posting text is capped at this many characters before storage. */
 export const MAX_TEXT = 12_000;
 
@@ -54,10 +55,18 @@ export async function getActiveJob(): Promise<SavedJob | null> {
   return jobs.find((j) => j.id === activeId) ?? null;
 }
 
+export interface AddJobResult extends SavedJobsState {
+  /**
+   * Jobs pushed off the end by the MAX_JOBS cap. Reported so the UI can say the
+   * oldest save was dropped instead of letting it vanish silently.
+   */
+  evicted: SavedJob[];
+}
+
 /** Adds a captured job (newest first), makes it active, and returns the new state. */
 export async function addJob(
   partial: Omit<SavedJob, 'id' | 'savedAt'>,
-): Promise<SavedJobsState> {
+): Promise<AddJobResult> {
   const state = await getSavedJobs();
   if (isJobTextTruncated(partial.text)) {
     console.warn(
@@ -70,12 +79,15 @@ export async function addJob(
     id: crypto.randomUUID(),
     savedAt: Date.now(),
   };
+  const all = [job, ...state.jobs];
   const next: SavedJobsState = {
-    jobs: [job, ...state.jobs].slice(0, MAX_JOBS),
+    jobs: all.slice(0, MAX_JOBS),
     activeId: job.id,
   };
   await setSavedJobs(next);
-  return next;
+  // Computed here rather than by comparing counts in the caller, whose copy of
+  // the list can lag behind storage.
+  return { ...next, evicted: all.slice(MAX_JOBS) };
 }
 
 export async function setActiveJob(id: string | null): Promise<void> {

--- a/src/popup/Popup.tsx
+++ b/src/popup/Popup.tsx
@@ -7,6 +7,7 @@ import {
   deleteJob,
   onSavedJobsChanged,
   isJobTextTruncated,
+  MAX_JOBS,
   MAX_TEXT,
   type SavedJob,
 } from '../lib/savedJobs';
@@ -20,6 +21,30 @@ import { signIn, reconcileAuthUser, onAuthChanged, type AuthUser } from '../lib/
  * company/role produces a weak, generic result. */
 export function canGenerateDocuments(company: string, role: string): boolean {
   return company.trim() !== '' && role.trim() !== '';
+}
+
+/**
+ * Status line shown after saving a job. Both caps can bite on the same save, so
+ * the notices are composed rather than chosen — silently dropping either one is
+ * how a trimmed posting or an evicted job goes unnoticed.
+ */
+export function saveJobNotice({
+  truncated,
+  evicted,
+}: {
+  truncated: boolean;
+  evicted: boolean;
+}): string {
+  const notices: string[] = [];
+  if (truncated) {
+    notices.push(
+      `the posting was long, so it was trimmed to ${MAX_TEXT.toLocaleString()} characters for AI context`,
+    );
+  }
+  if (evicted) {
+    notices.push(`your oldest saved job was dropped to stay under ${MAX_JOBS}`);
+  }
+  return notices.length === 0 ? 'Job saved.' : `Saved — ${notices.join('; ')}.`;
 }
 
 /** Compact "saved N ago" label for a saved job's timestamp. */
@@ -266,16 +291,17 @@ const copyTimer = useRef<number | null>(null);
         setError('No job posting detected on this page to save.');
         return;
       }
-      await addJob({
+      const { evicted } = await addJob({
         company: cap.company,
         role: cap.role || cap.title,
         url: cap.url,
         text: cap.text,
       });
       flashFillMsg(
-        isJobTextTruncated(cap.text)
-          ? `Saved — the posting was long, so it was trimmed to ${MAX_TEXT.toLocaleString()} characters for AI context.`
-          : 'Job saved.',
+        saveJobNotice({
+          truncated: isJobTextTruncated(cap.text),
+          evicted: evicted.length > 0,
+        }),
       );
     } catch {
       setError('Could not read this page. Reload it and try again.');

--- a/src/popup/saveJobNotice.test.ts
+++ b/src/popup/saveJobNotice.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest';
+import { saveJobNotice } from './Popup';
+import { MAX_JOBS, MAX_TEXT } from '../lib/savedJobs';
+
+describe('saveJobNotice', () => {
+  it('is a plain confirmation when neither cap was hit', () => {
+    expect(saveJobNotice({ truncated: false, evicted: false })).toBe('Job saved.');
+  });
+
+  it('reports a trimmed posting with the character cap', () => {
+    const msg = saveJobNotice({ truncated: true, evicted: false });
+    expect(msg).toContain(MAX_TEXT.toLocaleString());
+    expect(msg).toContain('trimmed');
+    expect(msg).not.toContain('oldest');
+  });
+
+  it('reports an evicted job with the list cap', () => {
+    const msg = saveJobNotice({ truncated: false, evicted: true });
+    expect(msg).toContain(String(MAX_JOBS));
+    expect(msg).toContain('oldest');
+    expect(msg).not.toContain('trimmed');
+  });
+
+  it('reports both when one save trips each cap', () => {
+    // A long posting saved at capacity hits both; reporting only one would hide
+    // the other, which is the silent data loss #85 is about.
+    const msg = saveJobNotice({ truncated: true, evicted: true });
+    expect(msg).toContain('trimmed');
+    expect(msg).toContain('oldest');
+    expect(msg.endsWith('.')).toBe(true);
+  });
+});


### PR DESCRIPTION
## What & why

Closes #85. Replaces #144, which GitHub auto-closed when its base branch (`test/savedjobs-coverage`, from #143) was deleted on merge. Same change, rebased onto `main` as a single commit.

Once 20 jobs are saved, `addJob`'s `slice(0, MAX_JOBS)` silently drops the oldest on every further save — no toast, nothing in the panel. A user at capacity can lose a captured posting, and the AI context that came with it, without ever being told.

## Changes

- **`savedJobs.ts`** — export `MAX_JOBS` (so the UI doesn't hardcode `20` twice, as the issue asked), and have `addJob` return the jobs it pushed off the end as `evicted: SavedJob[]`. Computing it at the source is more reliable than comparing list lengths in the caller, whose React copy of the list can lag behind storage.
- **`saveJobNotice()`** in `Popup.tsx` — **composes** the trim and eviction notices rather than choosing between them. A long posting saved at capacity trips *both* caps, and the previous ternary could only ever report the trim — hiding exactly the kind of silent loss this issue is about.
- **`Popup.tsx`** — passes the evicted flag into the existing `flashFillMsg` banner. No new UI surface.
- Drops the local `MAX_JOBS = 20` mirror #143 added to the test file, now that the real constant is exported.

The four messages it produces:

```
Job saved.
Saved — the posting was long, so it was trimmed to 12,000 characters for AI context.
Saved — your oldest saved job was dropped to stay under 20.
Saved — the posting was long, so it was trimmed to 12,000 characters for AI context; your oldest saved job was dropped to stay under 20.
```

## Verification

- `npm run lint`, `npm run typecheck`, `npm test` (**113 passed**), `npm run build` — all green on the rebased branch, which also picks up #147's `Popup.tsx` changes.
- New tests: `addJob` reports exactly the dropped job at capacity and an empty list under it; `saveJobNotice` covers all four combinations, including both-caps-at-once.
- Printed the rendered strings (above) to check the composed wording reads correctly.

## Checklist

- [x] `npm run lint` passes
- [x] `npm run typecheck` passes
- [x] `npm test` passes
- [x] `npm run build` succeeds
- [x] Tests added/updated if behavior changed
- [x] No secrets, keys, or personal data committed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Saving a job now indicates when the oldest saved job was removed after reaching the storage limit.
  * Save confirmations identify when posting text was shortened for processing, including the applicable limits.
* **Bug Fixes**
  * Improved save-status messaging when text shortening and saved-job limits occur together.
* **Tests**
  * Added coverage for job eviction and all save-notification scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->