### PR TITLE
chore(deps): bump github/codeql-action init+analyze to 4.37.6

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -21,13 +21,13 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4
+        uses: github/codeql-action/init@5595ccaf912efad79be6eef63a5619ff05969be3 # v4
         with:
           languages: javascript-typescript
           queries: security-and-quality
 
       # JS/TS is interpreted — no build step needed before analysis.
       - name: Perform CodeQL analysis
-        uses: github/codeql-action/analyze@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4
+        uses: github/codeql-action/analyze@5595ccaf912efad79be6eef63a5619ff05969be3 # v4
         with:
           category: '/language:javascript-typescript'


### PR DESCRIPTION
## What & why

Supersedes #212 (`init`) and #213 (`analyze`).

CodeQL requires `init` and `analyze` to run the **same** action version. Dependabot
bumps one path per PR and has no way to know these two are coupled, so each PR
alone leaves a mismatched pair and the `Analyze (javascript-typescript)` job
fails — both #212 and #213 are permanently red on their own and neither can ever
land.

Both refs move to the same SHA (`5595ccaf...`, v4.37.6) in one commit, which is
the only way either bump can go green.

Same class of problem as the ESLint coupling handled in #191.

## How I tested

CI on this PR is the test — the `Analyze` job passing is exactly what fails on
the two split PRs.

## Checklist

- [x] No secrets, keys, or personal data committed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the security analysis workflow to use newer pinned CodeQL action revisions.
  * CodeQL languages, queries, analysis category, and workflow behavior remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->