### PR TITLE
fix: disable spellcheck and autofill on secret fields

### DIFF
--- a/src/options/Options.tsx
+++ b/src/options/Options.tsx
@@ -211,6 +211,8 @@ function OptionsView({
             <div style={{ display: 'flex', gap: 8 }}>
               <input
                 type={showApiKey ? 'text' : 'password'}
+                autoComplete="off"
+                spellCheck={false}
                 value={p.ai.apiKey}
                 placeholder="Paste your AI Studio key"
                 onChange={(e) => setAI('apiKey', e.target.value)}
@@ -269,6 +271,8 @@ function OptionsView({
               <div style={{ display: 'flex', gap: 8 }}>
                 <input
                   type={showProxyToken ? 'text' : 'password'}
+                  autoComplete="off"
+                  spellCheck={false}
                   value={p.ai.proxyToken}
                   placeholder="Only the proxy owner needs this — bypasses sign-in & quota"
                   onChange={(e) => setAI('proxyToken', e.target.value)}


### PR DESCRIPTION
## Summary

This PR resolves #154 by adding  and  to the API key and admin token inputs.

## Changes

- Added  and  to API key input
- Added  and  to admin token input

## Why

When the secret fields are revealed as , browsers may:
1. Spellcheck the secret (sending it to Google if Enhanced spell check is on)
2. Offer to save/autofill the secret in password managers

These attributes reduce that exposure.

## Verification

- [x] API key input has autoComplete and spellCheck attributes
- [x] Admin token input has autoComplete and spellCheck attributes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Disabled browser autofill and spell-check for AI provider credential fields to reduce unintended suggestions and input changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->