### PR TITLE
feat(content): read work-authorization and OPT/CPT eligibility lines

### DIFF
--- a/src/content/analyze.test.ts
+++ b/src/content/analyze.test.ts
@@ -115,6 +115,54 @@ describe('analyze — eligibility verdict', () => {
     expect(a.verdict).toBe('caution');
   });
 
+  it('treats a work-authorization requirement as a caution, not a hard NO', () => {
+    // Someone on F-1/OPT is already authorized, so this mainly rules out people
+    // needing sponsorship from scratch — a MAYBE, not a NO.
+    for (const text of [
+      'US work authorization required',
+      'U.S. work authorization required',
+      'Work authorization is required for this role.',
+      'Must be authorized to work in the United States.',
+    ]) {
+      const a = analyze(text);
+      expect(a.verdict, text).toBe('caution');
+      expect(a.cautions, text).toContain('U.S. work authorization required');
+    }
+  });
+
+  it('marks an explicit OPT/CPT welcome as YES', () => {
+    for (const text of ['Open to candidates with OPT/CPT', 'We welcome OPT and CPT candidates']) {
+      const a = analyze(text);
+      expect(a.verdict, text).toBe('yes');
+      expect(a.positives, text).toContain('Open to OPT/CPT');
+    }
+  });
+
+  it('does not read a REFUSED OPT/CPT as friendly', () => {
+    // The affirmative cue has to lead and "not" is excluded, so a refusal can't
+    // masquerade as a positive.
+    expect(analyze('We do not accept OPT/CPT').verdict).not.toBe('yes');
+    expect(analyze('This role is not open to candidates with OPT/CPT').verdict).not.toBe('yes');
+  });
+
+  it('lets an explicit positive outrank the work-authorization boilerplate', () => {
+    // A caution normally beats a positive. "Work authorization required" is
+    // boilerplate on a huge share of US postings, so on its own it would drag
+    // genuinely sponsor-friendly postings down to MAYBE.
+    const optCpt = analyze('US work authorization required. Open to candidates with OPT/CPT.');
+    expect(optCpt.verdict).toBe('yes');
+    expect(optCpt.cautions).not.toContain('U.S. work authorization required');
+
+    expect(analyze('US work authorization required. Sponsorship is available.').verdict).toBe('yes');
+  });
+
+  it('still lets a hard restriction outrank both', () => {
+    expect(analyze('Must be a U.S. citizen. US work authorization required.').verdict).toBe('no');
+    expect(
+      analyze('We are unable to provide visa sponsorship. US work authorization required.').verdict,
+    ).toBe('no');
+  });
+
   it('returns unknown when no eligibility signal is present', () => {
     const a = analyze('We are a small team building developer tools in San Francisco.');
     expect(a.verdict).toBe('unknown');

--- a/src/content/sponsorship.ts
+++ b/src/content/sponsorship.ts
@@ -57,8 +57,18 @@ const RESTRICTIONS: { re: RegExp; label: string }[] = [
   { re: /\b(u\.?s\.?|united states)\s+persons?\b/i, label: 'U.S. person (export control)' },
 ];
 
+/**
+ * "US work authorization required" is a caution, not a NO: someone on F-1/OPT is
+ * already authorized, so it mainly rules out candidates who need sponsorship
+ * from scratch. It's also boilerplate on a large share of US postings, which is
+ * why it must never dominate an explicit sponsorship positive — see analyze().
+ */
+const WORK_AUTH_CAUTION = 'U.S. work authorization required';
+
 // Soft / preference signals → amber caution (not a hard disqualifier).
 const CAUTIONS: { re: RegExp; label: string }[] = [
+  { re: /\bwork authoriz(?:ation|ed)\b[^.!?]{0,20}\b(require[sd]?|must)\b/i, label: WORK_AUTH_CAUTION },
+  { re: /\bmust be authorized to work\b[^.!?]{0,40}\b(u\.?s\.?|united states)\b/i, label: WORK_AUTH_CAUTION },
   { re: /\b(u\.?s\.?|united states)\s+citizen(ship)?\b[^.!?]{0,30}\b(preferred|a plus|is a plus|desired|nice to have)\b/i, label: 'U.S. citizenship preferred' },
   { re: /\b(prefer(red|ence)?|a plus|desired)\b[^.!?]{0,30}\b(u\.?s\.?|united states)\s+citizen/i, label: 'U.S. citizenship preferred' },
   { re: /\b(security )?clearance\b[^.!?]{0,30}\b(preferred|a plus|is a plus|desired|nice to have)\b/i, label: 'Clearance preferred' },
@@ -74,6 +84,10 @@ const POSITIVES: { re: RegExp; label: string }[] = [
   { re: /\bsponsorship\b[^.!?]{0,25}\bfor the right candidate\b/i, label: 'Sponsorship available' },
   { re: /\bopen to international (candidates|applicants|hires)\b/i, label: 'Open to international candidates' },
   { re: /\bh-?1b\b[^.]{0,30}(sponsor|welcome|transfer)/i, label: 'H-1B sponsorship' },
+  // Explicitly welcoming OPT/CPT. The affirmative cue has to lead (and "not" is
+  // excluded) so "we do not accept OPT/CPT" can't read as friendly.
+  { re: /(?<!\bnot\s)\bopen to\b[^.!?]{0,40}\b(opt|cpt)\b/i, label: 'Open to OPT/CPT' },
+  { re: /(?<!\bnot\s)\bwelcomes?\b[^.!?]{0,30}\b(opt|cpt)\b/i, label: 'Open to OPT/CPT' },
 ];
 
 // Spelled-out numbers → digits so "a minimum of three years" is caught.
@@ -101,8 +115,15 @@ export function analyze(text: string): SponsorAnalysis {
   // stance, and would otherwise produce a false NO.
   const prose = stripQuestions(norm);
   const restrictions = dedupe(RESTRICTIONS.filter((r) => r.re.test(prose)).map((r) => r.label));
-  const cautions = dedupe(CAUTIONS.filter((c) => c.re.test(prose)).map((c) => c.label));
   const positives = dedupe(POSITIVES.filter((p) => p.re.test(prose)).map((p) => p.label));
+  const allCautions = dedupe(CAUTIONS.filter((c) => c.re.test(prose)).map((c) => c.label));
+  // A caution outranks a positive below, so the boilerplate work-authorization
+  // line would otherwise drag a posting that explicitly sponsors (or welcomes
+  // OPT/CPT) down to MAYBE. An explicit positive answers that line directly, so
+  // drop it — every other caution is a genuine preference and still stands.
+  const cautions = positives.length
+    ? allCautions.filter((c) => c !== WORK_AUTH_CAUTION)
+    : allCautions;
   // Hard restriction dominates; then soft preference; then a positive signal.
   const verdict: Verdict = restrictions.length
     ? 'no'


### PR DESCRIPTION
## What & why

Second half of the Handshake detection-gap investigation (first half is #157). The scanner had **no rule at all** for two very common phrasings, so postings that clearly stated their eligibility terms still reported "No eligibility info detected":

| Phrase | Before | After |
|---|---|---|
| `US work authorization required` | ❌ unknown | ⚠️ caution |
| `Must be authorized to work in the United States` | ❌ unknown | ⚠️ caution |
| `Open to candidates with OPT/CPT` | ❌ unknown | ✅ yes |
| `We welcome OPT and CPT candidates` | ❌ unknown | ✅ yes |

This is exactly what the reported **Saroot Labs** posting needed — it carries *both* "US work authorization required" and "Open to candidates with OPT/CPT", and the badge showed no signal for either.

## Tier choices

- **Work authorization required → amber CAUTION, not NO.** Someone on F-1/OPT *is* already authorized, so the line mainly rules out candidates needing sponsorship from scratch. It's also boilerplate on a large share of US postings, so a hard NO would cry wolf constantly.
- **OPT/CPT welcome → POSITIVE.** Genuinely good news for a visa-needing candidate.

## The interaction that needed handling

A caution **outranks** a positive in the verdict ladder:

```js
const verdict = restrictions.length ? 'no' : cautions.length ? 'caution' : positives.length ? 'yes' : 'unknown';
```

So adding work-auth boilerplate as a caution would have dragged genuinely sponsor-friendly postings down from YES to MAYBE — including the Saroot Labs case, which has both lines. Fixed by suppressing **only** that caution when an explicit positive is present; an explicit "we sponsor" / "OPT/CPT welcome" answers the work-authorization line directly. Every other caution is a real preference and still stands, and hard restrictions continue to dominate both.

## Verification

- `npm run lint`, `npm run typecheck`, `npm test` (**121 passed**, up from 116), `npm run build` — all green.
- Ran a 16-case matrix covering the new rules, the suppression, negations, restriction dominance, and untouched controls — all as expected. Notably:
  - `We do not accept OPT/CPT` → **not** yes (affirmative cue must lead, `not` excluded)
  - `This role is not open to candidates with OPT/CPT` → **not** yes
  - `Must be a U.S. citizen. US work authorization required.` → **no** (restriction still dominates)
  - `Are you authorized to work in the US?` → unknown (screening question still stripped)
  - `U.S. citizenship preferred but not required.` → caution (unchanged)

## Note on ordering with #157

Independent branches, and they touch different rule arrays so they should merge cleanly in either order. They do interact in one spot worth knowing: `"We do not provide visa sponsorship. US work authorization required."` reads **caution** on this branch alone (the negation is still missed on `main`) and **no** once #157 lands. The permanent test here uses `"unable to provide visa sponsorship"` — a phrasing `main` already detects — so it isn't order-dependent. Merging #157 first is the tidier sequence.

## Scope

Per your call, I did not add the broader `"Applicants must be legally authorized to work in the U.S."` variants — easy one-line extension to the same caution rule if you want them later.

## Checklist

- [x] `npm run lint` passes
- [x] `npm run typecheck` passes
- [x] `npm test` passes
- [x] `npm run build` succeeds
- [x] Tests added/updated if behavior changed
- [x] No secrets, keys, or personal data committed