### PR TITLE
test(ai): add unit tests for isOnDeviceAvailable

### DIFF
--- a/src/lib/ai/onDevice.test.ts
+++ b/src/lib/ai/onDevice.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { OnDeviceProvider } from './onDevice';
+import { isOnDeviceAvailable, OnDeviceProvider } from './onDevice';
 
 function installLanguageModel(response = '{"ok":true}') {
   const prompt = vi.fn().mockResolvedValue(response);
@@ -7,6 +7,20 @@ function installLanguageModel(response = '{"ok":true}') {
   const create = vi.fn().mockResolvedValue({ prompt, destroy });
   vi.stubGlobal('self', { LanguageModel: { create } });
   return { create, destroy, prompt };
+}
+
+// Stubs just enough of `self` to exercise one availability/capabilities shape.
+// `global` lets a case target the older self.ai.languageModel path instead of
+// the newer top-level LanguageModel.
+function installAvailability(
+  shape: { availability?: () => unknown; capabilities?: () => unknown },
+  global: 'LanguageModel' | 'ai.languageModel' = 'LanguageModel',
+) {
+  const lm = { create: vi.fn(), ...shape };
+  vi.stubGlobal(
+    'self',
+    global === 'LanguageModel' ? { LanguageModel: lm } : { ai: { languageModel: lm } },
+  );
 }
 
 afterEach(() => {
@@ -42,5 +56,65 @@ describe('OnDeviceProvider', () => {
     });
 
     expect(prompt).toHaveBeenCalledWith('Why are you interested in this role?');
+  });
+});
+
+describe('isOnDeviceAvailable', () => {
+  it('is false when no on-device model global is present', async () => {
+    vi.stubGlobal('self', {});
+    expect(await isOnDeviceAvailable()).toBe(false);
+  });
+
+  it.each(['available', 'downloadable', 'downloading'])(
+    'is true when availability() reports "%s"',
+    async (status) => {
+      installAvailability({ availability: vi.fn().mockResolvedValue(status) });
+      expect(await isOnDeviceAvailable()).toBe(true);
+    },
+  );
+
+  it.each(['unavailable', 'no'])(
+    'is false when availability() reports "%s"',
+    async (status) => {
+      installAvailability({ availability: vi.fn().mockResolvedValue(status) });
+      expect(await isOnDeviceAvailable()).toBe(false);
+    },
+  );
+
+  it('falls back to capabilities() when availability() is absent', async () => {
+    installAvailability({ capabilities: vi.fn().mockResolvedValue({ available: 'readily' }) });
+    expect(await isOnDeviceAvailable()).toBe(true);
+  });
+
+  it('is false when capabilities() reports "no"', async () => {
+    installAvailability({ capabilities: vi.fn().mockResolvedValue({ available: 'no' }) });
+    expect(await isOnDeviceAvailable()).toBe(false);
+  });
+
+  it('prefers availability() over capabilities() when both are present', async () => {
+    // If this ever regresses to preferring capabilities(), a model that only
+    // reports readiness via availability() would be reported as false.
+    const capabilities = vi.fn().mockResolvedValue({ available: 'no' });
+    installAvailability({ availability: vi.fn().mockResolvedValue('available'), capabilities });
+    expect(await isOnDeviceAvailable()).toBe(true);
+    expect(capabilities).not.toHaveBeenCalled();
+  });
+
+  it('detects the older self.ai.languageModel global the same way', async () => {
+    installAvailability(
+      { availability: vi.fn().mockResolvedValue('available') },
+      'ai.languageModel',
+    );
+    expect(await isOnDeviceAvailable()).toBe(true);
+  });
+
+  it('is false, not a rejected promise, when availability() throws', async () => {
+    installAvailability({ availability: vi.fn().mockRejectedValue(new Error('boom')) });
+    await expect(isOnDeviceAvailable()).resolves.toBe(false);
+  });
+
+  it('is false, not a rejected promise, when capabilities() throws', async () => {
+    installAvailability({ capabilities: vi.fn().mockRejectedValue(new Error('boom')) });
+    await expect(isOnDeviceAvailable()).resolves.toBe(false);
   });
 });


### PR DESCRIPTION
## What & why

Closes #177

`onDevice.test.ts` only covered `OnDeviceProvider.generate`. `isOnDeviceAvailable`
decides whether Options offers Chrome's built-in on-device model as a choice at
all, and it had every branch untested: two feature-detection globals
(`LanguageModel` vs. the older `self.ai.languageModel`), two capability APIs
(`availability()` vs. `capabilities()`), and a catch-all swallowing any thrown
error into `false`.

Added `installAvailability()`, mirroring the existing `installLanguageModel`
helper's style, to stub just enough of `self` per case rather than duplicating
`vi.stubGlobal` calls inline.

Covers everything the issue listed, plus one extra branch-precedence case I
added because the code's `if (lm.availability) {...} if (lm.capabilities) {...}`
structure has an implicit precedence that wasn't otherwise exercised:

- No on-device global present → `false`
- `availability()` → `true` for `available`/`downloadable`/`downloading`,
  `false` for anything else
- `capabilities()` fallback (only used when `availability` is absent) — both
  directions
- **`availability()` takes precedence over `capabilities()` when both exist** —
  asserts `capabilities` is never called in that case
- The older `self.ai.languageModel` global is detected the same way as the
  newer `LanguageModel`
- A thrown error in either API resolves `false` rather than rejecting

No production code changes.

## How I tested

- `npm run lint`, `npm run typecheck`, `npm test` (201 passed), `npm run build` — all pass.
- Mutation-checked three behaviors to confirm the tests bite:
  - Narrowing the truthy `availability()` set to just `'available'` → fails the
    `downloadable`/`downloading` cases.
  - No longer swallowing thrown errors → fails both throw-handling tests.
  - Skipping the `availability()` branch entirely → fails 5 tests, including the
    precedence one.

## Checklist

- [x] `npm run lint` passes
- [x] `npm run typecheck` passes
- [x] `npm test` passes
- [x] `npm run build` succeeds
- [x] Tests added/updated if behavior changed
- [x] No secrets, keys, or personal data committed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage for on-device AI availability checks, including supported and unsupported environments.
  * Verified behavior across browser API paths, capability states, precedence rules, and error scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->