### PR TITLE
fix(adapters): treat zero-width characters as word separators

### DIFF
--- a/src/content/adapters/shared.test.ts
+++ b/src/content/adapters/shared.test.ts
@@ -46,11 +46,36 @@ describe('normalize — label text canonicalisation', () => {
     expect(normalize(normalize(label))).toBe(normalize(label));
   });
 
-  // Pins current (incorrect) behaviour: \s does not match U+200B, so the ZWSP
-  // survives normalization and breaks multi-word rule matching in matchRule.
-  // Tracked in https://github.com/ritsth/job-autofill-extension/issues/176
-  it('documents a known bug — zero-width space is not a separator (see #176)', () => {
-    expect(normalize('First\u200BName')).toBe('first\u200Bname');
+  it('treats a zero-width space as a word separator', () => {
+    // JS \s does not match U+200B, so it needs explicit handling (#176).
+    // Collapsing to a space rather than deleting is deliberate — see the
+    // boundary-preservation test below.
+    expect(normalize('First​Name')).toBe('first name');
+    expect(normalize('​First Name​')).toBe('first name');
+  });
+
+  it('treats the other zero-width characters as separators too', () => {
+    // ZWNJ, ZWJ, word joiner and the BOM / zero-width no-break space are all
+    // invisible and all unmatched by \s, so they fail identically to U+200B.
+    expect(normalize('First‌Name')).toBe('first name');
+    expect(normalize('First‍Name')).toBe('first name');
+    expect(normalize('First⁠Name')).toBe('first name');
+    expect(normalize('First﻿Name')).toBe('first name');
+  });
+
+  it('collapses a zero-width run mixed with ordinary whitespace to one space', () => {
+    expect(normalize('First​ ​\tName')).toBe('first name');
+  });
+
+  it('keeps the word boundary that the fill rules match on', () => {
+    // This is *why* zero-width chars collapse to a space instead of being
+    // removed. Deleting them yields "emailaddress", which /\be-?mail\b/ cannot
+    // match, so the field would silently never autofill — and the same breaks
+    // every single-word rule (city, github, phone...). Guards that choice.
+    expect(normalize('Email​Address')).toBe('email address');
+    expect(/\be-?mail\b/.test(normalize('Email​Address'))).toBe(true);
+    expect(/\bcity\b/.test(normalize('City​Field'))).toBe(true);
+    expect(/\bgithub\b/.test(normalize('GitHub​URL'))).toBe(true);
   });
 
 });

--- a/src/content/adapters/shared.ts
+++ b/src/content/adapters/shared.ts
@@ -6,8 +6,25 @@ import type { Profile } from '../../lib/profile';
 
 export type FillableField = HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement;
 
+// Zero-width characters that JS `\s` does NOT match: ZWSP, ZWNJ, ZWJ, word
+// joiner, and the BOM / zero-width no-break space. They turn up in scraped
+// label markup (line-break hints inside long identifiers, copy-pasted text).
+const ZERO_WIDTH = '\\u200b-\\u200d\\u2060\\ufeff';
+const SEPARATORS = new RegExp(`[\\s${ZERO_WIDTH}]+`, 'g');
+
+/**
+ * Canonicalises label text for rule matching: lowercase, all runs of separators
+ * collapsed to one space, trimmed.
+ *
+ * Zero-width characters collapse to a space rather than being deleted, even
+ * though they render as no gap at all. Deleting them would weld the surrounding
+ * words together and destroy the `\b` boundary that most rules in `RULES` rely
+ * on — "Email<ZWSP>Address" would become "emailaddress", which `/\be-?mail\b/`
+ * no longer matches. Collapsing keeps every rule matching, and mirrors how `\s`
+ * already treats the non-breaking space.
+ */
 export function normalize(s: string): string {
-  return s.toLowerCase().replace(/\s+/g, ' ').trim();
+  return s.toLowerCase().replace(SEPARATORS, ' ').trim();
 }
 
 /**


### PR DESCRIPTION
## What & why

Closes #176.

`\s` matches U+00A0 but **not** U+200B, so a zero-width space in scraped label
text survived `normalize()` intact and broke rule matching. The field was then
silently skipped — no error, it just never autofills.

## The design call

#176 left one question open: should a zero-width character **collapse to a
space** or be **deleted entirely**? Deleting is the more intuitive reading — a
ZWSP renders as no gap at all — but it's wrong here, and measurably so.

Deleting welds the neighbouring words together and destroys the `\b` boundary
that most of `RULES` depends on. Checked against the real patterns:

| Label | Deleted | Match | Collapsed | Match |
|---|---|---|---|---|
| `First<ZWSP>Name` | `firstname` | ✅ `firstName` | `first name` | ✅ `firstName` |
| `Email<ZWSP>Address` | `emailaddress` | ❌ none | `email address` | ✅ `email` |
| `City<ZWSP>Field` | `cityfield` | ❌ none | `city field` | ✅ `city` |
| `GitHub<ZWSP>URL` | `githuburl` | ❌ none | `github url` | ✅ `github` |

Two-word rules using `\s*` survive either way. Every **single-word** rule
(`email`, `city`, `github`, `phone`, `linkedin`, `portfolio`, `country`,
`state`) breaks under deletion, because each ends in `\b`. Collapsing keeps all
of them matching, and is consistent with how `\s` already treats U+00A0.

## Slight scope widening

The fix covers the other invisible characters `\s` also misses — ZWNJ (U+200C),
ZWJ (U+200D), word joiner (U+2060), and the BOM / zero-width no-break space
(U+FEFF). They fail in exactly the same way for exactly the same reason, so
fixing only U+200B would leave the identical bug latent under four other
codepoints. Flagging it since #176 only named U+200B — happy to narrow if you'd
rather keep it strictly to the reported character.

## How I tested

- `npm run lint`, `npm run typecheck`, `npm test` (174 passed), `npm run build` — all pass.
- Replaced the placeholder test from #175 (which pinned the *buggy* behaviour and
  pointed at this issue) with real coverage.
- **Mutation-checked both directions**, so the tests pin the decision and not just
  the outcome:
  - Reverting to the old `\s`-only regex → 4 new tests fail.
  - Switching to the rejected delete-entirely variant → 3 fail, including
    `expected 'emailaddress' to be 'email address'`.

The `keeps the word boundary that the fill rules match on` test exists purely to
guard that second case — it asserts the rule regexes directly, so anyone who
later "simplifies" this to a deletion gets an immediate, self-explaining failure.

## Checklist

- [x] `npm run lint` passes
- [x] `npm run typecheck` passes
- [x] `npm test` passes
- [x] `npm run build` succeeds
- [x] Tests added/updated if behavior changed
- [x] No secrets, keys, or personal data committed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved text matching by treating zero-width spaces and other invisible characters as word separators.
  * Preserved word boundaries when content mixes invisible and standard whitespace.
  * Continued normalizing text consistently through whitespace collapsing, trimming, and lowercase conversion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->