### PR TITLE
fix(popup): don't report already-correct fields as a fill failure

### DIFF
--- a/src/content/adapters/shared.ts
+++ b/src/content/adapters/shared.ts
@@ -160,6 +160,8 @@ function matchRule(label: string, el: FillableField): Rule | undefined {
 export interface FillSummary {
   filled: number;
   total: number;
+  /** Recognised fields left untouched because they already held a value. */
+  alreadyFilled: number;
 }
 
 /** Fills every recognised, empty field within `root`. */
@@ -170,6 +172,7 @@ export function applyStandardFills(profile: Profile, root: ParentNode = document
 
   let filled = 0;
   let total = 0;
+  let alreadyFilled = 0;
 
   for (const el of fields) {
     const label = getLabelText(el);
@@ -182,13 +185,16 @@ export function applyStandardFills(profile: Profile, root: ParentNode = document
     if (el instanceof HTMLSelectElement) {
       if (fillSelect(el, value)) filled++;
     } else {
-      if (el.value.trim()) continue; // don't clobber existing input
+      if (el.value.trim()) {
+        alreadyFilled++;
+        continue; // don't clobber existing input
+      }
       fillInput(el, value);
       filled++;
     }
   }
 
-  return { filled, total };
+  return { filled, total, alreadyFilled };
 }
 
 function isFillable(el: FillableField): boolean {

--- a/src/content/index.ts
+++ b/src/content/index.ts
@@ -70,9 +70,13 @@ chrome.runtime.onMessage.addListener((msg: ContentMessage, _sender, sendResponse
       .then((profile) => {
         const summary = applyStandardFills(profile);
         injectQuestionButtons();
-        sendResponse({ filled: summary.filled, total: summary.total } satisfies FillResult);
+        sendResponse({
+          filled: summary.filled,
+          total: summary.total,
+          alreadyFilled: summary.alreadyFilled,
+        } satisfies FillResult);
       })
-      .catch(() => sendResponse({ filled: 0, total: 0 } satisfies FillResult));
+      .catch(() => sendResponse({ filled: 0, total: 0, alreadyFilled: 0 } satisfies FillResult));
     return true;
   }
   return false;

--- a/src/lib/messages.ts
+++ b/src/lib/messages.ts
@@ -14,6 +14,8 @@ export interface PageInfo {
 export interface FillResult {
   filled: number;
   total: number;
+  /** Recognised fields left untouched because they already held a value. */
+  alreadyFilled: number;
 }
 
 // --- Background-handled (AI) ---

--- a/src/popup/Popup.tsx
+++ b/src/popup/Popup.tsx
@@ -49,6 +49,26 @@ export function saveJobNotice({
   return notices.length === 0 ? 'Job saved.' : `Saved — ${notices.join('; ')}.`;
 }
 
+/**
+ * Status line shown after "Fill this page". A field the extension recognised
+ * but left alone because it already held a value is not a failure — without
+ * this split, re-clicking Fill on an already-filled page reports "Filled 0 of
+ * N" at the exact moment nothing actually went wrong.
+ */
+export function fillNotice({
+  filled,
+  total,
+  alreadyFilled,
+}: {
+  filled: number;
+  total: number;
+  alreadyFilled: number;
+}): string {
+  const base = `Filled ${filled} of ${total} recognised field${total === 1 ? '' : 's'}.`;
+  if (alreadyFilled === 0) return base;
+  return `Filled ${filled} of ${total} — ${alreadyFilled} already had your details.`;
+}
+
 /** Compact "saved N ago" label for a saved job's timestamp. */
 export function timeAgo(ts: number): string {
   const secs = Math.max(0, Math.round((Date.now() - ts) / 1000));
@@ -235,7 +255,7 @@ const copyTimer = useRef<number | null>(null);
     setError('');
     try {
       const res = await sendToTab<FillResult>(tabId, { type: 'PAGE_FILL' });
-      flashFillMsg(`Filled ${res.filled} of ${res.total} recognised field${res.total === 1 ? '' : 's'}.`);
+      flashFillMsg(fillNotice(res));
     } catch {
       setError('Could not reach the page. Reload the job page and try again.');
     } finally {

--- a/src/popup/fillNotice.test.ts
+++ b/src/popup/fillNotice.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest';
+import { fillNotice } from './Popup';
+
+describe('fillNotice', () => {
+  it('reads unchanged when nothing was already filled', () => {
+    expect(fillNotice({ filled: 3, total: 5, alreadyFilled: 0 })).toBe(
+      'Filled 3 of 5 recognised fields.',
+    );
+  });
+
+  it('reports every field as already correct instead of "Filled 0 of N"', () => {
+    // The regression this exists for: re-clicking Fill on an already-filled
+    // page should not read as a total failure.
+    const msg = fillNotice({ filled: 0, total: 5, alreadyFilled: 5 });
+    expect(msg).toContain('Filled 0 of 5');
+    expect(msg).toContain('5 already had your details');
+  });
+
+  it('reports a mix of newly filled and already-correct fields', () => {
+    const msg = fillNotice({ filled: 2, total: 5, alreadyFilled: 3 });
+    expect(msg).toContain('Filled 2 of 5');
+    expect(msg).toContain('3 already had your details');
+  });
+
+  it('uses singular "field" only for a single recognised field', () => {
+    expect(fillNotice({ filled: 1, total: 1, alreadyFilled: 0 })).toBe(
+      'Filled 1 of 1 recognised field.',
+    );
+    expect(fillNotice({ filled: 0, total: 2, alreadyFilled: 0 })).toBe(
+      'Filled 0 of 2 recognised fields.',
+    );
+  });
+
+  it('is a plain "0 of 0" message when nothing on the page was recognised', () => {
+    expect(fillNotice({ filled: 0, total: 0, alreadyFilled: 0 })).toBe(
+      'Filled 0 of 0 recognised fields.',
+    );
+  });
+});


### PR DESCRIPTION
## What & why

Closes #181

`applyStandardFills` counted a recognised field toward `total` before the
guard that skips fields already holding the right value, so a field the
extension deliberately left alone still counted toward `total` but never
toward `filled`. Re-clicking **Fill this page** on an already-filled form (or
any form that arrives partially pre-filled — browser autofill, a returning
applicant, a saved draft) reported `Filled 0 of N recognised fields.` at the
exact moment nothing actually went wrong. Workday's multi-step wizard hits
this on a routine re-click, not as a corner case.

## What changed

- `FillSummary` (shared.ts) and `FillResult` (messages.ts) gain an
  `alreadyFilled` count, incremented exactly where the existing
  `el.value.trim()` guard bails — threaded through `content/index.ts`'s
  `PAGE_FILL` handler, which already copies the summary field by field.
- A pure `fillNotice()` helper in `Popup.tsx`, mirroring the existing
  `saveJobNotice` pattern, composes the status line:

  ```
  Filled 3 of 5 recognised fields.               (nothing pre-filled — unchanged)
  Filled 0 of 5 — 5 already had your details.    (all pre-filled)
  Filled 2 of 5 — 3 already had your details.    (mixed)
  ```

- `onFill` now calls `fillNotice(res)` instead of building the string inline.

A genuine miss — a field whose label matched no rule — is still invisible
either way (both counters skip it via `continue` before `total++`); that's an
existing, separate gap and out of scope here.

## Tests

`fillNotice.test.ts` follows the `saveJobNotice.test.ts` template: unchanged
message when nothing was pre-filled, the `0 of N` regression case, a mixed
case, singular/plural on `total === 1`, and the `total === 0` edge.
`applyStandardFills` itself needs a real DOM and the test env is `node`, so
per the issue's own scoping the pure helper is the only unit-tested seam.

## How I tested

- `npm run lint`, `npm run typecheck`, `npm test` (194 passed), `npm run build` — all pass.
- Mutation-checked `fillNotice`: reverting it to the old single-line message
  fails exactly the two tests meant to catch it —
  `expected 'Filled 0 of 5 recognised fields.' to contain '5 already had your details'`.

## Checklist

- [x] `npm run lint` passes
- [x] `npm run typecheck` passes
- [x] `npm test` passes
- [x] `npm run build` succeeds
- [x] Tests added/updated if behavior changed
- [x] No secrets, keys, or personal data committed