### PR TITLE
fix: reset profile save state when auto-save fails

### DIFF
--- a/src/ui/useProfile.ts
+++ b/src/ui/useProfile.ts
@@ -31,10 +31,15 @@ export function useProfile() {
       setSaveState('saving');
       window.clearTimeout(saveTimer.current);
       saveTimer.current = window.setTimeout(async () => {
-        await saveProfile(next);
-        setSaveState('saved');
-        editing.current = false;
-        window.setTimeout(() => setSaveState('idle'), 1500);
+        try {
+          await saveProfile(next);
+          setSaveState('saved');
+          window.setTimeout(() => setSaveState('idle'), 1500);
+        } catch {
+          setSaveState('idle');
+        } finally {
+          editing.current = false;
+        }
       }, 500);
       return next;
     });


### PR DESCRIPTION
## Summary
- Wrap the debounced `saveProfile` call in `try/catch/finally`.
- On failure, reset `saveState` to `idle` and clear the editing lock so external sync is not blocked forever.

Closes #187

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved profile save error handling.
  * Editing mode now consistently ends after save attempts.
  * Save status correctly returns to idle when a save fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->