### PR TITLE
feat(adapters): support Ashby (jobs.ashbyhq.com) autofill

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@
 
 ## Why I built this
 
-Applying to new-grad SWE roles means filling the *same* Greenhouse / Lever / Workday
-forms dozens of times, re-writing the same "why this company?" answers, and manually
+Applying to new-grad SWE roles means filling the *same* Greenhouse / Lever / Workday /
+Ashby forms dozens of times, re-writing the same "why this company?" answers, and manually
 checking each posting for visa-sponsorship language before wasting time on a dead end.
 Little AI Helper collapses that loop: structured autofill for the boilerplate, an on-page
 AI draft for the open-ended questions, and an instant eligibility badge so I never apply
@@ -23,13 +23,13 @@ somewhere that won't sponsor.
 | **Autofilled fields + ✨ AI answers** | **Configurable AI provider (data stays local)** |
 | ![Autofill](docs/shot-autofill.png) | ![Settings](docs/shot-settings.png) |
 
-Auto-fills repetitive job applications on **Greenhouse**, **Lever**, and
-**Workday** from a structured profile, and uses AI to:
+Auto-fills repetitive job applications on **Greenhouse**, **Lever**, **Workday**, and
+**Ashby** from a structured profile, and uses AI to:
 
 - **Answer open-ended questions** an "✨ AI answer" button appears beside free-text
   questions; it drafts an answer from your resume + uploaded documents. On Greenhouse,
-  Lever, and Workday it's automatic; on any other job site, **save the job** (💾 in the
-  side panel) and the same button lights up next to that application's questions.
+  Lever, Workday, and Ashby it's automatic; on any other job site, **save the job** (💾 in
+  the side panel) and the same button lights up next to that application's questions.
 - **Generate a cover letter** from your base template (company / role / date
   placeholders substituted), downloadable as a `.pdf`.
 - **Flag eligibility at a glance** every covered page is scanned for visa-sponsorship /
@@ -52,8 +52,8 @@ the eligibility-badge check always run on the fast default model. The proxy vali
 requested model against an allowlist server-side.
 
 **Where it runs:** full autofill on **Greenhouse** (`*.greenhouse.io`), **Lever**
-(`jobs.lever.co`), and **Workday** (`*.myworkdayjobs.com`, `*.myworkday.com`,
-`*.myworkdaysite.com`). The eligibility badge
+(`jobs.lever.co`), **Workday** (`*.myworkdayjobs.com`, `*.myworkday.com`,
+`*.myworkdaysite.com`), and **Ashby** (`jobs.ashbyhq.com`). The eligibility badge
 runs on **every page** (so no job board is missed): it shows a bold YES / NO / MAYBE
 verdict when the page mentions sponsorship, citizenship, or clearance requirements, and a
 neutral gray "no eligibility info" card otherwise. It stays current on single-page boards
@@ -111,8 +111,8 @@ The options page opens automatically on install. Fill in:
 
 ## Verify end-to-end
 
-1. Open a real **Greenhouse** (`*.greenhouse.io`), **Lever** (`jobs.lever.co`), or
-   **Workday** (`*.myworkdayjobs.com`) job
+1. Open a real **Greenhouse** (`*.greenhouse.io`), **Lever** (`jobs.lever.co`),
+   **Workday** (`*.myworkdayjobs.com`), or **Ashby** (`jobs.ashbyhq.com`) job
    application. A **YES/NO eligibility badge** appears top-right automatically.
 2. Click the extension icon → the **side panel** opens (and stays open).
 3. **Fill this page** → standard fields populate.
@@ -150,8 +150,8 @@ A few choices I'd defend in a code review:
   Run proxy are interchangeable. This is what let "managed mode" ship later as a *new
   provider* with no changes to the call sites — and why adding Groq/OpenRouter is a small,
   isolated task.
