### PR TITLE
fix(adapters): fill single "Name" fields — the ^name$ rule never matched

### DIFF
--- a/src/content/adapters/shared.test.ts
+++ b/src/content/adapters/shared.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
-import { normalize } from './shared';
+import { normalize, RULES } from './shared';
+import { DEFAULT_PROFILE, type Profile } from '../../lib/profile';
 
 describe('normalize — label text canonicalisation', () => {
   it('lowercases and otherwise leaves a whitespace-free string alone', () => {
@@ -78,4 +79,60 @@ describe('normalize — label text canonicalisation', () => {
     expect(/\bgithub\b/.test(normalize('GitHub​URL'))).toBe(true);
   });
 
+});
+
+describe('RULES — what a label resolves to', () => {
+  // getLabelText joins the <label> text with the field's aria-label,
+  // placeholder, name and id, then normalizes. So the string a rule is tested
+  // against is almost never the bare label — which is exactly what the old
+  // `^name$` (anchored at both ends) could not cope with.
+  //
+  // These drive the REAL RULES table rather than a copy of a regex, so a change
+  // to shared.ts actually breaks them. Identifying the winning rule by the value
+  // it produces also pins precedence: RULES is first-match-wins and ordered
+  // most-specific-first.
+  const P: Profile = {
+    ...DEFAULT_PROFILE,
+    personal: { ...DEFAULT_PROFILE.personal, firstName: 'Ada', lastName: 'Lovelace' },
+  };
+  const valueFor = (raw: string): string | undefined =>
+    RULES.find((r) => r.test.test(normalize(raw)))?.value(P);
+
+  it('resolves a single Name field once the id and name attrs are appended', () => {
+    // Ashby: <label for="_systemfield_name">Name</label> — confirmed on a live
+    // posting, where this was the only field that failed to autofill.
+    expect(valueFor('Name _systemfield_name')).toBe('Ada Lovelace');
+    // The far more common shape: <label>Name</label> + name="name" + id="name".
+    expect(valueFor('Name name name')).toBe('Ada Lovelace');
+    expect(valueFor('Name Your full name')).toBe('Ada Lovelace');
+  });
+
+  it('still resolves a bare label and an explicit "Full Name"', () => {
+    expect(valueFor('Name')).toBe('Ada Lovelace');
+    expect(valueFor('Full Name full_name')).toBe('Ada Lovelace');
+  });
+
+  it('lets the more specific first/last rules win over the full-name rule', () => {
+    expect(valueFor('First Name first_name')).toBe('Ada');
+    expect(valueFor('Last Name last_name')).toBe('Lovelace');
+  });
+
+  it('does not give the applicant name to fields that merely start with "name"', () => {
+    // These ask for someone/something else's name, not the applicant's.
+    for (const label of [
+      'Name of School school_name',
+      'Name of Current Employer',
+      'Name of Reference',
+      'Name Prefix',
+      'Name Suffix',
+    ]) {
+      expect(valueFor(label)).not.toBe('Ada Lovelace');
+    }
+  });
+
+  it('does not match when "name" is not the leading word, nor a plural', () => {
+    expect(valueFor('Names')).toBeUndefined();
+    // "Company Name" belongs to the employer rule further down RULES.
+    expect(valueFor('Company Name')).not.toBe('Ada Lovelace');
+  });
 });

--- a/src/content/adapters/shared.ts
+++ b/src/content/adapters/shared.ts
@@ -116,10 +116,20 @@ interface Rule {
 }
 
 // Ordered: earlier, more specific rules win.
-const RULES: Rule[] = [
+// Exported for tests: matchRule() needs a real element, so the rule table is the
+// only way to exercise the regexes and their precedence under `environment: node`.
+export const RULES: Rule[] = [
   { test: /\b(first|given)\s*name\b/, value: (p) => p.personal.firstName },
   { test: /\b(last|family|sur)\s*name\b/, value: (p) => p.personal.lastName },
-  { test: /\bfull\s*name\b|^name$/, value: (p) => `${p.personal.firstName} ${p.personal.lastName}`.trim() },
+  // `^name$` never fired in practice: getLabelText CONCATENATES the label with
+  // the field's id/name/placeholder, so a plain "Name" field reads as
+  // "name name name" (or "name _systemfield_name" on Ashby), never bare "name".
+  // Anchor only the start, and exclude the qualifiers that make it a different
+  // field entirely — "Name of School/Employer/Reference", "Name Prefix/Suffix".
+  {
+    test: /\bfull\s*name\b|^name\b(?!\s+(?:of|prefix|suffix|title)\b)/,
+    value: (p) => `${p.personal.firstName} ${p.personal.lastName}`.trim(),
+  },
   { test: /\be-?mail\b/, value: (p) => p.personal.email },
   { test: /\b(phone|mobile|tel)\b/, value: (p) => p.personal.phone },
   { test: /\blinkedin\b/, value: (p) => p.personal.linkedin },


### PR DESCRIPTION
## What & why

Closes #220.

The full-name rule's `^name$` branch is anchored at **both** ends, but
`getLabelText` **concatenates** the label with the field's `aria-label`,
`placeholder`, `name` and `id` before normalizing. So the string the rule is
tested against is essentially never the bare `"name"`:

| Field markup | Normalized label | Old | New |
|---|---|---|---|
| `<label>Name</label>` + `name="name"` + `id="name"` | `"name name name"` | ❌ | ✅ |
| Ashby: `<label for="_systemfield_name">Name</label>` | `"name _systemfield_name"` | ❌ | ✅ |
| `<label>Name</label>`, no attributes at all | `"name"` | ✅ | ✅ |

Any board using **one combined name field** instead of separate first/last
silently left it blank. Greenhouse and Lever mostly use `first_name`/`last_name`,
which is why this went unnoticed despite affecting every board.

**Confirmed on a live Ashby posting** (while testing #217): GitHub, LinkedIn,
Personal Website and Email all filled — Name alone did not. That also rules out
the alternatives, since it proves the labels were read correctly *and* the
profile was populated, leaving only this rule.

## The change

```diff
-{ test: /\bfull\s*name\b|^name$/, ... }
+{ test: /\bfull\s*name\b|^name\b(?!\s+(?:of|prefix|suffix|title)\b)/, ... }
```

Anchors the start only, and excludes the qualifiers that make it a *different*
field — "Name of School / Current Employer / Reference", "Name Prefix / Suffix /
Title". The more specific first/last rules already sit earlier in `RULES`, so
`"First Name"` still wins.

## A note on the tests

`RULES` is now exported so the tests can drive the **real** rule table.

This mattered more than expected. My first version of these tests asserted a
*copy* of the regex inlined into the test file — and **both mutations survived**:
reverting the fix to `^name$` and dropping the qualifier exclusion each still
passed, because nothing referenced `shared.ts`. Rewriting them to resolve a label
through `RULES` and identify the winning rule *by the value it produces* pins the
regex and the first-match-wins precedence together.

Both mutations now fail as they should:

| Mutation | Result |
|---|---|
| Restore `^name$` (the bug) | ✗ `resolves a single Name field once the id and name attrs are appended` |
| Drop the qualifier exclusion | ✗ `does not give the applicant name to fields that merely start with "name"` |

## How I tested

- `npm run lint`, `npm run typecheck`, `npm test` (223 passed), `npm run build` — all pass.
- Both mutation checks above.
- Worth a manual re-check on a Greenhouse/Lever/Workday posting after merge,
  since this rule is shared by all four adapters.

## Checklist

- [x] `npm run lint` passes
- [x] `npm run typecheck` passes
- [x] `npm test` passes
- [x] `npm run build` succeeds
- [x] Tests added/updated if behavior changed
- [x] No secrets, keys, or personal data committed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved recognition of name-related fields, including first names, last names, full names, and fields with appended attributes.
  - Added support for both bare and fully qualified name labels.
  - Prevented unrelated fields—such as school, employer, reference, prefix, suffix, and title fields—from being incorrectly classified as names.
- **Tests**
  - Added coverage for name-label matching, precedence, and exclusion scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->