### PR TITLE
fix(options): handle failed profile auto-save gracefully

### DIFF
--- a/src/options/Options.tsx
+++ b/src/options/Options.tsx
@@ -12,7 +12,7 @@ import { AIError } from '../lib/ai';
 import { signIn, signOut, reconcileAuthUser, onAuthChanged, getCachedToken, type AuthUser } from '../lib/auth';
 
 export function Options() {
-  const { profile, loaded, saveState, update } = useProfile();
+  const { profile, loaded, saveState, saveError, update } = useProfile();
 
   if (!loaded) return <div className="options">Loading…</div>;
 
@@ -28,6 +28,7 @@ export function Options() {
     <OptionsView
       p={p}
       saveState={saveState}
+      saveError={saveError}
       setPersonal={setPersonal}
       setPref={setPref}
       setAI={setAI}
@@ -39,6 +40,7 @@ export function Options() {
 function OptionsView({
   p,
   saveState,
+  saveError,
   setPersonal,
   setPref,
   setAI,
@@ -46,6 +48,7 @@ function OptionsView({
 }: {
   p: Profile;
   saveState: ReturnType<typeof useProfile>['saveState'];
+  saveError: ReturnType<typeof useProfile>['saveError'];
   setPersonal: (k: keyof Profile['personal'], v: string) => void;
   setPref: (k: keyof Profile['preferences'], v: string) => void;
   setAI: (k: keyof Profile['ai'], v: string) => void;
@@ -172,6 +175,7 @@ function OptionsView({
         <h1 style={{ flex: 1 }}>Little AI Helper — Settings</h1>
         {saveState === 'saving' && <span className="help">Saving…</span>}
         {saveState === 'saved' && <span className="saved">✓ Saved</span>}
+        {saveState === 'error' && saveError && <span className="warn">{saveError}</span>}
       </div>
       <p className="sub">
         Everything here stays on this device (local storage). Your API key is only sent to your

--- a/src/ui/useProfile.ts
+++ b/src/ui/useProfile.ts
@@ -1,7 +1,15 @@
 import { useEffect, useRef, useState } from 'react';
 import { DEFAULT_PROFILE, getProfile, onProfileChanged, saveProfile, type Profile } from '../lib/profile';
 
-export type SaveState = 'idle' | 'saving' | 'saved';
+export type SaveState = 'idle' | 'saving' | 'saved' | 'error';
+
+function profileSaveErrorMessage(err: unknown): string {
+  const msg = err instanceof Error ? err.message : String(err);
+  if (/quota/i.test(msg)) {
+    return 'Could not save — local storage is full. Remove an uploaded document to free space, then edit again.';
+  }
+  return `Could not save — ${msg}`;
+}
 
 /**
  * Loads the profile and auto-saves edits (debounced). External changes (e.g.
@@ -11,6 +19,7 @@ export function useProfile() {
   const [profile, setProfile] = useState<Profile>(DEFAULT_PROFILE);
   const [loaded, setLoaded] = useState(false);
   const [saveState, setSaveState] = useState<SaveState>('idle');
+  const [saveError, setSaveError] = useState('');
   const saveTimer = useRef<number | undefined>(undefined);
   const editing = useRef(false);
 
@@ -29,16 +38,23 @@ export function useProfile() {
     setProfile((prev) => {
       const next = updater(prev);
       setSaveState('saving');
+      setSaveError('');
       window.clearTimeout(saveTimer.current);
       saveTimer.current = window.setTimeout(async () => {
-        await saveProfile(next);
-        setSaveState('saved');
-        editing.current = false;
-        window.setTimeout(() => setSaveState('idle'), 1500);
+        try {
+          await saveProfile(next);
+          setSaveState('saved');
+          window.setTimeout(() => setSaveState('idle'), 1500);
+        } catch (err) {
+          setSaveState('error');
+          setSaveError(profileSaveErrorMessage(err));
+        } finally {
+          editing.current = false;
+        }
       }, 500);
       return next;
     });
   }
 
-  return { profile, loaded, saveState, update, setProfile };
+  return { profile, loaded, saveState, saveError, update, setProfile };
 }


### PR DESCRIPTION
Wrap debounced saveProfile in try/catch/finally so a storage quota failure shows an actionable error instead of stuck "Saving…", and editing.current is always cleared so external profile sync works again.

Fixes #187

<!-- Thanks for contributing! Keep PRs small and focused — one change per PR. -->

## What & why

<!-- What does this change do, and what problem does it solve? Link any related issue: "Closes #123". -->

## How I tested

<!-- e.g. loaded the unpacked extension and reproduced the fix on a real job page, added/updated tests. -->

## Checklist

- [ ] `npm run lint` passes
- [ ] `npm run typecheck` passes
- [ ] `npm test` passes
- [ ] `npm run build` succeeds
- [ ] Tests added/updated if behavior changed
- [ ] No secrets, keys, or personal data committed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Profile save failures are now detected and clearly displayed in the options screen.
  * Added a specific message when saving fails because local storage is full.
  * Saving state now resets correctly after both successful and failed attempts.
  * Previous save errors are cleared when a new save begins.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->