### PR TITLE
fix(content): rebuild the badge when the posting changes, not just the verdict

### DIFF
--- a/src/content/analyze.test.ts
+++ b/src/content/analyze.test.ts
@@ -45,6 +45,16 @@ describe('badgeSignature — what forces a badge rebuild', () => {
       badgeSignature(same, acme, true, false),
     );
   });
+
+  it('does not collide when a delimiter character sits in scraped company/role text', () => {
+    // Regression guard: company/role come from unsanitized DOM text, so a plain
+    // join('|') let company "A|B" + role "C" collide with company "A" + role
+    // "B|C" — two different postings would be treated as the same one and the
+    // rebuild (with it, the generator forms) would be skipped.
+    expect(badgeSignature(same, { company: 'A|B', role: 'C' }, true, true)).not.toBe(
+      badgeSignature(same, { company: 'A', role: 'B|C' }, true, true),
+    );
+  });
 });
 
 describe('nearestCorner — badge drag snapping', () => {

--- a/src/content/analyze.test.ts
+++ b/src/content/analyze.test.ts
@@ -2,11 +2,50 @@ import { describe, it, expect } from 'vitest';
 import {
   addBadgeDismissListener,
   analyze,
+  badgeSignature,
   clampAxis,
   isBadgeDismissKey,
   nearestCorner,
   shouldDismissBadge,
 } from './sponsorship';
+
+describe('badgeSignature — what forces a badge rebuild', () => {
+  // Two postings that analyse identically. Very common: any two postings with no
+  // eligibility wording both come back "unknown/rules", so the analysis alone
+  // cannot distinguish them.
+  const same = analyze('We are seeking a new grad to join the team.');
+  const acme = { company: 'Acme Corp', role: 'Software Engineer' };
+
+  it('changes when the posting company/role changes', () => {
+    // The bug: the generator forms are seeded once at build time, so if the
+    // signature ignores company/role, switching jobs in a split view keeps the
+    // previous posting's values in the cover-letter form.
+    expect(badgeSignature(same, acme, true, true)).not.toBe(
+      badgeSignature(same, { company: 'Saroot Labs', role: 'Software Engineer' }, true, true),
+    );
+    expect(badgeSignature(same, acme, true, true)).not.toBe(
+      badgeSignature(same, { company: 'Acme Corp', role: 'Data Analyst' }, true, true),
+    );
+  });
+
+  it('is stable for the same posting and settings', () => {
+    // Guards the perf win: mutation-happy pages must not rebuild every debounce.
+    expect(badgeSignature(same, acme, true, true)).toBe(badgeSignature(same, acme, true, true));
+  });
+
+  it('still changes when the verdict or generator toggles change', () => {
+    const restricted = analyze('Must be a U.S. citizen. No visa sponsorship.');
+    expect(badgeSignature(same, acme, true, true)).not.toBe(
+      badgeSignature(restricted, acme, true, true),
+    );
+    expect(badgeSignature(same, acme, true, true)).not.toBe(
+      badgeSignature(same, acme, false, true),
+    );
+    expect(badgeSignature(same, acme, true, true)).not.toBe(
+      badgeSignature(same, acme, true, false),
+    );
+  });
+});
 
 describe('nearestCorner — badge drag snapping', () => {
   it('maps each viewport quadrant to its corner', () => {

--- a/src/content/sponsorship.ts
+++ b/src/content/sponsorship.ts
@@ -470,6 +470,10 @@ let mutationDirty = false;
 // Signature of the badge currently on screen, so identical re-computations keep
 // the mounted DOM instead of tearing it down. Cleared by removeBadge().
 let renderedSig = '';
+// Bumped every time the mounted badge is replaced. Lets an in-flight async
+// action (the AI check) notice a posting switch happened while it was awaiting
+// and discard its now-stale result instead of clobbering the new badge.
+let badgeGeneration = 0;
 // AI results cached per posting (by scanned-text hash) so revisiting a job — or
 // a re-render from the watcher — reuses the AI verdict without another call.
 const aiCache = new Map<number, SponsorAnalysis>();
@@ -667,13 +671,18 @@ export function badgeSignature(
   showCoverLetter: boolean,
   showResume: boolean,
 ): string {
-  return [
+  // JSON.stringify, not join('|'): scraped DOM text is unsanitized, so a
+  // company/role that happens to contain the delimiter (e.g. company "A|B" vs
+  // company "A" + role "B|...") would collide under a plain join. JSON encodes
+  // each field's own quotes/length, so distinct inputs can't produce the same
+  // string.
+  return JSON.stringify([
     a.verdict, a.source, a.reason ?? '',
-    a.restrictions.join(','), a.cautions.join(','), a.positives.join(','),
+    a.restrictions, a.cautions, a.positives,
     a.experience.required ?? '', a.experience.preferred ?? '',
     meta.company, meta.role,
     showCoverLetter, showResume,
-  ].join('|');
+  ]);
 }
 
 function renderFrom(text: string): void {
@@ -688,7 +697,14 @@ function renderFrom(text: string): void {
   // Read the meta once and reuse it for both the signature and the render, so a
   // mutation landing between two reads can't sign one posting while showing
   // another.
-  const meta = getJobMeta();
+  //
+  // Only when a generator is actually shown: getJobMeta()'s non-LinkedIn path
+  // falls back to a bare `h1` / ancestor-content read, and the content script
+  // runs on <all_urls>, so this DOM read must stay opt-in rather than firing on
+  // every render everywhere. With neither generator visible there's no form to
+  // seed, so a constant empty meta is both cheaper and exactly as correct.
+  const meta: JobMeta =
+    showCoverLetterInBadge || showResumeInBadge ? getJobMeta() : { company: '', role: '' };
   // Skip the teardown/rebuild when the badge already shows exactly this result —
   // mutation-happy pages (live counts, timestamps) otherwise cause a rebuild
   // every debounce even though nothing visible changed. The generator toggles
@@ -819,6 +835,7 @@ let removeBadgeKeydownListener: (() => void) | null = null;
 /** Removes every instance of the badge host (guards against duplicates). */
 function removeBadge(): void {
   renderedSig = ''; // whatever renders next is a fresh mount, never skipped
+  badgeGeneration++;
   removeBadgeKeydownListener?.();
   removeBadgeKeydownListener = null;
   document.querySelectorAll(`#${BANNER_ID}`).forEach((n) => n.remove());
@@ -1172,11 +1189,28 @@ function renderBadge(a: SponsorAnalysis, meta: JobMeta): HTMLElement {
     ai.addEventListener('click', async () => {
       ai.textContent = 'Analyzing…';
       ai.disabled = true;
+      // Snapshot what this click is FOR, before the await: on a split-view board
+      // the user can switch to a different posting while the request is in
+      // flight, and generation only changes when a badge is actually replaced —
+      // unlike re-hashing scan text, a harmless mutation (a "N people viewed
+      // this" counter) can't cause a false "stale" read here.
+      const startUrl = location.href;
+      const startGeneration = badgeGeneration;
       try {
         const analysis = await runAiCheck();
-        // Pin it to this posting so the watcher's re-renders don't revert to rules.
+        if (badgeGeneration !== startGeneration) {
+          // The badge was already replaced (a genuine posting switch, or the
+          // user dismissed/toggled it) — this result is for a posting that is
+          // no longer showing. Applying it now would silently overwrite the
+          // current, correct badge with stale analysis and meta.
+          return;
+        }
+        // Pin it to this posting so the watcher's re-renders don't revert to
+        // rules. Use the URL captured at click time, not a fresh read — if it
+        // did change without a generation bump, pinning against the new URL
+        // would attach this analysis to the wrong posting.
         pinnedAi = analysis;
-        pinnedAiUrl = location.href;
+        pinnedAiUrl = startUrl;
         removeBadge();
         // Same posting the badge was built for, so reuse its meta rather than
         // re-reading the DOM and risking a different posting's company/role.

--- a/src/content/sponsorship.ts
+++ b/src/content/sponsorship.ts
@@ -646,6 +646,36 @@ function tick(): void {
   renderFrom(text);
 }
 
+/** Company/role scraped from the posting, used to seed the generator forms. */
+export interface JobMeta {
+  company: string;
+  role: string;
+}
+
+/**
+ * Identity of what the badge is currently showing. The rebuild is skipped while
+ * this is unchanged, so anything the badge *displays* has to be in here.
+ *
+ * That includes the posting's company/role: the generator forms are seeded once
+ * at build time, so leaving them out let a split-view job switch keep the
+ * previous posting's values whenever both postings analysed the same (very
+ * common — two "no eligibility info" postings produce an identical verdict).
+ */
+export function badgeSignature(
+  a: SponsorAnalysis,
+  meta: JobMeta,
+  showCoverLetter: boolean,
+  showResume: boolean,
+): string {
+  return [
+    a.verdict, a.source, a.reason ?? '',
+    a.restrictions.join(','), a.cautions.join(','), a.positives.join(','),
+    a.experience.required ?? '', a.experience.preferred ?? '',
+    meta.company, meta.role,
+    showCoverLetter, showResume,
+  ].join('|');
+}
+
 function renderFrom(text: string): void {
   if (!enabled || dismissed) return;
   if (!document.body) return;
@@ -655,19 +685,18 @@ function renderFrom(text: string): void {
     (pinnedAi && pinnedAiUrl === location.href ? pinnedAi : null) ??
     aiCache.get(hash(text)) ??
     analyze(text);
+  // Read the meta once and reuse it for both the signature and the render, so a
+  // mutation landing between two reads can't sign one posting while showing
+  // another.
+  const meta = getJobMeta();
   // Skip the teardown/rebuild when the badge already shows exactly this result —
   // mutation-happy pages (live counts, timestamps) otherwise cause a rebuild
   // every debounce even though nothing visible changed. The generator toggles
   // are part of the signature so a settings change still re-renders.
-  const sig = [
-    analysis.verdict, analysis.source, analysis.reason ?? '',
-    analysis.restrictions.join(','), analysis.cautions.join(','), analysis.positives.join(','),
-    analysis.experience.required ?? '', analysis.experience.preferred ?? '',
-    showCoverLetterInBadge, showResumeInBadge,
-  ].join('|');
+  const sig = badgeSignature(analysis, meta, showCoverLetterInBadge, showResumeInBadge);
   if (sig === renderedSig && document.getElementById(BANNER_ID)) return;
   removeBadge();
-  document.body.appendChild(renderBadge(analysis));
+  document.body.appendChild(renderBadge(analysis, meta));
   renderedSig = sig;
 }
 
@@ -926,10 +955,11 @@ function getJobMeta(): { company: string; role: string } {
  */
 function buildGeneratorSection(cfg: {
   toggleLabel: string;
+  meta: JobMeta;
   request: (company: string, role: string, jobText: string) => Promise<AIResult>;
   download: (text: string, company: string, role: string) => void;
 }): HTMLElement {
-  const meta = getJobMeta();
+  const meta = cfg.meta;
   const wrap = document.createElement('div');
   wrap.className = 'cl';
 
@@ -978,18 +1008,20 @@ function buildGeneratorSection(cfg: {
   return wrap;
 }
 
-function buildCoverLetterSection(): HTMLElement {
+function buildCoverLetterSection(meta: JobMeta): HTMLElement {
   return buildGeneratorSection({
     toggleLabel: '📄 Cover letter',
+    meta,
     request: (company, role, jobText) =>
       sendToBackground<AIResult>({ type: 'AI_GENERATE_COVER_LETTER', company, role, jobText }),
     download: downloadLetter,
   });
 }
 
-function buildResumeSection(): HTMLElement {
+function buildResumeSection(meta: JobMeta): HTMLElement {
   return buildGeneratorSection({
     toggleLabel: '🧾 Tailored resume',
+    meta,
     request: (company, role, jobText) =>
       sendToBackground<AIResult>({ type: 'AI_GENERATE_RESUME', company, role, jobText }),
     download: downloadResume,
@@ -1000,7 +1032,7 @@ function buildResumeSection(): HTMLElement {
  * Renders the badge inside a Shadow DOM so the host page's CSS can't bleed in
  * (which otherwise garbles/duplicates the text). Returns the host element.
  */
-function renderBadge(a: SponsorAnalysis): HTMLElement {
+function renderBadge(a: SponsorAnalysis, meta: JobMeta): HTMLElement {
   const s = STYLES[a.verdict];
 
   const host = document.createElement('div');
@@ -1146,7 +1178,11 @@ function renderBadge(a: SponsorAnalysis): HTMLElement {
         pinnedAi = analysis;
         pinnedAiUrl = location.href;
         removeBadge();
-        if (document.body && enabled && !dismissed) document.body.appendChild(renderBadge(analysis));
+        // Same posting the badge was built for, so reuse its meta rather than
+        // re-reading the DOM and risking a different posting's company/role.
+        if (document.body && enabled && !dismissed) {
+          document.body.appendChild(renderBadge(analysis, meta));
+        }
       } catch (e) {
         ai.textContent = `⚠ ${String((e as Error).message).slice(0, 32)}`;
         ai.disabled = false;
@@ -1164,8 +1200,8 @@ function renderBadge(a: SponsorAnalysis): HTMLElement {
   // Offer one-click tailor-and-download for a cover letter + resume right here,
   // below the AI check, on any posting. Each generator is shown unless the user
   // turned it off in settings.
-  if (showCoverLetterInBadge) card.appendChild(buildCoverLetterSection());
-  if (showResumeInBadge) card.appendChild(buildResumeSection());
+  if (showCoverLetterInBadge) card.appendChild(buildCoverLetterSection(meta));
+  if (showResumeInBadge) card.appendChild(buildResumeSection(meta));
 
   // Footer: brand tag + an always-available "turn the scanner off everywhere"
   // link, so the global off-switch is reachable from the badge itself (not only


### PR DESCRIPTION
## The bug

On split-view boards (Handshake, LinkedIn), switching between jobs often leaves the badge's **cover letter / tailored resume** forms pre-filled with the *previous* posting's company and role. Generating from there produces a document tailored to the wrong job.

Reported with a clear repro: viewing **Saroot Labs — Software Engineer** while the cover-letter form still read **JAM Teaching and Consulting / Automations And Systems Cont…**.

## Root cause

`renderFrom()` skips the teardown/rebuild while its signature is unchanged (a deliberate perf win against mutation-happy pages). But the signature only covered the eligibility analysis and the two generator toggles — **not the posting's company/role**:

```ts
const sig = [
  analysis.verdict, analysis.source, analysis.reason ?? '',
  analysis.restrictions.join(','), /* … */
  showCoverLetterInBadge, showResumeInBadge,
].join('|');
if (sig === renderedSig && document.getElementById(BANNER_ID)) return;
```

Meanwhile the forms are seeded **once at build time** from `getJobMeta()`. So any two postings that analyse the same produce an identical signature, the badge is never rebuilt, and the stale values stay.

That combination is extremely common: every posting with no eligibility wording yields `unknown/rules`. Both postings in the report collapse to the same signature:

```
sigA: "unknown|rules|||||New grad||true|true"   ← California Air Resources Board
sigB: "unknown|rules|||||New grad||true|true"   ← Saroot Labs
```

Which is exactly why it looked intermittent — it only refreshed when the verdict happened to differ. A URL change doesn't rescue it either: `tick()` resets `watchUrl`/`dismissed`/`pinnedAi`, but `renderFrom` applies the same gate, and `renderedSig` is only cleared inside `removeBadge()` — which the early return never reaches.

**Not a regression from recent work.** `git blame` puts the skip at `e3c40bf` (2026-07-09), PR #73 *"perf: make the eligibility scanner idle-cheap"*. The later badge changes (#98, #99, #133) never touched the signature or the generator forms.

## The fix

- Extract the signature into an exported, unit-tested **`badgeSignature()`** and include the posting's `company`/`role`. A job switch now rebuilds; identical postings still don't (the perf win is preserved).
- Read the meta **once per render** and thread it through `renderBadge` into the generator sections, so the signature and the rendered form always describe the same posting. Two separate `getJobMeta()` reads could otherwise straddle a mutation and re-introduce the mismatch.
- The AI-check re-render reuses that same meta instead of re-reading the DOM.

## Verification

- `npm run lint`, `npm run typecheck`, `npm test` (**119 passed**, up from 116), `npm run build` — all green.
- **Confirmed the new test isn't vacuous:** removing `meta.company, meta.role` from the signature fails `changes when the posting company/role changes`, and only that test. It passes with the fix.
- Tests also pin the behaviour the skip exists for: identical posting + settings still yields a stable signature, and verdict / toggle changes still force a rebuild.

Manual check worth doing on review: load the unpacked build, open Handshake's job search, and click between two postings that both show "No eligibility info detected" — the cover-letter form should now follow the selected job.

## Note

One accepted trade-off: a rebuild discards anything typed into those inputs and re-collapses the form. That already happened on any verdict change; it now also happens when you switch postings — which is the intended behaviour here.

## Checklist

- [x] `npm run lint` passes
- [x] `npm run typecheck` passes
- [x] `npm test` passes
- [x] `npm run build` succeeds
- [x] Tests added/updated if behavior changed
- [x] No secrets, keys, or personal data committed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Badges now refresh when the associated company or role changes.
  * Badge updates remain consistent when analysis results or generator settings change.
  * AI verification and document-generation sections now stay synchronized with the displayed job posting.

* **Tests**
  * Added coverage for badge refresh behavior, stability, and analysis-setting changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->