### PR TITLE
fix(popup): clear the error before copying to clipboard

### DIFF
--- a/src/popup/Popup.tsx
+++ b/src/popup/Popup.tsx
@@ -111,18 +111,21 @@ const copyTimer = useRef<number | null>(null);
   }
 
   async function copyToClipboard(text: string, target: 'letter' | 'resume') {
-  try {
-    await navigator.clipboard.writeText(text);
-    if (copyTimer.current !== null) clearTimeout(copyTimer.current);
-    setCopied(target);
-    copyTimer.current = window.setTimeout(() => {
-      setCopied('');
-      copyTimer.current = null;
-    }, 1500);
-  } catch {
-    setError('Could not copy to clipboard. Select the text and copy manually.');
+    // Clear first, like every other handler here: without this a failed copy
+    // leaves its error on screen next to a later "✓ Copied!".
+    setError('');
+    try {
+      await navigator.clipboard.writeText(text);
+      if (copyTimer.current !== null) clearTimeout(copyTimer.current);
+      setCopied(target);
+      copyTimer.current = window.setTimeout(() => {
+        setCopied('');
+        copyTimer.current = null;
+      }, 1500);
+    } catch {
+      setError('Could not copy to clipboard. Select the text and copy manually.');
+    }
   }
-}
 
   function flashFillMsg(message: string) {
     if (fillMsgTimer.current !== null) {


### PR DESCRIPTION
## What & why

Closes #151

`copyToClipboard` was the only handler in `Popup.tsx` that never cleared
`error` before running. Every other one (`onSignIn`, `onFill`,
`onUseCurrentPage`, `onCoverLetter`, `onResume`, `onSaveJob`) starts with
`setError('')`.

So after a failed copy (clipboard permission hiccup, unfocused document),
clicking **📋 Copy** again and succeeding flipped the button to **✓ Copied!**
while `Could not copy to clipboard. Select the text and copy manually.` was
still on screen — success and failure shown simultaneously. Nothing else
cleared it, so it lingered until some unrelated action reset it.

Fixed by clearing up front, matching the rest of the file.

The diff is larger than one line because the function body was indented two
spaces short of every sibling handler; since the fix touches the top of the
block anyway, the body is re-indented to match. The only behavioural change
is the added `setError('')`.

## How I tested

- `npm run lint`, `npm run typecheck`, `npm test` (166 passed), `npm run build` — all pass.

## Checklist

- [x] `npm run lint` passes
- [x] `npm run typecheck` passes
- [x] `npm test` passes
- [x] `npm run build` succeeds
- [x] No secrets, keys, or personal data committed