### PR TITLE
fix: show an actionable message when the content script is orphaned

### DIFF
--- a/src/content/index.ts
+++ b/src/content/index.ts
@@ -9,7 +9,7 @@ import { greenhouseAdapter } from './adapters/greenhouse';
 import { leverAdapter } from './adapters/lever';
 import { workdayAdapter } from './adapters/workday';
 import type { SiteAdapter } from './adapters/types';
-import { sendToBackground } from '../lib/messages';
+import { CONTEXT_LOST_MESSAGE, isContextInvalidated, sendToBackground } from '../lib/messages';
 import type { AIResult, CapturedJob, ContentMessage, FillResult, PageInfo } from '../lib/messages';
 import {
   startSponsorshipWatch,
@@ -157,7 +157,11 @@ async function generateAnswer(q: OpenQuestion, btn: HTMLButtonElement): Promise<
       setTimeout(() => (btn.textContent = original), 2000);
     }
   } catch (e) {
-    btn.textContent = '⚠️ failed';
+    // A stale content script (extension reloaded/updated under an open tab) is
+    // recoverable by refreshing, so say that rather than a bare "failed".
+    btn.textContent = isContextInvalidated(e)
+      ? '⚠️ ' + CONTEXT_LOST_MESSAGE.slice(0, 40)
+      : '⚠️ failed';
     console.error('[JobAutofill] answer generation failed', e);
     setTimeout(() => (btn.textContent = original), 3000);
   } finally {

--- a/src/lib/messages.test.ts
+++ b/src/lib/messages.test.ts
@@ -1,0 +1,68 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { CONTEXT_LOST_MESSAGE, isContextInvalidated, sendToBackground } from './messages';
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('isContextInvalidated', () => {
+  it('recognises the error Chrome raises in an orphaned content script', () => {
+    expect(isContextInvalidated(new Error('Extension context invalidated.'))).toBe(true);
+    // Chrome's casing has varied across versions, so match case-insensitively.
+    expect(isContextInvalidated(new Error('extension context invalidated'))).toBe(true);
+  });
+
+  it('recognises the message sendToBackground rewrites it to', () => {
+    // Without this, every caller downstream of the rewrite would see only the
+    // friendly string and the predicate would silently never fire.
+    expect(isContextInvalidated(new Error(CONTEXT_LOST_MESSAGE))).toBe(true);
+  });
+
+  it('does not claim unrelated failures', () => {
+    expect(isContextInvalidated(new Error('Daily limit reached (50/day).'))).toBe(false);
+    expect(isContextInvalidated(new Error('Could not reach the proxy: network error'))).toBe(false);
+    expect(isContextInvalidated(undefined)).toBe(false);
+    expect(isContextInvalidated(null)).toBe(false);
+  });
+});
+
+describe('sendToBackground — orphaned content script', () => {
+  const msg = { type: 'AI_ANALYZE_JOB', text: 'posting' } as const;
+
+  it('fails with the actionable message when the runtime is already gone', async () => {
+    // chrome.runtime.id goes undefined the moment the context dies, so this is
+    // caught before Chrome throws anything.
+    const sendMessage = vi.fn();
+    vi.stubGlobal('chrome', { runtime: { sendMessage } });
+
+    await expect(sendToBackground(msg)).rejects.toThrow(CONTEXT_LOST_MESSAGE);
+    expect(sendMessage).not.toHaveBeenCalled();
+  });
+
+  it('rewrites Chrome\'s raw error when sendMessage is the thing that throws', async () => {
+    const sendMessage = vi.fn().mockRejectedValue(new Error('Extension context invalidated.'));
+    vi.stubGlobal('chrome', { runtime: { id: 'abc', sendMessage } });
+
+    await expect(sendToBackground(msg)).rejects.toThrow(CONTEXT_LOST_MESSAGE);
+  });
+
+  it('leaves unrelated errors untouched so real failures stay diagnosable', async () => {
+    const sendMessage = vi.fn().mockRejectedValue(new Error('Daily limit reached (50/day).'));
+    vi.stubGlobal('chrome', { runtime: { id: 'abc', sendMessage } });
+
+    await expect(sendToBackground(msg)).rejects.toThrow('Daily limit reached (50/day).');
+  });
+
+  it('passes the response through when the runtime is healthy', async () => {
+    const sendMessage = vi.fn().mockResolvedValue({ text: 'ok' });
+    vi.stubGlobal('chrome', { runtime: { id: 'abc', sendMessage } });
+
+    await expect(sendToBackground(msg)).resolves.toEqual({ text: 'ok' });
+    expect(sendMessage).toHaveBeenCalledWith(msg);
+  });
+
+  it('stays readable after the badge truncates it to 32 characters', () => {
+    // The AI-check button slices the message; the action must survive.
+    expect(CONTEXT_LOST_MESSAGE.slice(0, 32)).toContain('Refresh this page');
+  });
+});

--- a/src/lib/messages.ts
+++ b/src/lib/messages.ts
@@ -82,9 +82,46 @@ export interface AIResult {
   error?: string;
 }
 
+/**
+ * Shown instead of Chrome's internal "Extension context invalidated."
+ *
+ * When the extension is reloaded or auto-updated, content scripts from the
+ * previous build keep running in already-open tabs but lose their connection to
+ * the runtime. Every chrome.* call from that orphaned script then throws, and
+ * the only cure is reloading the page so a fresh content script is injected.
+ *
+ * The action comes first because callers truncate this for display — the badge's
+ * AI check cuts at 32 characters — so "Refresh this page" survives the slice.
+ */
+export const CONTEXT_LOST_MESSAGE = 'Refresh this page — the extension was updated.';
+
+/**
+ * True for the failure an orphaned content script gets. Matched on the message
+ * because Chrome surfaces it as a plain Error with no code to test.
+ *
+ * Recognises BOTH Chrome's raw wording and the CONTEXT_LOST_MESSAGE that
+ * sendToBackground rewrites it to — callers downstream of that rewrite only ever
+ * see the friendly form, so matching the raw string alone would never fire.
+ */
+export function isContextInvalidated(e: unknown): boolean {
+  const msg = e instanceof Error ? e.message : String(e ?? '');
+  return /extension context invalidated/i.test(msg) || msg === CONTEXT_LOST_MESSAGE;
+}
+
 /** Promise wrapper around chrome.runtime.sendMessage (to background). */
-export function sendToBackground<T = unknown>(msg: BackgroundMessage): Promise<T> {
-  return chrome.runtime.sendMessage(msg);
+export async function sendToBackground<T = unknown>(msg: BackgroundMessage): Promise<T> {
+  // chrome.runtime.id is undefined once the context is gone. Checking it first
+  // catches the case before Chrome throws, and doesn't depend on the wording of
+  // an internal error string.
+  if (!chrome.runtime?.id) throw new Error(CONTEXT_LOST_MESSAGE);
+  try {
+    return (await chrome.runtime.sendMessage(msg)) as T;
+  } catch (e) {
+    // Keep the original as `cause` — the friendly message replaces it in the UI,
+    // but the raw Chrome error is what you want in the console.
+    if (isContextInvalidated(e)) throw new Error(CONTEXT_LOST_MESSAGE, { cause: e });
+    throw e;
+  }
 }
 
 /** Promise wrapper around chrome.tabs.sendMessage (to a content script). */


### PR DESCRIPTION
## What & why

Reported as an intermittent AI failure: **"⚠ Extension context invalidated."** on the
badge's cover-letter generator, and "it works again when I reload the page".

That's not an AI problem. Reloading or auto-updating the extension leaves content
scripts from the *previous* build running in already-open tabs, cut off from the
runtime. Every `chrome.*` call from that orphaned script throws, and we piped
Chrome's internal string straight into the UI — which says nothing about the one
thing that fixes it. Reloading the page re-injects a fresh content script, which is
exactly why it "came back".

It looked intermittent and AI-specific because it hits whichever AI action you try
next — the AI check, the cover letter, or the tailored resume — while the
rules-based badge keeps working (it never messages the background).

## The fix

Handled centrally in `sendToBackground`, so all four content-script call sites
benefit at once:

- **`chrome.runtime.id` is checked up front.** It's `undefined` the moment the
  context dies, so this catches the case *before* Chrome throws, and doesn't depend
  on the wording of an internal error string.
- **A raw `Extension context invalidated` from `sendMessage` is rewritten** to
  `Refresh this page — the extension was updated.`
- **The original error is kept as `cause`**, so the console still shows the real
  thing. (ESLint 10's `preserve-caught-error` rule flagged this — good catch.)

The message **leads with the action** deliberately: callers truncate it for display
(`slice(0, 32)` on the AI-check button, `40` on AI answer, `60` on the generators),
so "Refresh this page" survives the cut. There's a test pinning that.

Also updated the AI-answer button, which previously collapsed this to a bare
`⚠️ failed`.

## One subtlety worth flagging

`isContextInvalidated` matches **both** Chrome's raw wording *and* the rewritten
message. That isn't belt-and-braces — `sendToBackground` replaces the message, so
any caller downstream of the rewrite only ever sees the friendly form. Matching the
raw string alone would have made the predicate silently dead, and the new AI-answer
branch is exactly such a caller: it would have never fired. I hit this while writing
it, and there's a dedicated test so nobody removes that arm.

## How I tested

- `npm run lint`, `npm run typecheck`, `npm test` (226 passed), `npm run build` — all pass.
- New `src/lib/messages.test.ts` (8 cases), driving the real `sendToBackground` against
  a stubbed `chrome` global — including that unrelated failures (quota, network) pass
  through untouched so real errors stay diagnosable.
- **Mutation-checked all three guards** — each fails only the test written for it:

| Mutation | Fails |
|---|---|
| Remove the `chrome.runtime.id` check | `fails with the actionable message when the runtime is already gone` |
| Remove the second arm of the predicate | `recognises the message sendToBackground rewrites it to` |
| Stop rewriting Chrome's raw error | `rewrites Chrome's raw error when sendMessage is the thing that throws` |

### Manual

Load the extension, open a job page, then hit **Reload** on `chrome://extensions`
*without* refreshing the tab. Click the badge's AI check or cover letter: it should
now read `⚠ Refresh this page — the extensi…` instead of `⚠ Extension context
invalidated.`. Refresh the page and it works again, as before.

## Checklist

- [x] `npm run lint` passes
- [x] `npm run typecheck` passes
- [x] `npm test` passes
- [x] `npm run build` succeeds
- [x] Tests added/updated if behavior changed
- [x] No secrets, keys, or personal data committed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added a clearer message when AI answers cannot be generated because the page connection has expired.
  * Preserved the original error details for unexpected failures while continuing to show appropriate generic errors.
  * Improved handling when background messaging is unavailable or interrupted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->