### PR TITLE
chore(deps): bump github/codeql-action init+analyze to v4.37.3 together

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -21,13 +21,13 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@7188fc363630916deb702c7fdcf4e481b751f97a # v4
+        uses: github/codeql-action/init@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4
         with:
           languages: javascript-typescript
           queries: security-and-quality
 
       # JS/TS is interpreted — no build step needed before analysis.
       - name: Perform CodeQL analysis
-        uses: github/codeql-action/analyze@7188fc363630916deb702c7fdcf4e481b751f97a # v4
+        uses: github/codeql-action/analyze@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4
         with:
           category: '/language:javascript-typescript'


### PR DESCRIPTION
## What & why

Dependabot split this bump into two PRs that each fail on their own:
- #126 — bumps `github/codeql-action/init` alone
- #124 — bumps `github/codeql-action/analyze` alone

The `init` and `analyze` steps' pinned SHAs must match (same class of problem as the earlier #100/#101), so neither PR can go green in isolation. Combining both bumps here, verified against the actual Dependabot diffs (both point at the same target SHA `e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81` / v4.37.3):

```diff
-        uses: github/codeql-action/init@7188fc363630916deb702c7fdcf4e481b751f97a # v4
+        uses: github/codeql-action/init@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4
...
-        uses: github/codeql-action/analyze@7188fc363630916deb702c7fdcf4e481b751f97a # v4
+        uses: github/codeql-action/analyze@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4
```

Closes #124, closes #126 (superseding both).

## Checklist

- [x] CI (Lint/typecheck/test/build, Server syntax check) unaffected — workflow-only change
- [x] No secrets, keys, or personal data committed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated security analysis workflow actions to specific approved versions, improving build and security workflow reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->