### PR TITLE
test(cover-letter): add unit tests for substitutePlaceholders

### DIFF
--- a/src/lib/coverLetter.test.ts
+++ b/src/lib/coverLetter.test.ts
@@ -1,5 +1,82 @@
-import { describe, it, expect } from 'vitest';
-import { letterFilename } from './coverLetter';
+import { afterEach, describe, it, expect, vi } from 'vitest';
+import { letterFilename, substitutePlaceholders } from './coverLetter';
+
+describe('substitutePlaceholders', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('replaces company, role, and date', () => {
+    expect(substitutePlaceholders('{{company}}', { company: 'Acme', role: '', date: '1' })).toBe(
+      'Acme',
+    );
+    expect(substitutePlaceholders('{{role}}', { company: '', role: 'Engineer', date: '1' })).toBe(
+      'Engineer',
+    );
+    expect(substitutePlaceholders('{{date}}', { company: '', role: '', date: 'May 1, 2026' })).toBe(
+      'May 1, 2026',
+    );
+  });
+
+  it('replaces all three placeholders in one template', () => {
+    const result = substitutePlaceholders('Dear {{company}}, re: {{role}} ({{date}})', {
+      company: 'Acme',
+      role: 'Engineer',
+      date: 'May 1, 2026',
+    });
+    expect(result).toBe('Dear Acme, re: Engineer (May 1, 2026)');
+  });
+
+  it('matches placeholder names case-insensitively', () => {
+    const result = substitutePlaceholders('{{Company}} — {{ROLE}} — {{Date}}', {
+      company: 'Acme',
+      role: 'Engineer',
+      date: 'May 1, 2026',
+    });
+    expect(result).toBe('Acme — Engineer — May 1, 2026');
+  });
+
+  it('tolerates whitespace inside the braces', () => {
+    expect(
+      substitutePlaceholders('{{ company }}', { company: 'Acme', role: '', date: '1' }),
+    ).toBe('Acme');
+  });
+
+  it('replaces every occurrence of a repeated placeholder', () => {
+    const result = substitutePlaceholders('{{company}} and {{company}} again', {
+      company: 'Acme',
+      role: '',
+      date: '1',
+    });
+    expect(result).toBe('Acme and Acme again');
+  });
+
+  it('leaves the placeholder visible when the value is empty, instead of a blank gap', () => {
+    // Deliberate: a missing company/role should be obvious, not silently blank.
+    // See the comment in substitutePlaceholders.
+    expect(substitutePlaceholders('{{company}}', { company: '', role: '', date: '1' })).toBe(
+      '{{company}}',
+    );
+    expect(substitutePlaceholders('{{role}}', { company: '', role: '', date: '1' })).toBe(
+      '{{role}}',
+    );
+  });
+
+  it('defaults the date to today, formatted, when none is given', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-05-01T12:00:00Z'));
+    const result = substitutePlaceholders('{{date}}', { company: '', role: '' });
+    // Loose assertion — toLocaleDateString output depends on the runner's
+    // locale, so an exact string match would be flaky in CI.
+    expect(result).toContain('2026');
+  });
+
+  it('leaves an unknown placeholder untouched', () => {
+    expect(
+      substitutePlaceholders('{{name}}', { company: 'Acme', role: 'Engineer', date: '1' }),
+    ).toBe('{{name}}');
+  });
+});
 
 describe('letterFilename', () => {
   it('handles the normal case with both company and role', () => {


### PR DESCRIPTION
## What & why

Closes #170

`coverLetter.test.ts` only covered `letterFilename`. `substitutePlaceholders`
turns the user's saved template into the letter they actually download, with
no AI rewrite pass to catch a mistake — a broken substitution ships a literal
`{{company}}` or the previous employer's name.

Covers everything the issue called out:

- Each placeholder individually, and all three in one template
- Case-insensitive matching (`{{Company}}`, `{{ROLE}}`)
- Whitespace inside the braces (`{{ company }}`)
- Repeated placeholders (`g` flag)
- The deliberate empty-value behavior — an empty `company` leaves `{{company}}`
  visible rather than substituting a blank, which is the one the issue flagged
  as most likely to get "fixed" by accident
- The default-date fallback, with the clock pinned via `vi.useFakeTimers()` /
  `vi.setSystemTime()` (same pattern as `timeAgo.test.ts`) and asserted loosely
  (`toContain('2026')`) since `toLocaleDateString` output is locale-dependent
- An unknown placeholder (`{{name}}`) passing through untouched

No production code changes.

## How I tested

- `npm run lint`, `npm run typecheck`, `npm test` (186 passed), `npm run build` — all pass.
- Mutation-checked the two most fragile behaviors to confirm the tests actually
  bite rather than passing incidentally:
  - `map[key.toLowerCase()] || m` → `?? m` (empty string would silently
    substitute instead of leaving the placeholder) — fails exactly
    `leaves the placeholder visible when the value is empty...` with
    `expected '' to be '{{company}}'`.
  - Dropping `\s*` from the brace pattern — fails exactly
    `tolerates whitespace inside the braces`.

## Checklist

- [x] `npm run lint` passes
- [x] `npm run typecheck` passes
- [x] `npm test` passes
- [x] `npm run build` succeeds
- [x] Tests added/updated if behavior changed
- [x] No secrets, keys, or personal data committed