### PR TITLE
Fix parseEligibilityJson throwing on non-string enum values (#172)

### DIFF
--- a/src/lib/jobEligibility.test.ts
+++ b/src/lib/jobEligibility.test.ts
@@ -79,6 +79,24 @@ describe('parseEligibilityJson', () => {
     expect(result.reason).toBeUndefined();
   });
 
+  it('gracefully handles non-string enum values without throwing', () => {
+    const result = parseEligibilityJson(
+      JSON.stringify({ sponsorship: 5, citizenship: true, clearance: { a: 1 } }),
+    );
+    expect(result.verdict).toBe('unknown');
+    expect(result.restrictions).toEqual([]);
+    expect(result.cautions).toEqual([]);
+    expect(result.positives).toEqual([]);
+  });
+
+  it('keeps valid enum values when other enum values are non-strings', () => {
+    const result = parseEligibilityJson(
+      JSON.stringify({ sponsorship: 5, citizenship: 'required' }),
+    );
+    expect(result.verdict).toBe('no');
+    expect(result.restrictions).toEqual(['U.S. citizenship required']);
+  });
+
   it('accepts the fenced JSON returned by some model responses', () => {
     expect(parseEligibilityJson('```json\n{"sponsorship":"available"}\n```').verdict).toBe('yes');
   });

--- a/src/lib/jobEligibility.ts
+++ b/src/lib/jobEligibility.ts
@@ -17,9 +17,10 @@ export function parseEligibilityJson(raw: string): SponsorAnalysis {
   const d = parseLooseJson(raw) as RawEligibility | null;
   if (!d) throw new Error('The AI did not return readable JSON.');
 
-  const sponsorship = (d.sponsorship || '').toLowerCase();
-  const citizenship = (d.citizenship || '').toLowerCase();
-  const clearance = (d.clearance || '').toLowerCase();
+  const enumVal = (v: unknown): string => (typeof v === 'string' ? v.toLowerCase() : '');
+  const sponsorship = enumVal(d.sponsorship);
+  const citizenship = enumVal(d.citizenship);
+  const clearance = enumVal(d.clearance);
 
   const restrictions: string[] = [];
   const cautions: string[] = [];


### PR DESCRIPTION
## What & why

Fixes #172. `parseEligibilityJson` normalized sponsorship/citizenship/clearance 
with `.toLowerCase()` directly, which throws when the model returns a 
non-string value (number, object, boolean, array) for those fields.

Added an `enumVal` helper (mirroring the existing `str` helper) that safely 
returns `''` for non-string input, so bad values fall through to the 
existing `'unknown'` verdict instead of throwing.

## How I tested

Added two test cases to `src/lib/jobEligibility.test.ts`:
- Non-string values for all three enum fields now return `verdict: 'unknown'` 
  with empty arrays instead of throwing.
- A mixed case with one valid and one invalid field still returns the 
  correct verdict for the valid field.

Ran `npm test` — all 143 tests pass, including the 2 new ones.

## Checklist

- [x] `npm test` passes
- [x] Tests added/updated if behavior changed
- [x] No secrets, keys, or personal data committed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved job eligibility checks to handle unexpected non-text values without errors.
  * Valid text values continue to be normalized and evaluated correctly.

* **Tests**
  * Added coverage confirming invalid values are ignored while valid eligibility values are still processed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->