### PR TITLE
fix: deduplicate saved jobs by URL

### DIFF
--- a/src/lib/savedJobs.test.ts
+++ b/src/lib/savedJobs.test.ts
@@ -125,7 +125,7 @@ describe('addJob — storage-side truncation', () => {
 describe('addJob — ordering and active selection', () => {
   it('prepends the new job and makes it active', async () => {
     const first = await addJob(partial('first'));
-    const second = await addJob(partial('second'));
+    const second = await addJob({ ...partial('second'), url: 'https://y' });
 
     expect(second.jobs.map((j) => j.text)).toEqual(['second', 'first']);
     // The newest job is the one AI tailoring should use.
@@ -139,15 +139,82 @@ describe('addJob — ordering and active selection', () => {
     expect(jobs[0].id).toBeTruthy();
     expect(jobs[0].savedAt).toBeGreaterThan(0);
 
-    const after = await addJob(partial());
+    const after = await addJob({ ...partial(), url: 'https://y' });
     expect(after.jobs[0].id).not.toBe(after.jobs[1].id);
+  });
+});
+
+describe('addJob — duplicate URL', () => {
+  it('keeps the list length and existing id unchanged', async () => {
+    seed({ jobs: [job({ id: 'existing' })], activeId: null });
+
+    const { jobs } = await addJob(partial('fresh capture'));
+
+    expect(jobs).toHaveLength(1);
+    expect(jobs[0].id).toBe('existing');
+    expect(persisted().jobs).toHaveLength(1);
+  });
+
+  it('moves the existing entry to the front, refreshes savedAt, and makes it active', async () => {
+    seed({
+      jobs: [
+        job({ id: 'other', url: 'https://other', savedAt: 2 }),
+        job({ id: 'existing', savedAt: 1 }),
+      ],
+      activeId: 'other',
+    });
+
+    const result = await addJob({
+      ...partial('fresh capture'),
+      company: 'Updated Acme',
+      role: 'Staff Engineer',
+    });
+
+    expect(result.jobs.map((saved) => saved.id)).toEqual(['existing', 'other']);
+    expect(result.jobs[0].savedAt).toBeGreaterThan(1);
+    expect(result.jobs[0]).toMatchObject({ company: 'Updated Acme', role: 'Staff Engineer' });
+    expect(result.activeId).toBe('existing');
+    expect(persisted().activeId).toBe('existing');
+  });
+
+  it('does not match a genuinely different URL', async () => {
+    seed({ jobs: [job({ id: 'existing' })], activeId: 'existing' });
+
+    const { jobs } = await addJob({ ...partial('another posting'), url: 'https://different' });
+
+    expect(jobs).toHaveLength(2);
+    expect(jobs[0].id).not.toBe('existing');
+    expect(jobs[1].id).toBe('existing');
+  });
+
+  it('preserves the original captured text', async () => {
+    seed({ jobs: [job({ id: 'existing', text: 'original posting' })], activeId: null });
+
+    const { jobs } = await addJob(partial('later application form boilerplate'));
+
+    expect(jobs[0].text).toBe('original posting');
+  });
+
+  it('does not evict another job when the capped list already contains the URL', async () => {
+    const existing = Array.from({ length: MAX_JOBS }, (_, i) =>
+      job({ id: `old-${i}`, url: `https://old/${i}` }),
+    );
+    existing[MAX_JOBS - 1] = job({ id: 'duplicate', url: 'https://x' });
+    seed({ jobs: existing, activeId: 'old-0' });
+
+    const result = await addJob(partial('fresh capture'));
+
+    expect(result.jobs).toHaveLength(MAX_JOBS);
+    expect(result.jobs[0].id).toBe('duplicate');
+    expect(result.evicted).toEqual([]);
+    expect(result.jobs.some((saved) => saved.id === 'old-0')).toBe(true);
   });
 });
 
 describe('addJob — MAX_JOBS eviction cap', () => {
   it('keeps at most MAX_JOBS, dropping the oldest', async () => {
     const existing = Array.from({ length: MAX_JOBS }, (_, i) =>
-      job({ id: `old-${i}`, text: `old-${i}` }),
+      job({ id: `old-${i}`, url: `https://old/${i}`, text: `old-${i}` }),
     );
     seed({ jobs: existing, activeId: 'old-0' });
 
@@ -162,7 +229,7 @@ describe('addJob — MAX_JOBS eviction cap', () => {
   });
 
   it('does not evict while under the cap', async () => {
-    seed({ jobs: [job({ id: 'a' })], activeId: 'a' });
+    seed({ jobs: [job({ id: 'a', url: 'https://other' })], activeId: 'a' });
 
     const { jobs } = await addJob(partial('newest'));
 
@@ -171,7 +238,9 @@ describe('addJob — MAX_JOBS eviction cap', () => {
   });
 
   it('reports the dropped job so the UI can say so', async () => {
-    const existing = Array.from({ length: MAX_JOBS }, (_, i) => job({ id: `old-${i}` }));
+    const existing = Array.from({ length: MAX_JOBS }, (_, i) =>
+      job({ id: `old-${i}`, url: `https://old/${i}` }),
+    );
     seed({ jobs: existing, activeId: 'old-0' });
 
     const { evicted } = await addJob(partial('newest'));
@@ -181,7 +250,7 @@ describe('addJob — MAX_JOBS eviction cap', () => {
   });
 
   it('reports nothing evicted while under the cap', async () => {
-    seed({ jobs: [job({ id: 'a' })], activeId: 'a' });
+    seed({ jobs: [job({ id: 'a', url: 'https://other' })], activeId: 'a' });
 
     expect((await addJob(partial('newest'))).evicted).toEqual([]);
   });

--- a/src/lib/savedJobs.ts
+++ b/src/lib/savedJobs.ts
@@ -63,23 +63,40 @@ export interface AddJobResult extends SavedJobsState {
   evicted: SavedJob[];
 }
 
-/** Adds a captured job (newest first), makes it active, and returns the new state. */
+/** Adds or refreshes a captured job (newest first), makes it active, and returns the state. */
 export async function addJob(
   partial: Omit<SavedJob, 'id' | 'savedAt'>,
 ): Promise<AddJobResult> {
   const state = await getSavedJobs();
-  if (isJobTextTruncated(partial.text)) {
-    console.warn(
-      `[Little AI Helper] Saved posting trimmed from ${partial.text.length} to ${MAX_TEXT} chars for AI context.`,
-    );
+  const existing = state.jobs.find((saved) => saved.url === partial.url);
+  let job: SavedJob;
+  let all: SavedJob[];
+  if (existing) {
+    job = {
+      ...existing,
+      ...partial,
+      id: existing.id,
+      // Re-saving from a later application step can capture form boilerplate.
+      // Keep the known-good posting text instead of silently degrading it.
+      text: existing.text,
+      savedAt: Date.now(),
+    };
+    // Also heal duplicates created by releases that always minted a new id.
+    all = [job, ...state.jobs.filter((saved) => saved.url !== partial.url)];
+  } else {
+    if (isJobTextTruncated(partial.text)) {
+      console.warn(
+        `[Little AI Helper] Saved posting trimmed from ${partial.text.length} to ${MAX_TEXT} chars for AI context.`,
+      );
+    }
+    job = {
+      ...partial,
+      text: partial.text.slice(0, MAX_TEXT),
+      id: crypto.randomUUID(),
+      savedAt: Date.now(),
+    };
+    all = [job, ...state.jobs];
   }
-  const job: SavedJob = {
-    ...partial,
-    text: partial.text.slice(0, MAX_TEXT),
-    id: crypto.randomUUID(),
-    savedAt: Date.now(),
-  };
-  const all = [job, ...state.jobs];
   const next: SavedJobsState = {
     jobs: all.slice(0, MAX_JOBS),
     activeId: job.id,


### PR DESCRIPTION
## What & why

- Re-saving an existing posting URL now refreshes that same entry instead of minting another id.
- The entry moves to the front, becomes active, and gets fresh company/role/savedAt metadata while retaining the original captured posting text.
- Existing duplicates for that URL are collapsed, and a duplicate save at the 20-job cap evicts nothing.
- New regressions cover unchanged length/id, ordering and active selection, distinct URLs, text preservation, and cap behavior.

Closes #195

## How I tested

- RED: the new duplicate-save tests failed on length/id, ordering, text preservation, and cap eviction before the implementation change.
- `npm test -- src/lib/savedJobs.test.ts` — 32 passed
- `npm test` — 171 passed across 18 files
- `npm run lint` — passed
- `npm run typecheck` — passed
- `npm run build` — passed
- `git diff --check` — passed

## Checklist

- [x] `npm run lint` passes
- [x] `npm run typecheck` passes
- [x] `npm test` passes
- [x] `npm run build` succeeds
- [x] Tests added/updated if behavior changed
- [x] No secrets, keys, or personal data committed

AI disclosure: OpenAI Codex assisted with implementation and validation; I reviewed the diff and ran the reported gates.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Saving a job with an existing URL now updates the existing entry instead of creating a duplicate.
  * Updated jobs retain their original ID and posting text while refreshing current details.
  * Re-saved jobs are moved to the top and remain active without being incorrectly removed when the saved-job limit is reached.
  * Different job URLs continue to create separate saved entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->