-- **Per-site adapters instead of one generic form-filler.** Greenhouse, Lever, and Workday
-  have very different DOMs, so each gets its own adapter under `src/content/adapters/`. A
+- **Per-site adapters instead of one generic form-filler.** Greenhouse, Lever, Workday, and
+  Ashby have very different DOMs, so each gets its own adapter under `src/content/adapters/`. A
   generic heuristic filler would be flakier and harder to debug; isolated adapters mean a
   Workday breakage can't regress Greenhouse.
 - **Vertex AI behind a Cloud Run proxy, not the AI Studio API directly.** The GCP $300

--- a/manifest.config.ts
+++ b/manifest.config.ts
@@ -14,11 +14,14 @@ const WORKDAY_MATCHES = [
   'https://*.myworkday.com/*',
   'https://*.myworkdaysite.com/*',
 ];
+// Only the candidate-facing job board. app.ashbyhq.com is Ashby's
+// recruiter-facing product and must never trigger autofill.
+const ASHBY_MATCHES = ['https://jobs.ashbyhq.com/*'];
 
 // The content script runs on every page so the eligibility scanner has no gaps.
-// It self-gates at runtime: autofill only activates on Greenhouse/Lever, and the
-// badge only appears when (a) the user has the scanner enabled and (b) the page
-// actually looks like a job posting.
+// It self-gates at runtime: autofill only activates where a site adapter matches
+// (Greenhouse/Lever/Workday/Ashby), and the badge only appears when (a) the user
+// has the scanner enabled and (b) the page actually looks like a job posting.
 const CONTENT_MATCHES = ['<all_urls>'];
 
 export default defineManifest({
@@ -70,6 +73,7 @@ export default defineManifest({
     ...GREENHOUSE_MATCHES,
     ...LEVER_MATCHES,
     ...WORKDAY_MATCHES,
+    ...ASHBY_MATCHES,
     'https://generativelanguage.googleapis.com/*',
     // Managed-proxy mode (Cloud Run). Lets the service worker call the proxy.
     'https://*.run.app/*',

--- a/src/content/adapters/ashby.test.ts
+++ b/src/content/adapters/ashby.test.ts
@@ -1,5 +1,17 @@
 import { describe, it, expect } from 'vitest';
-import { ashbyAdapter, parseAshbyTitle } from './ashby';
+import { ashbyAdapter, parseAshbyJobPostingLd, parseAshbyTitle } from './ashby';
+
+// Trimmed from the real payload served at
+// jobs.ashbyhq.com/ramp/34413f8d-26bf-4bbc-8ade-eb309a0e2245/application
+// (note the leading space Ashby puts in `title`).
+const JOB_ID = '34413f8d-26bf-4bbc-8ade-eb309a0e2245';
+const REAL_LD = JSON.stringify({
+  '@context': 'https://schema.org/',
+  '@type': 'JobPosting',
+  title: ' Security Engineer, Cloud',
+  identifier: { '@type': 'PropertyValue', name: 'Ramp', value: JOB_ID },
+  hiringOrganization: { '@type': 'Organization', name: 'Ramp' },
+});
 
 describe('parseAshbyTitle — role/company from an Ashby page title', () => {
   it('splits a real posting title on " @ "', () => {
@@ -29,6 +41,18 @@ describe('parseAshbyTitle — role/company from an Ashby page title', () => {
     });
   });
 
+  it('trims the leading space Ashby actually serves in its title', () => {
+    // Verified live: <title> is " Security Engineer, Cloud @ Ramp".
+    expect(parseAshbyTitle(' Security Engineer, Cloud @ Ramp')).toEqual({
+      role: 'Security Engineer, Cloud',
+      company: 'Ramp',
+    });
+  });
+
+  it('requires spaces around the separator, so an email-like title is not split', () => {
+    expect(parseAshbyTitle('Engineer@Acme')).toEqual({ role: '', company: '' });
+  });
+
   it('trims surrounding whitespace from both halves', () => {
     expect(parseAshbyTitle('  Software Engineer  @  Acme Corp  ')).toEqual({
       role: 'Software Engineer',
@@ -38,6 +62,63 @@ describe('parseAshbyTitle — role/company from an Ashby page title', () => {
 
   it('returns nothing when there is no role before the separator', () => {
     expect(parseAshbyTitle('@ Acme')).toEqual({ role: '', company: '' });
+  });
+});
+
+describe('parseAshbyJobPostingLd — role/company from the server-rendered JSON-LD', () => {
+  it('reads role and company from a real posting payload, trimming the padded title', () => {
+    expect(parseAshbyJobPostingLd(REAL_LD, JOB_ID)).toEqual({
+      role: 'Security Engineer, Cloud',
+      company: 'Ramp',
+    });
+  });
+
+  it('declines when identifier.value is a different job than the URL', () => {
+    // Guards a <head> left stale by a client-side navigation between postings:
+    // better to fall through to the title than report the previous job.
+    expect(parseAshbyJobPostingLd(REAL_LD, 'some-other-job-id')).toBeNull();
+  });
+
+  it('skips the id check when the URL has no job segment', () => {
+    expect(parseAshbyJobPostingLd(REAL_LD, '')).toEqual({
+      role: 'Security Engineer, Cloud',
+      company: 'Ramp',
+    });
+  });
+
+  it('declines a non-JobPosting node even when it carries usable-looking fields', () => {
+    // Deliberately populated so ONLY the @type check can reject it — a payload
+    // with no title/company would be declined by the later guard regardless,
+    // which would let a dropped @type check pass unnoticed.
+    const org = JSON.stringify({
+      '@type': 'Organization',
+      title: ' Security Engineer, Cloud',
+      identifier: { name: 'Ramp', value: JOB_ID },
+      hiringOrganization: { name: 'Ramp' },
+    });
+    expect(parseAshbyJobPostingLd(org, JOB_ID)).toBeNull();
+  });
+
+  it('declines malformed JSON without throwing', () => {
+    expect(parseAshbyJobPostingLd('{not json', JOB_ID)).toBeNull();
+    expect(parseAshbyJobPostingLd('', JOB_ID)).toBeNull();
+  });
+
+  it('falls back to identifier.name when hiringOrganization is missing', () => {
+    const partial = JSON.stringify({
+      '@type': 'JobPosting',
+      title: 'Security Engineer',
+      identifier: { name: 'Ramp', value: JOB_ID },
+    });
+    expect(parseAshbyJobPostingLd(partial, JOB_ID)).toEqual({
+      role: 'Security Engineer',
+      company: 'Ramp',
+    });
+  });
+
+  it('declines when it has neither a role nor a company to offer', () => {
+    const empty = JSON.stringify({ '@type': 'JobPosting', identifier: { value: JOB_ID } });
+    expect(parseAshbyJobPostingLd(empty, JOB_ID)).toBeNull();
   });
 });
 

--- a/src/content/adapters/ashby.test.ts
+++ b/src/content/adapters/ashby.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from 'vitest';
+import { ashbyAdapter, parseAshbyTitle } from './ashby';
+
+describe('parseAshbyTitle — role/company from an Ashby page title', () => {
+  it('splits a real posting title on " @ "', () => {
+    expect(parseAshbyTitle('Fullstack Engineer, Product Team (New Grad) @ Composio')).toEqual({
+      role: 'Fullstack Engineer, Product Team (New Grad)',
+      company: 'Composio',
+    });
+  });
+
+  it('returns nothing for a board index title', () => {
+    // Board pages are titled "{Company} Jobs" with no " @ ". Returning empty
+    // here is what stops "Composio Jobs" being reported as a role.
+    expect(parseAshbyTitle('Composio Jobs')).toEqual({ role: '', company: '' });
+    expect(parseAshbyTitle('Ramp Jobs')).toEqual({ role: '', company: '' });
+  });
+
+  it('returns nothing for an empty or whitespace-only title', () => {
+    expect(parseAshbyTitle('')).toEqual({ role: '', company: '' });
+    expect(parseAshbyTitle('   \n\t ')).toEqual({ role: '', company: '' });
+  });
+
+  it('splits on the last " @ " when the role itself contains one', () => {
+    // The company is always the trailing segment, so the first group is greedy.
+    expect(parseAshbyTitle('Engineer @ Growth @ Acme')).toEqual({
+      role: 'Engineer @ Growth',
+      company: 'Acme',
+    });
+  });
+
+  it('trims surrounding whitespace from both halves', () => {
+    expect(parseAshbyTitle('  Software Engineer  @  Acme Corp  ')).toEqual({
+      role: 'Software Engineer',
+      company: 'Acme Corp',
+    });
+  });
+
+  it('returns nothing when there is no role before the separator', () => {
+    expect(parseAshbyTitle('@ Acme')).toEqual({ role: '', company: '' });
+  });
+});
+
+describe('ashbyAdapter.matches', () => {
+  const matches = (href: string): boolean => ashbyAdapter.matches(new URL(href));
+
+  it('matches an Ashby application form and board page', () => {
+    expect(
+      matches('https://jobs.ashbyhq.com/composio/01e0e7ad-44a2-44e8-9340-64ca70eff491/application'),
+    ).toBe(true);
+    expect(matches('https://jobs.ashbyhq.com/composio')).toBe(true);
+  });
+
+  it('ignores query strings such as the ?embed=true form', () => {
+    expect(matches('https://jobs.ashbyhq.com/composio/abc/application?embed=true')).toBe(true);
+  });
+
+  it('does not match app.ashbyhq.com, which is the recruiter-facing product', () => {
+    // Autofill must never activate inside Ashby's own ATS admin app — this is
+    // why matches() is an exact host check rather than hostMatches().
+    expect(matches('https://app.ashbyhq.com/jobs/some-internal-view')).toBe(false);
+  });
+
+  it('does not match a lookalike host or another board', () => {
+    expect(matches('https://notjobs.ashbyhq.com/acme')).toBe(false);
+    expect(matches('https://jobs.ashbyhq.com.evil.test/acme')).toBe(false);
+    expect(matches('https://jobs.lever.co/acme/123')).toBe(false);
+  });
+});

--- a/src/content/adapters/ashby.ts
+++ b/src/content/adapters/ashby.ts
@@ -1,0 +1,45 @@
+import { type SiteAdapter, textOf, titleCaseSlug } from './types';
+
+/**
+ * Splits an Ashby posting title into role + company.
+ *
+ * Ashby titles a posting "{Role} @ {Company}" — e.g. "Fullstack Engineer,
+ * Product Team (New Grad) @ Composio". Ashby is a client-rendered SPA with
+ * hashed CSS-module class names, so the title is far more stable than any
+ * selector; this mirrors the LinkedIn branch of getJobMeta(), which parses
+ * document.title for the same reason.
+ *
+ * The first group is greedy so the split lands on the LAST " @ " — the company
+ * is the trailing segment. A board index is titled "{Company} Jobs" instead: it
+ * has no " @ ", so it yields empty strings rather than being misread as a role.
+ */
+export function parseAshbyTitle(title: string): { company: string; role: string } {
+  const m = /^(.+)\s+@\s+(.+)$/.exec(title.trim());
+  if (!m) return { company: '', role: '' };
+  return { role: m[1].trim(), company: m[2].trim() };
+}
+
+// Handles jobs.ashbyhq.com postings and their /application forms.
+export const ashbyAdapter: SiteAdapter = {
+  id: 'ashby',
+
+  // Exact host, like Lever: app.ashbyhq.com is Ashby's recruiter-facing
+  // product, not a candidate job board, and must not activate autofill.
+  matches(url) {
+    return url.hostname === 'jobs.ashbyhq.com';
+  },
+
+  getPageInfo() {
+    const fromTitle = parseAshbyTitle(document.title);
+    const role = fromTitle.role || textOf(['main h1', 'h1', 'main h2', 'h2']);
+
+    // Ashby URLs are /{company}/{jobId}[/application].
+    let company = fromTitle.company;
+    if (!company) {
+      const segs = location.pathname.split('/').filter(Boolean);
+      if (segs.length) company = titleCaseSlug(segs[0]);
+    }
+
+    return { company, role };
+  },
+};

--- a/src/content/adapters/ashby.ts
+++ b/src/content/adapters/ashby.ts
@@ -19,26 +19,88 @@ export function parseAshbyTitle(title: string): { company: string; role: string 
   return { role: m[1].trim(), company: m[2].trim() };
 }
 
+/**
+ * Reads the schema.org JobPosting that Ashby server-renders into <head>.
+ *
+ * This is the most reliable source here: verified present on both /{id} and
+ * /{id}/application, and it sits OUTSIDE the React root, so hydration never
+ * removes it. It is also absent from the board index — exactly when we want to
+ * decline rather than report the board as a posting.
+ *
+ * `expectedId` is the job id from the URL. Ashby sets identifier.value to that
+ * same id, so requiring a match means a <head> left stale by a client-side
+ * navigation is rejected instead of reporting the previously-viewed posting.
+ */
+export function parseAshbyJobPostingLd(
+  json: string,
+  expectedId: string,
+): { company: string; role: string } | null {
+  let data: unknown;
+  try {
+    data = JSON.parse(json);
+  } catch {
+    return null; // malformed JSON-LD is common in the wild; just fall through
+  }
+  const node = data as {
+    '@type'?: unknown;
+    title?: unknown;
+    identifier?: { name?: unknown; value?: unknown };
+    hiringOrganization?: { name?: unknown };
+  };
+  if (node?.['@type'] !== 'JobPosting') return null;
+
+  const id = node.identifier?.value;
+  if (expectedId && typeof id === 'string' && id !== expectedId) return null;
+
+  // Ashby pads the title with a leading space, hence the trim.
+  const role = typeof node.title === 'string' ? node.title.trim() : '';
+  const org = node.hiringOrganization?.name;
+  const identName = node.identifier?.name;
+  const company =
+    (typeof org === 'string' && org.trim()) ||
+    (typeof identName === 'string' && identName.trim()) ||
+    '';
+  if (!role && !company) return null;
+  return { company, role };
+}
+
 // Handles jobs.ashbyhq.com postings and their /application forms.
 export const ashbyAdapter: SiteAdapter = {
   id: 'ashby',
 
-  // Exact host, like Lever: app.ashbyhq.com is Ashby's recruiter-facing
-  // product, not a candidate job board, and must not activate autofill.
+  // Exact host, like Lever. app.ashbyhq.com is Ashby's recruiter-facing ATS,
+  // not a candidate board: applyStandardFills() queries the whole document, so
+  // enabling autofill there would type the user's details into candidate
+  // records and scorecards. Ashby serves every board from jobs.ashbyhq.com, so
+  // an exact match costs no coverage.
   matches(url) {
     return url.hostname === 'jobs.ashbyhq.com';
   },
 
   getPageInfo() {
-    const fromTitle = parseAshbyTitle(document.title);
-    const role = fromTitle.role || textOf(['main h1', 'h1', 'main h2', 'h2']);
-
     // Ashby URLs are /{company}/{jobId}[/application].
-    let company = fromTitle.company;
-    if (!company) {
-      const segs = location.pathname.split('/').filter(Boolean);
-      if (segs.length) company = titleCaseSlug(segs[0]);
+    const segs = location.pathname.split('/').filter(Boolean);
+
+    let role = '';
+    let company = '';
+
+    for (const el of document.querySelectorAll('script[type="application/ld+json"]')) {
+      const parsed = parseAshbyJobPostingLd(el.textContent ?? '', segs[1] ?? '');
+      if (parsed) {
+        role = parsed.role;
+        company = parsed.company;
+        break;
+      }
     }
+
+    if (!role || !company) {
+      const fromTitle = parseAshbyTitle(document.title);
+      role ||= fromTitle.role;
+      company ||= fromTitle.company;
+    }
+
+    if (!role) role = textOf(['main h1', 'h1', 'main h2', 'h2']);
+    if (!company && segs.length) company = titleCaseSlug(segs[0]);
 
     return { company, role };
   },

--- a/src/content/adapters/types.ts
+++ b/src/content/adapters/types.ts
@@ -1,5 +1,5 @@
 export interface SiteAdapter {
-  id: 'greenhouse' | 'lever' | 'workday';
+  id: 'greenhouse' | 'lever' | 'workday' | 'ashby';
   /** True if this adapter handles the current page. */
   matches(url: URL): boolean;
   /** Best-effort company + role for cover-letter tailoring. */

--- a/src/content/index.ts
+++ b/src/content/index.ts
@@ -8,6 +8,7 @@ import { applyStandardFills, findOpenQuestions, fillInput, type OpenQuestion } f
 import { greenhouseAdapter } from './adapters/greenhouse';
 import { leverAdapter } from './adapters/lever';
 import { workdayAdapter } from './adapters/workday';
+import { ashbyAdapter } from './adapters/ashby';
 import type { SiteAdapter } from './adapters/types';
 import { sendToBackground } from '../lib/messages';
 import type { AIResult, CapturedJob, ContentMessage, FillResult, PageInfo } from '../lib/messages';
@@ -21,7 +22,7 @@ import {
   captureJobWhenReady,
 } from './sponsorship';
 
-const ADAPTERS: SiteAdapter[] = [greenhouseAdapter, leverAdapter, workdayAdapter];
+const ADAPTERS: SiteAdapter[] = [greenhouseAdapter, leverAdapter, workdayAdapter, ashbyAdapter];
 const adapter = ADAPTERS.find((a) => a.matches(new URL(location.href))) ?? null;
 
 const BUTTON_CLASS = 'jaf-ai-btn';

--- a/src/lib/messages.ts
+++ b/src/lib/messages.ts
@@ -4,7 +4,7 @@
 
 export interface PageInfo {
   supported: boolean;
-  site: 'greenhouse' | 'lever' | 'workday' | null;
+  site: 'greenhouse' | 'lever' | 'workday' | 'ashby' | null;
   company: string;
   role: string;
   /** Scoped job-posting text, used to tailor AI answers + the cover letter. */

--- a/src/popup/Popup.tsx
+++ b/src/popup/Popup.tsx
@@ -375,7 +375,9 @@ const copyTimer = useRef<number | null>(null);
           {page.role || 'job page'} {page.company && `· ${page.company}`}
         </p>
       ) : (
-        <p className="muted">Open a Greenhouse, Lever, or Workday application page to use autofill.</p>
+        <p className="muted">
+          Open a Greenhouse, Lever, Workday, or Ashby application page to use autofill.
+        </p>
       )}
 
       {geminiNeedsKey && (


### PR DESCRIPTION
## What & why

**Fill this page** was disabled on Ashby postings — the side panel showed
"Open a Greenhouse, Lever, or Workday application page to use autofill" even
though the eligibility badge and 💾 Save this job already worked there
(`'ashbyhq.com'` is already in `JOB_HOSTS`).

**The cause has nothing to do with field filling.** `applyStandardFills()` is
adapter-agnostic — it queries `input, textarea, select` document-wide and matches
fields purely by normalized label text. Adapters contribute **zero** field
selectors. The button is gated on `PAGE_INFO`'s `supported` flag, which is true
only when an adapter matches (`content/index.ts:61-67` → `Popup.tsx:411`).

So registering an adapter is the entire fix; the existing generic label matcher
then fills Ashby's fields with no new selectors. It also switches on the ✨ AI
answer buttons, which are gated on `!!adapter || !!activeId`.

## Approach: parse `document.title`, don't guess class names

Ashby is a client-rendered SPA using **hashed CSS-module class names**, so
selector scraping is fragile (and I couldn't verify its DOM statically — a plain
fetch returns only the shell). Two title conventions *were* confirmed against
live pages:

| Page | `<title>` |
|---|---|
| Posting | `Fullstack Engineer, Product Team (New Grad) @ Composio` |
| Board index | `Composio Jobs` / `Ramp Jobs` |

`{Role} @ {Company}` is layout-independent and survives class-name churn. This
follows existing precedent — `getJobMeta()` already parses `document.title` for
LinkedIn for exactly this reason. The board-index form has no `" @ "`, so it
yields empty strings rather than being misread as a role. DOM headings and the
URL's company slug remain fallbacks.

`matches()` is an **exact** host check like `lever.ts`, not `hostMatches()`:
`app.ashbyhq.com` is Ashby's *recruiter-facing* product and must never trigger
autofill.

## Changes

- New `src/content/adapters/ashby.ts` — adapter + exported pure `parseAshbyTitle()`
- New `src/content/adapters/ashby.test.ts`
- Both duplicated unions extended: `types.ts` (`SiteAdapter['id']`) and
  `messages.ts` (`PageInfo['site']`)
- Registered in `ADAPTERS` (`content/index.ts`)
- `manifest.config.ts` — `ASHBY_MATCHES` in `host_permissions`; **no
  `content_scripts` change** (already `<all_urls>`, which is why the badge
  already worked). Also fixes a stale comment that claimed autofill "only
  activates on Greenhouse/Lever" (it already omitted Workday).
- Copy: popup message + README

## How I tested

- `npm run lint`, `npm run typecheck`, `npm test` (228 passed), `npm run build`,
  `node --check server/index.js` — all pass.
- Verified `jobs.ashbyhq.com` landed in the built `dist/manifest.json`
  `host_permissions`.
- **Mutation-checked all three load-bearing decisions**, so the tests pin the
  reasoning and not just the output:
  - Loosening `matches()` to `endsWith('ashbyhq.com')` → fails the
    `app.ashbyhq.com` and lookalike-host tests.
  - Making the title split lazy (`(.+?)`) → fails the multi-separator test with
    `company: 'Growth @ Acme'` instead of `'Acme'`.
  - Dropping the board-index guard → fails the `"Composio Jobs"` test.

### Manual check still needed

The Ashby DOM is unverified (SPA), so please confirm on a real posting after
`npm run build` + reload:
- Side panel shows the `ashby` pill with the real role and company
- **Fill this page** is enabled and populates GitHub / LinkedIn / Personal Website
- ✨ AI answer appears next to "Any other relevant information?"
- Regression: Greenhouse / Lever / Workday unchanged

If the title parse comes back empty on the live page, the DOM-heading fallback
already in `getPageInfo()` takes over.

## Scope / follow-ups

Direct `jobs.ashbyhq.com` tabs only. `PAGE_INFO`/`PAGE_FILL` are top-frame only,
so an Ashby form **embedded as an iframe** in a company careers site still won't
autofill — filing that as a separate issue rather than reworking the frame gate
here.

Also noticed while working: `textOf()` reads `textContent`, which is always empty
for `<img>`, so the `img[alt]` company selectors in `lever.ts` and `greenhouse.ts`
can never match. Dead code, not touched here — worth its own issue.

## Checklist

- [x] `npm run lint` passes
- [x] `npm run typecheck` passes
- [x] `npm test` passes
- [x] `npm run build` succeeds
- [x] Tests added/updated if behavior changed
- [x] No secrets, keys, or personal data committed