### PR TITLE
test: cover profile storage listener

### DIFF
--- a/src/lib/profile.test.ts
+++ b/src/lib/profile.test.ts
@@ -1,5 +1,129 @@
-import { describe, it, expect } from 'vitest';
-import { profileToContext, DEFAULT_PROFILE, type Profile } from './profile';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { DEFAULT_MODEL, GEMINI_MODELS } from './ai/models';
+import { DEFAULT_PROFILE, onProfileChanged, profileToContext, type Profile } from './profile';
+
+const STORAGE_KEY = 'profile';
+
+type StorageChangeListener = (
+  changes: { [key: string]: chrome.storage.StorageChange },
+  area: string,
+) => void;
+let storageChangeListeners: Set<StorageChangeListener>;
+
+beforeEach(() => {
+  storageChangeListeners = new Set();
+  vi.stubGlobal('chrome', {
+    storage: {
+      onChanged: {
+        addListener: vi.fn((listener: StorageChangeListener) => {
+          storageChangeListeners.add(listener);
+        }),
+        removeListener: vi.fn((listener: StorageChangeListener) => {
+          storageChangeListeners.delete(listener);
+        }),
+      },
+    },
+  });
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+function emitStorageChange(
+  changes: { [key: string]: chrome.storage.StorageChange },
+  area: string,
+): void {
+  for (const listener of storageChangeListeners) listener(changes, area);
+}
+
+describe('onProfileChanged', () => {
+  it('calls back with the profile for local changes', () => {
+    const callback = vi.fn();
+    const next: Profile = {
+      ...DEFAULT_PROFILE,
+      personal: { ...DEFAULT_PROFILE.personal, firstName: 'Jane' },
+    };
+    onProfileChanged(callback);
+
+    emitStorageChange({ [STORAGE_KEY]: { newValue: next } }, 'local');
+
+    expect(callback).toHaveBeenCalledOnce();
+    expect(callback).toHaveBeenCalledWith(next);
+  });
+
+  it('ignores profile changes from the sync area', () => {
+    const callback = vi.fn();
+    onProfileChanged(callback);
+
+    emitStorageChange({ [STORAGE_KEY]: { newValue: DEFAULT_PROFILE } }, 'sync');
+
+    expect(callback).not.toHaveBeenCalled();
+  });
+
+  it('ignores unrelated local storage changes', () => {
+    const callback = vi.fn();
+    onProfileChanged(callback);
+
+    emitStorageChange({ savedJobs: { newValue: [] } }, 'local');
+
+    expect(callback).not.toHaveBeenCalled();
+  });
+
+  it('uses the full default profile when the profile key is removed', () => {
+    const callback = vi.fn();
+    onProfileChanged(callback);
+
+    emitStorageChange({ [STORAGE_KEY]: { newValue: undefined } }, 'local');
+
+    expect(callback).toHaveBeenCalledWith(DEFAULT_PROFILE);
+  });
+
+  it('stops delivering changes after unsubscribe', () => {
+    const callback = vi.fn();
+    const unsubscribe = onProfileChanged(callback);
+
+    unsubscribe();
+    emitStorageChange({ [STORAGE_KEY]: { newValue: DEFAULT_PROFILE } }, 'local');
+
+    expect(callback).not.toHaveBeenCalled();
+    expect(chrome.storage.onChanged.removeListener).toHaveBeenCalledOnce();
+  });
+
+  it('deep-merges a partial profile with defaults', () => {
+    const callback = vi.fn();
+    onProfileChanged(callback);
+
+    emitStorageChange(
+      { [STORAGE_KEY]: { newValue: { personal: { firstName: 'Jane' } } } },
+      'local',
+    );
+
+    expect(callback).toHaveBeenCalledWith({
+      ...DEFAULT_PROFILE,
+      personal: { ...DEFAULT_PROFILE.personal, firstName: 'Jane' },
+    });
+  });
+
+  it.each([
+    ['unknown', 'gemini-2.0-flash', DEFAULT_MODEL],
+    ['known', GEMINI_MODELS[0].id, GEMINI_MODELS[0].id],
+  ])('normalizes a %s stored model', (_kind, storedModel, expectedModel) => {
+    const callback = vi.fn();
+    onProfileChanged(callback);
+
+    emitStorageChange(
+      { [STORAGE_KEY]: { newValue: { ai: { model: storedModel } } } },
+      'local',
+    );
+
+    expect(callback).toHaveBeenCalledWith(
+      expect.objectContaining({
+        ai: { ...DEFAULT_PROFILE.ai, model: expectedModel },
+      }),
+    );
+  });
+});
 
 describe('profileToContext', () => {
   it('returns an empty string for a completely empty profile', () => {


### PR DESCRIPTION
## What & why

Closes #185.

Adds focused coverage for `onProfileChanged`, using the same in-memory `chrome.storage.onChanged` listener pattern as `savedJobs.test.ts`.

The tests cover:
- local profile delivery, ignored sync/unrelated changes, and unsubscribe cleanup
- key removal restoring `DEFAULT_PROFILE`
- nested partial-profile default merging
- unknown model migration to `DEFAULT_MODEL` while known model IDs are preserved

No production code changes.

## How I tested

- `npm run lint`
- `npm run typecheck`
- `npm test` (18 files, 166 tests)
- `npm run build`

## Checklist

- [x] `npm run lint` passes
- [x] `npm run typecheck` passes
- [x] `npm test` passes
- [x] `npm run build` succeeds
- [x] Tests added/updated if behavior changed
- [x] No secrets, keys, or personal data committed