### PR TITLE
fix: dedupe saved jobs by posting URL

### DIFF
--- a/src/lib/savedJobs.test.ts
+++ b/src/lib/savedJobs.test.ts
@@ -331,3 +331,51 @@ describe('deleteJob', () => {
     expect(persisted().activeId).toBe('a');
   });
 });
+
+describe('addJob — dedupe by url (#195)', () => {
+  it('saving the same URL again leaves list length unchanged', async () => {
+    await addJob({ ...partial(), url: 'https://jobs.example/a', text: 'posting alpha' });
+    await addJob({ ...partial(), url: 'https://jobs.example/a', text: 'posting alpha again' });
+    expect(persisted().jobs).toHaveLength(1);
+  });
+
+  it('moves the existing entry to the front and makes it active', async () => {
+    await addJob({ ...partial(), url: 'https://jobs.example/old', text: 'older posting text here' });
+    await addJob({ ...partial(), url: 'https://jobs.example/keep', text: 'keep this posting text' });
+    const beforeId = persisted().jobs.find((j) => j.url === 'https://jobs.example/old')!.id;
+    await addJob({ ...partial(), url: 'https://jobs.example/old', text: 'short' });
+    expect(persisted().jobs[0].url).toBe('https://jobs.example/old');
+    expect(persisted().jobs[0].id).toBe(beforeId);
+    expect(persisted().activeId).toBe(beforeId);
+  });
+
+  it('two different URLs still produce two entries', async () => {
+    await addJob({ ...partial(), url: 'https://jobs.example/a', text: 'posting one text' });
+    await addJob({ ...partial(), url: 'https://jobs.example/b', text: 'posting two text' });
+    expect(persisted().jobs).toHaveLength(2);
+  });
+
+  it('keeps the longer stored text when the re-save is shorter', async () => {
+    await addJob({
+      ...partial(),
+      url: 'https://jobs.example/a',
+      text: 'a long original posting that should be kept',
+    });
+    await addJob({ ...partial(), url: 'https://jobs.example/a', text: 'short form page' });
+    expect(persisted().jobs[0].text).toBe(
+      'a long original posting that should be kept',
+    );
+  });
+
+  it('upgrades stored text when the re-save is longer', async () => {
+    await addJob({ ...partial(), url: 'https://jobs.example/a', text: 'short capture' });
+    await addJob({
+      ...partial(),
+      url: 'https://jobs.example/a',
+      text: 'a much longer and better posting capture',
+    });
+    expect(persisted().jobs[0].text).toBe(
+      'a much longer and better posting capture',
+    );
+  });
+});

--- a/src/lib/savedJobs.ts
+++ b/src/lib/savedJobs.ts
@@ -73,9 +73,31 @@ export async function addJob(
       `[Little AI Helper] Saved posting trimmed from ${partial.text.length} to ${MAX_TEXT} chars for AI context.`,
     );
   }
+  const truncated = partial.text.slice(0, MAX_TEXT);
+  const existingIdx = state.jobs.findIndex((j) => j.url === partial.url);
+  if (existingIdx >= 0) {
+    // Same posting URL: refresh in place instead of minting a duplicate that
+    // would burn a MAX_JOBS slot. Keep the longer text so a re-save on a thin
+    // application page cannot degrade a good capture.
+    const existing = state.jobs[existingIdx];
+    const text =
+      truncated.length > existing.text.length ? truncated : existing.text;
+    const job: SavedJob = {
+      ...existing,
+      ...partial,
+      text,
+      id: existing.id,
+      savedAt: Date.now(),
+    };
+    const rest = state.jobs.filter((_, i) => i !== existingIdx);
+    const next: SavedJobsState = { jobs: [job, ...rest], activeId: job.id };
+    await setSavedJobs(next);
+    return { ...next, evicted: [] };
+  }
+
   const job: SavedJob = {
     ...partial,
-    text: partial.text.slice(0, MAX_TEXT),
+    text: truncated,
     id: crypto.randomUUID(),
     savedAt: Date.now(),
   };


### PR DESCRIPTION
## Summary
- Re-saving the same `url` refreshes the existing entry instead of minting a duplicate.
- Longer captured text wins so a thin application-page re-save cannot degrade a good posting.
- Adds unit coverage for length, active move-to-front, distinct URLs, and the text rule.

Closes #195

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Saving a job posting that already exists now updates the existing entry instead of creating a duplicate.
  * Refreshed postings move to the top of the saved list and become active.
  * Longer captured job text is preserved when updating an existing posting.
  * Different job URLs continue to be saved separately.

* **Tests**
  * Added coverage for duplicate detection, updates, ordering, activation, and text preservation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->