### PR TITLE
feat: use larger units for old saved jobs

### DIFF
--- a/src/popup/Popup.tsx
+++ b/src/popup/Popup.tsx
@@ -58,7 +58,13 @@ export function timeAgo(ts: number): string {
   const hrs = Math.round(mins / 60);
   if (hrs < 24) return `${hrs} hr ago`;
   const days = Math.round(hrs / 24);
-  return `${days} day${days === 1 ? '' : 's'} ago`;
+  if (days < 7) return `${days} day${days === 1 ? '' : 's'} ago`;
+  const weeks = Math.round(days / 7);
+  if (weeks < 5) return `${weeks} wk ago`;
+  const months = Math.round(days / 30);
+  if (months < 12) return `${months} mo ago`;
+  const years = Math.round(days / 365);
+  return `${years} yr ago`;
 }
 
 export function Popup() {

--- a/src/popup/timeAgo.test.ts
+++ b/src/popup/timeAgo.test.ts
@@ -34,10 +34,29 @@ describe('timeAgo', () => {
     expect(timeAgo(secondsAgo(5 * 60 * 60))).toBe('5 hr ago');
   });
 
-  it('reports days, singular vs plural', () => {
+  it('reports days, singular vs plural before the week boundary', () => {
     at(NOW);
     expect(timeAgo(secondsAgo(24 * 60 * 60))).toBe('1 day ago');
     expect(timeAgo(secondsAgo(3 * 24 * 60 * 60))).toBe('3 days ago');
+    expect(timeAgo(secondsAgo(6 * 24 * 60 * 60))).toBe('6 days ago');
+  });
+
+  it('reports weeks at and after seven days', () => {
+    at(NOW);
+    expect(timeAgo(secondsAgo(7 * 24 * 60 * 60))).toBe('1 wk ago');
+    expect(timeAgo(secondsAgo(4 * 7 * 24 * 60 * 60))).toBe('4 wk ago');
+  });
+
+  it('reports months at and after five weeks', () => {
+    at(NOW);
+    expect(timeAgo(secondsAgo(5 * 7 * 24 * 60 * 60))).toBe('1 mo ago');
+    expect(timeAgo(secondsAgo(11 * 30 * 24 * 60 * 60))).toBe('11 mo ago');
+  });
+
+  it('reports years at and after twelve months', () => {
+    at(NOW);
+    expect(timeAgo(secondsAgo(12 * 30 * 24 * 60 * 60))).toBe('1 yr ago');
+    expect(timeAgo(secondsAgo(2 * 365 * 24 * 60 * 60))).toBe('2 yr ago');
   });
 
   it('clamps a future timestamp to "just now" instead of a negative age', () => {


### PR DESCRIPTION
## Summary
- extend `timeAgo` with week, month, and year units
- keep the existing rounded elapsed-time behavior
- add tests for day/week/month/year boundaries

Closes #141

## Unit choices
- Days are shown below 7 days.
- Weeks are shown below 5 weeks.
- Months are shown below 12 months.
- Years are used for older saved jobs.

## Validation
- `npm test -- src/popup/timeAgo.test.ts` (9 passed)
- `npm run lint`
- `npm run typecheck`
- `npm test` (116 passed)
- `npm run build`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved relative time labels for older timestamps, including weeks, months, and years.
  * Added correct singular and plural formatting across time ranges.

* **Tests**
  * Expanded coverage for larger time units, boundary values, and pluralization.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->