### PR TITLE
fix: honor MAX_TEXT in all prompt builders

### DIFF
--- a/src/lib/ai/prompts.test.ts
+++ b/src/lib/ai/prompts.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+import { MAX_TEXT } from '../savedJobs';
+import {
+  buildAnswerPrompt,
+  buildJobEligibilityPrompt,
+  buildTailoredResumePrompt,
+} from './prompts';
+
+describe('prompt builders honor MAX_TEXT', () => {
+  const longJob = 'x'.repeat(MAX_TEXT + 500);
+
+  it('keeps the full saved posting in the answer prompt', () => {
+    const result = buildAnswerPrompt('Question?', 'Profile', longJob);
+    expect(result.prompt).toContain('x'.repeat(MAX_TEXT));
+    expect(result.prompt).not.toContain('x'.repeat(MAX_TEXT + 1));
+  });
+
+  it('keeps the full saved posting in the eligibility prompt', () => {
+    const result = buildJobEligibilityPrompt(longJob);
+    expect(result.prompt).toContain('x'.repeat(MAX_TEXT));
+    expect(result.prompt).not.toContain('x'.repeat(MAX_TEXT + 1));
+  });
+
+  it('keeps the full saved posting in the tailored resume prompt', () => {
+    const result = buildTailoredResumePrompt('Profile', longJob);
+    expect(result.prompt).toContain('x'.repeat(MAX_TEXT));
+    expect(result.prompt).not.toContain('x'.repeat(MAX_TEXT + 1));
+  });
+});

--- a/src/lib/ai/prompts.ts
+++ b/src/lib/ai/prompts.ts
@@ -1,4 +1,5 @@
 import type { GenerateInput } from './provider';
+import { MAX_TEXT } from '../savedJobs';
 
 // Prompt templates. Kept in one place so tone/behaviour is easy to tune.
 
@@ -26,7 +27,7 @@ export function buildAnswerPrompt(
   jobText?: string,
 ): GenerateInput {
   const job = jobText?.trim()
-    ? `JOB POSTING (tailor the answer to this role):\n${jobText.trim().slice(0, 8000)}\n\n`
+    ? `JOB POSTING (tailor the answer to this role):\n${jobText.trim().slice(0, MAX_TEXT)}\n\n`
     : '';
   return {
     system: ANSWER_SYSTEM,
@@ -106,7 +107,7 @@ export function buildJobEligibilityPrompt(jobText: string): GenerateInput {
     system: JOB_ELIGIBILITY_SYSTEM,
     json: true,
     maxOutputTokens: 512,
-    prompt: `JOB POSTING:\n${jobText.slice(0, 12000)}\n\nReturn the JSON:`,
+    prompt: `JOB POSTING:\n${jobText.slice(0, MAX_TEXT)}\n\nReturn the JSON:`,
   };
 }
 
@@ -134,7 +135,7 @@ export function buildTailoredResumePrompt(
   role?: string,
 ): GenerateInput {
   const job = jobText?.trim()
-    ? `JOB POSTING (tailor the resume to this role):\n${jobText.trim().slice(0, 8000)}\n\n`
+    ? `JOB POSTING (tailor the resume to this role):\n${jobText.trim().slice(0, MAX_TEXT)}\n\n`
     : '';
   return {
     system: RESUME_SYSTEM,
@@ -150,4 +151,3 @@ export function buildTailoredResumePrompt(
       `Return the tailored resume:`,
   };
 }
-


### PR DESCRIPTION
Fixes the silent 8,000-character cuts in the answer and tailored-resume prompt builders.

- `buildAnswerPrompt` and `buildTailoredResumePrompt` now use the same `MAX_TEXT` cap as the saved job storage.
- `buildJobEligibilityPrompt` now imports the shared constant instead of duplicating the number.
- Added regression tests proving all three builders keep the full saved posting.

Verified with Vitest and `npm run typecheck`.

Closes #179

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved consistency when processing long job-posting text across AI-generated answers, eligibility checks, and tailored resumes.
  * Ensured text is truncated at the supported limit without including additional characters.

* **Tests**
  * Added coverage verifying the truncation behavior for all supported prompt types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->