### PR TITLE
Fix company detection from image alt text

### DIFF
--- a/src/content/adapters/types.test.ts
+++ b/src/content/adapters/types.test.ts
@@ -1,5 +1,45 @@
-import { describe, it, expect } from 'vitest';
-import { titleCaseSlug } from './types';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { textOf, titleCaseSlug } from './types';
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('textOf — visible text and image alternatives', () => {
+  it('reads the alt text from an image with no text content', () => {
+    vi.stubGlobal('document', {
+      querySelector: vi.fn().mockReturnValue({
+        textContent: '',
+        getAttribute: (name: string) => (name === 'alt' ? '  Acme Corp  ' : null),
+      }),
+    });
+
+    expect(textOf(['header img[alt]'])).toBe('Acme Corp');
+  });
+
+  it('keeps text content ahead of alt text', () => {
+    vi.stubGlobal('document', {
+      querySelector: vi.fn().mockReturnValue({
+        textContent: '  Visible Company  ',
+        getAttribute: (name: string) => (name === 'alt' ? 'Logo Company' : null),
+      }),
+    });
+
+    expect(textOf(["[class*='company']"])).toBe('Visible Company');
+  });
+
+  it('falls through when both text and alt are blank', () => {
+    vi.stubGlobal('document', {
+      querySelector: vi.fn((selector: string) =>
+        selector === 'img[alt]'
+          ? { textContent: '', getAttribute: () => '   ' }
+          : { textContent: 'Fallback Company', getAttribute: () => null },
+      ),
+    });
+
+    expect(textOf(['img[alt]', '.company-name'])).toBe('Fallback Company');
+  });
+});
 
 describe('titleCaseSlug — company-name fallback from URL segments', () => {
   it('replaces hyphens with spaces and title-cases each word', () => {

--- a/src/content/adapters/types.ts
+++ b/src/content/adapters/types.ts
@@ -16,7 +16,7 @@ function titleCaseSlug(slug: string): string {
 export function textOf(selectors: string[]): string {
   for (const sel of selectors) {
     const el = document.querySelector(sel);
-    const text = el?.textContent?.trim();
+    const text = el?.textContent?.trim() || el?.getAttribute('alt')?.trim();
     if (text) return text;
   }
   return '';


### PR DESCRIPTION
Closes #219.

## Summary

- let `textOf()` use trimmed `alt` text when a selected element has no text content
- keep text content as the first priority and preserve selector fallthrough for blank values
- add regression coverage for image alt extraction, text priority, and blank-alt fallthrough

## Verification

- `npm test -- src/content/adapters/types.test.ts` (10 passed)
- `npm test` (221 passed)
- `npm run lint`
- `npm run typecheck`
- `npm run build`
- `git diff --check`

## Residual risk

No manual live Chrome smoke was performed on Greenhouse or Lever. Logo alt text varies by site and can be generic (for example, `Company logo`), so this change keeps the existing best-effort behavior but does not validate the quality of every site's alt value.
