### PR TITLE
docs: mention the badge is draggable to any corner

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,8 +34,9 @@ Auto-fills repetitive job applications on **Greenhouse**, **Lever**, and
   placeholders substituted), downloadable as a `.pdf`.
 - **Flag eligibility at a glance** every covered page is scanned for visa-sponsorship /
   U.S.-citizenship / security-clearance language and shows a bold **YES / NO** badge
-  in the corner. On **Handshake** the badge also hosts a one-click cover-letter
-  generator (employer/role auto-detected from the posting).
+  in the corner. Drag it by its header to any corner to see what's under it; it
+  remembers where you put it. On **Handshake** the badge also hosts a one-click
+  cover-letter generator (employer/role auto-detected from the posting).
 
 The UI is a **side panel** (stays open while you browse, closes only when you close it).
 


### PR DESCRIPTION
## What & why

Closes #108

The eligibility badge became draggable to any of the four viewport corners
(snaps on release, choice persists) in #98/#99, but the README still described
it as fixed in place and never mentioned it can be moved — which was the
whole point of the feature.

Added one sentence to the feature bullet: "Drag it by its header to any
corner to see what's under it; it remembers where you put it."

Left the "top-right" mention in the Verify end-to-end section as-is — that's
still accurate (top-right is the default corner before the user moves it),
and the issue asked to keep this to one sentence.

## How I tested

Docs-only change, no code touched.

## Checklist

- [x] Docs-only change
- [x] No secrets, keys, or personal data committed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that the eligibility badge can be dragged by its header to another corner.
  * Documented that the badge remembers its selected position.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->