### PR TITLE
fix: use raw durations for timeAgo buckets

### DIFF
--- a/src/popup/Popup.tsx
+++ b/src/popup/Popup.tsx
@@ -58,12 +58,13 @@ export function timeAgo(ts: number): string {
   const hrs = Math.round(mins / 60);
   if (hrs < 24) return `${hrs} hr ago`;
   const days = Math.round(hrs / 24);
-  if (days < 7) return `${days} day${days === 1 ? '' : 's'} ago`;
-  const weeks = Math.round(days / 7);
-  if (weeks < 5) return `${weeks} wk ago`;
-  const months = Math.round(days / 30);
-  if (months < 12) return `${months} mo ago`;
-  const years = Math.round(days / 365);
+  const daysElapsed = secs / (24 * 60 * 60);
+  if (daysElapsed < 7) return `${days} day${days === 1 ? '' : 's'} ago`;
+  const weeks = Math.round(daysElapsed / 7);
+  if (daysElapsed < 35) return `${weeks} wk ago`;
+  const months = Math.round(daysElapsed / 30);
+  if (daysElapsed < 360) return `${months} mo ago`;
+  const years = Math.round(daysElapsed / 365);
   return `${years} yr ago`;
 }
 

--- a/src/popup/timeAgo.test.ts
+++ b/src/popup/timeAgo.test.ts
@@ -44,6 +44,7 @@ describe('timeAgo', () => {
   it('reports weeks at and after seven days', () => {
     at(NOW);
     expect(timeAgo(secondsAgo(7 * 24 * 60 * 60))).toBe('1 wk ago');
+    expect(timeAgo(secondsAgo(32 * 24 * 60 * 60))).toBe('5 wk ago');
     expect(timeAgo(secondsAgo(4 * 7 * 24 * 60 * 60))).toBe('4 wk ago');
   });
 
@@ -55,6 +56,7 @@ describe('timeAgo', () => {
 
   it('reports years at and after twelve months', () => {
     at(NOW);
+    expect(timeAgo(secondsAgo(345 * 24 * 60 * 60))).toBe('12 mo ago');
     expect(timeAgo(secondsAgo(12 * 30 * 24 * 60 * 60))).toBe('1 yr ago');
     expect(timeAgo(secondsAgo(2 * 365 * 24 * 60 * 60))).toBe('2 yr ago');
   });


### PR DESCRIPTION
## Summary
- use raw elapsed duration for week, month, and year bucket boundaries
- keep rounded values only for the displayed unit
- cover 32-day and 345-day edge cases from review feedback

Follow-up to #150.

## Validation
- `npm test -- src/popup/timeAgo.test.ts` (9 passed)
- `npm run lint`
- `npm run typecheck`
- `npm test` (116 passed)
- `npm run build`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved relative timestamp formatting for elapsed days, weeks, months, and years.
  * Updated boundary handling so timestamps such as 32 days and 345 days display more accurately.

* **Tests**
  * Added coverage for week and month conversion edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->