### PR TITLE
docs: add license/author/repository fields to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,12 @@
   "version": "1.1.7",
   "type": "module",
   "description": "Autofill job applications on Greenhouse, Lever & Workday and draft AI answers and tailored cover letters from your profile.",
+  "license": "MIT",
+  "author": "Ritika Shrestha",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ritsth/job-autofill-extension.git"
+  },
   "engines": {
     "node": "^20.19.0 || ^22.13.0 || >=24"
   },


### PR DESCRIPTION
## What & why

Closes #112

The repo ships an MIT `LICENSE` file, but `package.json` declared no
`license`/`author`/`repository` fields, so npm, GitHub's dependency insights,
and license scanners all read the project as UNLICENSED despite the LICENSE
file being right there.

Added the SPDX id `"MIT"` to match the LICENSE file exactly, plus `author` and
`repository`. The package stays `"private": true`, so this is metadata only —
nothing changes about what gets published.

## How I tested

- `npm pkg get license author repository` returns the new values.
- `npm run lint`, `npm run typecheck`, `npm test` (178 passed), `npm run build` — all pass.

## Checklist

- [x] `npm run lint` passes
- [x] `npm run typecheck` passes
- [x] `npm test` passes
- [x] `npm run build` succeeds
- [x] No secrets, keys, or personal data committed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added MIT license information.
  * Added package author and repository details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->