### PR TITLE
test: cover saved jobs storage listener

### DIFF
--- a/src/lib/savedJobs.test.ts
+++ b/src/lib/savedJobs.test.ts
@@ -7,6 +7,7 @@ import {
   isJobTextTruncated,
   MAX_JOBS,
   MAX_TEXT,
+  onSavedJobsChanged,
   setActiveJob,
   type SavedJob,
   type SavedJobsState,
@@ -17,15 +18,29 @@ const STORAGE_KEY = 'savedJobs';
 // Minimal in-memory chrome.storage.local: enough for get/set with one key.
 // Shared by every suite below so each starts from empty storage.
 let store: Record<string, unknown>;
+type StorageChangeListener = (
+  changes: { [key: string]: chrome.storage.StorageChange },
+  area: string,
+) => void;
+let storageChangeListeners: Set<StorageChangeListener>;
 
 beforeEach(() => {
   store = {};
+  storageChangeListeners = new Set();
   vi.stubGlobal('chrome', {
     storage: {
       local: {
         get: vi.fn(async (key: string) => ({ [key]: store[key] })),
         set: vi.fn(async (items: Record<string, unknown>) => {
           Object.assign(store, items);
+        }),
+      },
+      onChanged: {
+        addListener: vi.fn((listener: StorageChangeListener) => {
+          storageChangeListeners.add(listener);
+        }),
+        removeListener: vi.fn((listener: StorageChangeListener) => {
+          storageChangeListeners.delete(listener);
         }),
       },
     },
@@ -46,6 +61,13 @@ function persisted(): SavedJobsState {
 /** Seeds storage directly, bypassing addJob. */
 function seed(state: SavedJobsState): void {
   store[STORAGE_KEY] = state;
+}
+
+function emitStorageChange(
+  changes: { [key: string]: chrome.storage.StorageChange },
+  area: string,
+): void {
+  for (const listener of storageChangeListeners) listener(changes, area);
 }
 
 function job(overrides: Partial<SavedJob> = {}): SavedJob {
@@ -183,6 +205,57 @@ describe('getSavedJobs — defaults for missing or partial state', () => {
     const first = await getSavedJobs();
     first.jobs.push(job());
     expect((await getSavedJobs()).jobs).toEqual([]);
+  });
+});
+
+describe('onSavedJobsChanged', () => {
+  it('calls back with the new saved-jobs state for local changes', () => {
+    const callback = vi.fn();
+    const next = { jobs: [job({ id: 'new' })], activeId: 'new' };
+    onSavedJobsChanged(callback);
+
+    emitStorageChange({ [STORAGE_KEY]: { newValue: next } }, 'local');
+
+    expect(callback).toHaveBeenCalledOnce();
+    expect(callback).toHaveBeenCalledWith(next);
+  });
+
+  it('ignores saved-jobs changes from the sync area', () => {
+    const callback = vi.fn();
+    onSavedJobsChanged(callback);
+
+    emitStorageChange({ [STORAGE_KEY]: { newValue: { jobs: [], activeId: null } } }, 'sync');
+
+    expect(callback).not.toHaveBeenCalled();
+  });
+
+  it('ignores unrelated local storage changes', () => {
+    const callback = vi.fn();
+    onSavedJobsChanged(callback);
+
+    emitStorageChange({ profile: { newValue: { name: 'Ada' } } }, 'local');
+
+    expect(callback).not.toHaveBeenCalled();
+  });
+
+  it('uses empty defaults when the saved-jobs key is removed', () => {
+    const callback = vi.fn();
+    onSavedJobsChanged(callback);
+
+    emitStorageChange({ [STORAGE_KEY]: { newValue: undefined } }, 'local');
+
+    expect(callback).toHaveBeenCalledWith({ jobs: [], activeId: null });
+  });
+
+  it('stops delivering changes after unsubscribe', () => {
+    const callback = vi.fn();
+    const unsubscribe = onSavedJobsChanged(callback);
+
+    unsubscribe();
+    emitStorageChange({ [STORAGE_KEY]: { newValue: { jobs: [], activeId: null } } }, 'local');
+
+    expect(callback).not.toHaveBeenCalled();
+    expect(chrome.storage.onChanged.removeListener).toHaveBeenCalledOnce();
   });
 });
 


### PR DESCRIPTION
## What & why

Add focused coverage for every branch in `onSavedJobsChanged`: valid local updates, ignored sync/unrelated changes, deleted values receiving defaults, and unsubscribe behavior. This protects the popup and side-panel synchronization path from silent regressions.

Closes #161

## How I tested

- `npm run lint`
- `npm run typecheck`
- `npm test` — 132 passed
- `npm run build`

## Checklist

- [x] `npm run lint` passes
- [x] `npm run typecheck` passes
- [x] `npm test` passes
- [x] `npm run build` succeeds
- [x] Tests added/updated if behavior changed
- [x] No secrets, keys, or personal data committed

AI-assisted contribution; I reviewed the mock behavior, assertions, and full validation output.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage for saved jobs updates from local storage changes.
  * Verified unrelated and synchronized changes are ignored.
  * Verified default state restoration when saved jobs are removed.
  * Verified listeners can be unsubscribed correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->