### PR TITLE
fix(documents): warn when uploads contain no text

### DIFF
--- a/src/lib/documents.test.ts
+++ b/src/lib/documents.test.ts
@@ -1,8 +1,10 @@
 import { describe, expect, it, vi } from 'vitest';
 
+const { getDocumentMock } = vi.hoisted(() => ({ getDocumentMock: vi.fn() }));
+
 vi.mock('pdfjs-dist', () => ({
   GlobalWorkerOptions: { workerSrc: '' },
-  getDocument: vi.fn(),
+  getDocument: getDocumentMock,
 }));
 vi.mock('pdfjs-dist/build/pdf.worker.min.mjs?url', () => ({ default: 'pdf.worker.mjs' }));
 vi.mock('mammoth', () => ({
@@ -39,6 +41,24 @@ describe('extractText', () => {
     await expect(extractText(file)).resolves.toEqual({
       text: '',
       warning: 'No text found in this file.',
+    });
+  });
+
+  it('preserves the specific warning for a PDF with no selectable text', async () => {
+    getDocumentMock.mockReturnValueOnce({
+      promise: Promise.resolve({
+        numPages: 1,
+        getPage: vi.fn().mockResolvedValue({
+          getTextContent: vi.fn().mockResolvedValue({ items: [] }),
+          getAnnotations: vi.fn().mockResolvedValue([]),
+        }),
+      }),
+    });
+    const file = new File([], 'resume.pdf', { type: 'application/pdf' });
+
+    await expect(extractText(file)).resolves.toEqual({
+      text: '',
+      warning: 'No selectable text found (scanned PDF?). Try a text-based PDF.',
     });
   });
 

--- a/src/lib/documents.test.ts
+++ b/src/lib/documents.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('pdfjs-dist', () => ({
+  GlobalWorkerOptions: { workerSrc: '' },
+  getDocument: vi.fn(),
+}));
+vi.mock('pdfjs-dist/build/pdf.worker.min.mjs?url', () => ({ default: 'pdf.worker.mjs' }));
+vi.mock('mammoth', () => ({
+  extractRawText: vi.fn().mockResolvedValue({ value: '' }),
+  convertToHtml: vi.fn().mockResolvedValue({ value: '' }),
+}));
+
+import { extractText } from './documents';
+
+describe('extractText', () => {
+  it('warns when a text file is empty', async () => {
+    const file = new File([], 'resume.txt', { type: 'text/plain' });
+
+    await expect(extractText(file)).resolves.toEqual({
+      text: '',
+      warning: 'No text found in this file.',
+    });
+  });
+
+  it('normalizes whitespace-only markdown before warning', async () => {
+    const file = new File(['  \n\t'], 'notes.md', { type: 'text/markdown' });
+
+    await expect(extractText(file)).resolves.toEqual({
+      text: '',
+      warning: 'No text found in this file.',
+    });
+  });
+
+  it('warns when a document has no extractable text', async () => {
+    const file = new File([], 'resume.docx', {
+      type: 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+    });
+
+    await expect(extractText(file)).resolves.toEqual({
+      text: '',
+      warning: 'No text found in this file.',
+    });
+  });
+
+  it('returns non-empty text without a warning', async () => {
+    const file = new File(['Experienced TypeScript developer'], 'resume.txt', {
+      type: 'text/plain',
+    });
+
+    await expect(extractText(file)).resolves.toEqual({
+      text: 'Experienced TypeScript developer',
+    });
+  });
+
+  it('preserves the specific warning for legacy documents', async () => {
+    const file = new File([], 'resume.doc', { type: 'application/msword' });
+
+    await expect(extractText(file)).resolves.toEqual({
+      text: '',
+      warning: 'Legacy .doc is not supported — please upload a PDF or .docx.',
+    });
+  });
+});

--- a/src/lib/documents.ts
+++ b/src/lib/documents.ts
@@ -15,15 +15,31 @@ export interface ExtractResult {
 
 export async function extractText(file: File): Promise<ExtractResult> {
   const name = file.name.toLowerCase();
-  if (name.endsWith('.pdf')) return extractPdf(file);
-  if (name.endsWith('.docx')) return extractDocx(file);
-  if (name.endsWith('.txt') || name.endsWith('.md') || file.type.startsWith('text/')) {
-    return { text: await file.text() };
+  let result: ExtractResult;
+
+  if (name.endsWith('.pdf')) {
+    result = await extractPdf(file);
+  } else if (name.endsWith('.docx')) {
+    result = await extractDocx(file);
+  } else if (
+    name.endsWith('.txt') ||
+    name.endsWith('.md') ||
+    file.type.startsWith('text/')
+  ) {
+    result = { text: await file.text() };
+  } else if (name.endsWith('.doc')) {
+    result = {
+      text: '',
+      warning: 'Legacy .doc is not supported — please upload a PDF or .docx.',
+    };
+  } else {
+    result = { text: '', warning: `Unsupported file type: ${file.name}` };
   }
-  if (name.endsWith('.doc')) {
-    return { text: '', warning: 'Legacy .doc is not supported — please upload a PDF or .docx.' };
+
+  if (!result.text.trim() && !result.warning) {
+    return { text: '', warning: 'No text found in this file.' };
   }
-  return { text: '', warning: `Unsupported file type: ${file.name}` };
+  return result;
 }
 
 async function extractPdf(file: File): Promise<ExtractResult> {


### PR DESCRIPTION
## What & why

Closes #206

Empty and whitespace-only text, Markdown, and DOCX uploads returned no text and no warning, so the upload UI silently stopped after extraction. This change routes every extraction path through a shared empty-text guard, normalizes whitespace-only output to an empty string, and returns a clear warning while preserving existing format-specific warnings.

Regression tests cover empty text, whitespace-only Markdown, empty DOCX extraction, non-empty text, and preservation of the legacy `.doc` warning.

## How I tested

- `npm test -- src/lib/documents.test.ts` — 6 passed
- `npm run lint`
- `npm run typecheck`
- `npm test` — 20 files / 195 tests passed
- `npm run build`

## Checklist

- [x] `npm run lint` passes
- [x] `npm run typecheck` passes
- [x] `npm test` passes
- [x] `npm run build` succeeds
- [x] Tests added/updated if behavior changed
- [x] No secrets, keys, or personal data committed
