### PR TITLE
Fix blank metadata overwrites when re-saving jobs

### DIFF
--- a/src/lib/savedJobs.test.ts
+++ b/src/lib/savedJobs.test.ts
@@ -195,6 +195,18 @@ describe('addJob — duplicate URL', () => {
     expect(jobs[0].text).toBe('original posting');
   });
 
+  it('preserves known company and role when a duplicate capture has blank metadata', async () => {
+    seed({
+      jobs: [job({ id: 'existing', company: 'Acme', role: 'Engineer' })],
+      activeId: null,
+    });
+
+    const { jobs } = await addJob({ ...partial('fresh capture'), company: '', role: '' });
+
+    expect(jobs[0]).toMatchObject({ company: 'Acme', role: 'Engineer' });
+    expect(persisted().jobs[0]).toMatchObject({ company: 'Acme', role: 'Engineer' });
+  });
+
   it('does not evict another job when the capped list already contains the URL', async () => {
     const existing = Array.from({ length: MAX_JOBS }, (_, i) =>
       job({ id: `old-${i}`, url: `https://old/${i}` }),

--- a/src/lib/savedJobs.ts
+++ b/src/lib/savedJobs.ts
@@ -79,6 +79,8 @@ export async function addJob(
       // Re-saving from a later application step can capture form boilerplate.
       // Keep the known-good posting text instead of silently degrading it.
       text: existing.text,
+      company: partial.company || existing.company,
+      role: partial.role || existing.role,
       savedAt: Date.now(),
     };
     // Also heal duplicates created by releases that always minted a new id.


### PR DESCRIPTION
Closes #198.

## Summary

- preserve the existing company and role when a duplicate capture provides blank metadata
- continue accepting non-empty company and role updates for duplicate captures
- add regression coverage for both the returned and persisted saved-job state

## Verification

- `npm test -- src/lib/savedJobs.test.ts` (33 passed)
- `npm test` (218 passed)
- `npm run lint`
- `npm run typecheck`
- `npm run build`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved existing company and role details when refreshing a saved job with blank incoming metadata.
  * Ensured saved job information remains consistent both in the app and after persistence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->