### PR TITLE
test: add unit tests for normalize()

### DIFF
--- a/src/content/adapters/shared.test.ts
+++ b/src/content/adapters/shared.test.ts
@@ -46,11 +46,11 @@ describe('normalize — label text canonicalisation', () => {
     expect(normalize(normalize(label))).toBe(normalize(label));
   });
 
-  // Documents current behaviour, not desired behaviour: JS \s does NOT match
-  // U+200B, so a zero-width space inside label text survives normalisation and
-  // the label can never match its rule. Left as-is here — see PR discussion.
-  it('does not strip a zero-width space', () => {
-    expect(normalize('First\u200BName')).toBe('first\u200bname');
+  // Pins current (incorrect) behaviour: \s does not match U+200B, so the ZWSP
+  // survives normalization and breaks multi-word rule matching in matchRule.
+  // Tracked in https://github.com/ritsth/job-autofill-extension/issues/176
+  it('documents a known bug — zero-width space is not a separator (see #176)', () => {
+    expect(normalize('First\u200BName')).toBe('first\u200Bname');
   });
 
 });

--- a/src/content/adapters/shared.test.ts
+++ b/src/content/adapters/shared.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from 'vitest';
+import { normalize } from './shared';
+
+describe('normalize — label text canonicalisation', () => {
+  it('lowercases and otherwise leaves a whitespace-free string alone', () => {
+    expect(normalize('FIRsTName')).toBe('firstname');
+    expect(normalize('E-Mail')).toBe('e-mail');
+    expect(normalize('firstname')).toBe('firstname');
+  });
+
+  it('collapses consecutive internal spaces to one', () => {
+    expect(normalize('First   Name')).toBe('first name');
+    expect(normalize('First     Na    me')).toBe('first na me');
+  });
+
+  it('trims leading and trailing whitespace', () => {
+    expect(normalize('  First Name  ')).toBe('first name');
+    expect(normalize('\t\n First Name \n\t')).toBe('first name');
+  });
+
+  it('treats tabs and newlines like spaces', () => {
+    // Label text read off the DOM is indented markup, so the separator between
+    // two words is usually "\n      " rather than a single space.
+    expect(normalize('First\tName')).toBe('first name');
+    expect(normalize('First\n      Name')).toBe('first name');
+    expect(normalize('First \t\n\n  Name')).toBe('first name');
+  });
+
+  it('collapses a non-breaking space like ordinary whitespace', () => {
+    // The case that makes this function worth pinning: Workday & co. emit
+    // &nbsp; inside label text. JS \s matches U+00A0, so rewriting the regex
+    // to / +/g or to split(' ') would silently stop matching those labels.
+    expect(normalize('First\u00A0Name')).toBe('first name');
+    expect(normalize('\u00A0First Name\u00A0')).toBe('first name');
+  });
+
+  it('returns an empty string for empty and whitespace-only input', () => {
+    expect(normalize('')).toBe('');
+    expect(normalize(' ')).toBe('');
+    expect(normalize('\n')).toBe('');
+    expect(normalize('   \t\n  ')).toBe('');
+  });
+
+  it('is idempotent', () => {
+    const label = '  First \n  Name ';
+    expect(normalize(normalize(label))).toBe(normalize(label));
+  });
+
+  // Documents current behaviour, not desired behaviour: JS \s does NOT match
+  // U+200B, so a zero-width space inside label text survives normalisation and
+  // the label can never match its rule. Left as-is here — see PR discussion.
+  it('does not strip a zero-width space', () => {
+    expect(normalize('First\u200BName')).toBe('first\u200bname');
+  });
+
+});


### PR DESCRIPTION
<!-- Thanks for contributing! Keep PRs small and focused — one change per PR. -->

## What & why
<!-- What does this change do, and what problem does it solve? Link any related issue: "Closes #123". -->

Closes #174

Adds `src/content/adapters/shared.test.ts` covering `normalize`, one `it` per
behaviour: lowercasing, internal whitespace collapsing, trimming, tabs and
newlines, non-breaking spaces, empty/whitespace-only input, and idempotence.

The non-breaking-space case is the one worth calling out: `\s` does match
U+00A0, so the current implementation already handles `&nbsp;` in Workday label
text correctly. The test pins that down, since a rewrite to `/ +/g` or
`split(' ')` would break it silently — and a label that fails to match its rule
surfaces no error anywhere.

Test-only change, no production code touched.

Unrelated to this PR, but found while writing the tests: `\s` does not match
U+200B (zero-width space), so a label carrying one can never match its rule.
I've added a test documenting the current behaviour rather than changing it,
since that's a separate change. Happy to open a bug report for it.

## How I tested
<!-- e.g. loaded the unpacked extension and reproduced the fix on a real job page, added/updated tests. -->

`npm run lint`, `npm run typecheck`, `npm test` and `npm run build` all pass
locally (Node 22).

## Checklist

- [x] `npm run lint` passes
- [x] `npm run typecheck` passes
- [x] `npm test` passes
- [x] `npm run build` succeeds
- [x] Tests added/updated if behavior changed
- [x] No secrets, keys, or personal data committed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added comprehensive coverage for text normalization, including casing, whitespace handling, empty input, repeated application, and zero-width spaces.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->