### PR TITLE
fix(popup): say "within the 20-job limit", not "under 20"

### DIFF
--- a/src/popup/Popup.tsx
+++ b/src/popup/Popup.tsx
@@ -42,7 +42,9 @@ export function saveJobNotice({
     );
   }
   if (evicted) {
-    notices.push(`your oldest saved job was dropped to stay under ${MAX_JOBS}`);
+    // "within the N-job limit", not "under N": after eviction the list holds
+    // exactly MAX_JOBS, so "under" would be off by one.
+    notices.push(`your oldest saved job was dropped to stay within the ${MAX_JOBS}-job limit`);
   }
   return notices.length === 0 ? 'Job saved.' : `Saved — ${notices.join('; ')}.`;
 }


### PR DESCRIPTION
## What & why

Follow-up to #148. CodeRabbit flagged this on that PR and I committed the fix, but **the commit never reached the remote** — the branch was tracking `origin/main` (created via `git checkout -B <branch> origin/main`), so a bare `git push` targeted main and was rejected. #148 merged with the original wording.

The message was off by one: after eviction `addJob` keeps *exactly* `MAX_JOBS` entries, so "to stay under 20" is inaccurate.

```diff
-your oldest saved job was dropped to stay under 20
+your oldest saved job was dropped to stay within the 20-job limit
```

Comment added so the distinction doesn't get "simplified" back later.

## Verification

- `npm run lint`, `npm run typecheck`, `npm test` (113 passed), `npm run build` — green.
- Rendered strings:

```
Saved — your oldest saved job was dropped to stay within the 20-job limit.
Saved — the posting was long, so it was trimmed to 12,000 characters for AI context; your oldest saved job was dropped to stay within the 20-job limit.
```

The existing `saveJobNotice` tests assert on `MAX_JOBS` and `'oldest'` rather than the full sentence, so they cover this wording without change.

## Checklist

- [x] `npm run lint` passes
- [x] `npm run typecheck` passes
- [x] `npm test` passes
- [x] `npm run build` succeeds
- [x] No secrets, keys, or personal data committed