### PR TITLE
fix(content): catch "do not provide VISA sponsorship" as a hard NO

### DIFF
--- a/src/content/analyze.test.ts
+++ b/src/content/analyze.test.ts
@@ -104,6 +104,32 @@ describe('analyze — eligibility verdict', () => {
     expect(a.restrictions).toContain('No visa sponsorship');
   });
 
+  it('flags "do not provide/offer VISA sponsorship" as NO', () => {
+    // Regression guard. The "do/does not … sponsor" rule allowed only an
+    // immediate verb ("do not provide sponsorship"), so the far more common
+    // wording with a qualifier in between — "do not provide VISA sponsorship" —
+    // matched nothing and the badge reported "no eligibility info detected".
+    for (const text of [
+      'We do not provide visa sponsorship.',
+      'We do not offer visa sponsorship at this time.',
+      'We do not offer employer sponsorship.',
+      'We do not support visa sponsorship.',
+      'This company does not provide visa sponsorship.',
+      'We are not currently offering visa sponsorship.',
+    ]) {
+      const a = analyze(text);
+      expect(a.verdict, text).toBe('no');
+      expect(a.restrictions, text).toContain('No visa sponsorship');
+    }
+  });
+
+  it('keeps the sponsorship negation narrow enough to skip "do not hesitate"', () => {
+    // The rule enumerates verbs/qualifiers instead of using a wildcard gap
+    // precisely so an unrelated "do not" near the word "sponsor" is not a NO.
+    const a = analyze('Please do not hesitate to contact us about our sponsor program.');
+    expect(a.verdict).not.toBe('no');
+  });
+
   it('marks an employer that will sponsor as YES', () => {
     const a = analyze('We will sponsor visas for the right candidate.');
     expect(a.verdict).toBe('yes');

--- a/src/content/analyze.test.ts
+++ b/src/content/analyze.test.ts
@@ -116,6 +116,13 @@ describe('analyze — eligibility verdict', () => {
       'We do not support visa sponsorship.',
       'This company does not provide visa sponsorship.',
       'We are not currently offering visa sponsorship.',
+      // Every enumerated qualifier and verb form gets its own case so a typo'd
+      // alternative in the regex fails here instead of shipping silently.
+      'We are not supporting H-1B sponsorship.',
+      'We do not support work sponsorship.',
+      'We do not provide immigration sponsorship.',
+      "This company doesn't provide visa sponsorship.",
+      "We don't offer visa sponsorship.",
     ]) {
       const a = analyze(text);
       expect(a.verdict, text).toBe('no');

--- a/src/content/sponsorship.ts
+++ b/src/content/sponsorship.ts
@@ -42,8 +42,11 @@ const RESTRICTIONS: { re: RegExp; label: string }[] = [
   // Strong inability cue anywhere in the same sentence as "sponsor(ship)" —
   // catches "unable to consider candidates who require visa sponsorship".
   { re: /\b(unable to|not able to|cannot|can.?t|won.?t|will not|not in a position to|ineligible|not eligible|are unable to|is unable to)\b[^.!?]{0,70}\bsponsor(ship|ed|ing)?\b/i, label: 'No visa sponsorship' },
-  // "do/does not ... sponsor" kept narrow so it doesn't catch "do not hesitate".
-  { re: /\b(do not|does not|don.?t|are not|aren.?t)\s+(currently |presently )?(provide |offer |support )?sponsor/i, label: 'No visa sponsorship' },
+  // "do/does not ... sponsor". The verb and the qualifier ("visa", "employer")
+  // are both enumerated rather than using a wildcard gap, so this stays narrow
+  // enough not to catch "do not hesitate". Without the qualifier slot the very
+  // common "do not provide VISA sponsorship" slipped through as a false negative.
+  { re: /\b(do not|does not|don.?t|are not|aren.?t)\s+(currently |presently )?(provid(?:e|ing) |offer(?:ing)? |support(?:ing)? )?(visa |employer |work |immigration |h-?1b )?sponsor/i, label: 'No visa sponsorship' },
   // "sponsorship is not available / not provided / not offered" word order.
   { re: /\bsponsor(ship|ed|ing)?\b[^.!?]{0,40}\b(is not|are not|not (available|provided|offered)|will not|cannot|can.?t)\b/i, label: 'No visa sponsorship' },
   { re: /\bno (visa |employer )?sponsorship\b/i, label: 'No visa sponsorship' },

--- a/src/content/sponsorship.ts
+++ b/src/content/sponsorship.ts
@@ -46,7 +46,7 @@ const RESTRICTIONS: { re: RegExp; label: string }[] = [
   // are both enumerated rather than using a wildcard gap, so this stays narrow
   // enough not to catch "do not hesitate". Without the qualifier slot the very
   // common "do not provide VISA sponsorship" slipped through as a false negative.
-  { re: /\b(do not|does not|don.?t|are not|aren.?t)\s+(currently |presently )?(provid(?:e|ing) |offer(?:ing)? |support(?:ing)? )?(visa |employer |work |immigration |h-?1b )?sponsor/i, label: 'No visa sponsorship' },
+  { re: /\b(do not|does not|don.?t|doesn.?t|are not|aren.?t)\s+(currently |presently )?(provid(?:e|ing) |offer(?:ing)? |support(?:ing)? )?(visa |employer |work |immigration |h-?1b )?sponsor/i, label: 'No visa sponsorship' },
   // "sponsorship is not available / not provided / not offered" word order.
   { re: /\bsponsor(ship|ed|ing)?\b[^.!?]{0,40}\b(is not|are not|not (available|provided|offered)|will not|cannot|can.?t)\b/i, label: 'No visa sponsorship' },
   { re: /\bno (visa |employer )?sponsorship\b/i, label: 'No visa sponsorship' },


### PR DESCRIPTION
## The bug

Found while investigating why the badge reported "No eligibility info detected" on Handshake postings that clearly state eligibility terms.

The `do/does not … sponsor` restriction rule allowed only an **immediate** verb before `sponsor`:

```js
/\b(do not|does not|don.?t|are not|aren.?t)\s+(currently |presently )?(provide |offer |support )?sponsor/i
```

So it matched `"do not provide sponsorship"` but **not** the far more common wording with a qualifier in between. Every one of these analysed as `unknown` — the badge said "No eligibility info detected" on a posting that had explicitly ruled sponsorship out:

| Phrase | Before | After |
|---|---|---|
| `We do not provide visa sponsorship` | ❌ unknown | ✅ no |
| `We do not offer visa sponsorship` | ❌ unknown | ✅ no |
| `We do not offer employer sponsorship` | ❌ unknown | ✅ no |
| `We do not support visa sponsorship` | ❌ unknown | ✅ no |
| `… does not provide visa sponsorship` | ❌ unknown | ✅ no |
| `We are not currently offering visa sponsorship` | ❌ unknown | ✅ no |
| `We do not sponsor visas` | ✅ no | ✅ no |
| `We do not provide sponsorship` | ✅ no | ✅ no |

A false negative is the worst direction for this feature — the whole point is to warn before you spend time on a posting that can't hire you.

It went unnoticed because the only covered phrasing, `"We are unable to provide visa sponsorship"`, matches a *different* and much wider rule (`unable to|not able to|cannot|…` with a 70-char gap) — and that's the variant the existing test used.

## The fix

Widen the verb slot to `-ing` forms and add an enumerated qualifier slot:

```js
/\b(do not|does not|don.?t|are not|aren.?t)\s+(currently |presently )?(provid(?:e|ing) |offer(?:ing)? |support(?:ing)? )?(visa |employer |work |immigration |h-?1b )?sponsor/i
```

Both slots are **enumerated rather than a wildcard gap**, deliberately — the original comment notes the rule is "kept narrow so it doesn't catch 'do not hesitate'", and a `[^.!?]{0,20}` style gap would have broken that. Verified it still holds, and it's now pinned by a test.

## Verification

- `npm run lint`, `npm run typecheck`, `npm test` (**118 passed**, up from 116), `npm run build` — all green.
- **Confirmed the new test isn't vacuous:** restoring the old regex fails `flags "do not provide/offer VISA sponsorship" as NO`, and only that test.
- Negative controls all still behave — none of these became a false NO:
  - `Please do not hesitate to contact us about our sponsor program` → unknown
  - `We do not require a cover letter` → unknown
  - `Are you authorized to work without sponsorship?` → unknown (screening question still stripped)
  - `Sponsorship is available for the right candidate` → yes
  - `We will sponsor visas for the right candidate` → yes

## Scope note

This does **not** fix every gap I found in that investigation. Two others need a product decision on which tier they belong to and are left out on purpose:

- `US work authorization required` / `Must be authorized to work in the US` — currently `unknown`. Hard NO, amber caution, or intentionally neutral? Common boilerplate, so tier matters.
- `Open to candidates with OPT/CPT` — currently `unknown`, arguably a **positive** signal.

## Checklist

- [x] `npm run lint` passes
- [x] `npm run typecheck` passes
- [x] `npm test` passes
- [x] `npm run build` succeeds
- [x] Tests added/updated if behavior changed
- [x] No secrets, keys, or personal data committed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of job postings that explicitly state they do not provide visa sponsorship.
  * Reduced false positives from unrelated phrases such as “do not hesitate” followed by “sponsor program.”
* **Tests**
  * Added coverage for multiple visa sponsorship wording variations and unrelated sponsorship language.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->