### PR TITLE
fix(build): stop emitting modulepreload links that Chrome rejects

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -15,5 +15,15 @@ export default defineConfig({
   },
   build: {
     target: 'es2022',
+    // Vite emits <link rel="modulepreload" crossorigin> into the extension's
+    // HTML entry points. Chrome refuses to reuse those preloads inside an
+    // extension page — "a preload ... is not used because it is a cross-world
+    // extension resource mismatch" — so every chunk is fetched twice-over and
+    // each one logs an error on chrome://extensions.
+    //
+    // The hints buy nothing here: extension pages load their chunks off local
+    // disk, not the network. Turning them off removes the warnings without
+    // changing what actually gets loaded.
+    modulePreload: false,
   },
 });


### PR DESCRIPTION
## What & why

`chrome://extensions` logs one error per chunk, every time the side panel opens:

> A preload for `chrome-extension://…/assets/ui-gL9Tuan3.js` is found, but is not
> used because it is a **cross-world extension resource mismatch**.

Vite emits `<link rel="modulepreload" crossorigin>` into each HTML entry point.
Chrome won't reuse those preloads inside an extension page, so each one is
declared, rejected, and logged. Six for the side panel alone.

It's harmless, but it's permanent noise that buries real errors — and because
it's baked into the built HTML, it survives remove → rebuild → reload, which is
exactly why it kept reappearing.

The hints buy nothing here: extension pages load their chunks off local disk,
not the network, so there's no latency to hide. `build.modulePreload: false`
removes them.

## Verified the chunks still load

Turning off preload *hints* must not stop the code loading. The entry script
still imports all six chunks:

```
dist/src/sidepanel/index.html
  <script type="module" crossorigin src="/assets/index.html-BHL45SzC.js">
  (no <link rel="modulepreload">)

assets/index.html-BHL45SzC.js
  from"./ui-Dp3o5KZ0.js"   from"./profile-B_vPr-mG.js"   from"./coverLetter-CDU65Eb5.js"
  from"./auth-CsorxSAg.js" from"./messages-CE8FfhGS.js"  from"./resume-W2BXi-pF.js"
```

Same six chunks, still reachable through the module graph — only the redundant
hint is gone.

## How I tested

- `grep -rc modulepreload dist --include="*.html"` → **zero** across every entry
  (side panel and options); before the change the side panel had 6.
- `npm run lint`, `npm run typecheck`, `npm test` (253 passed), `npm run build` — all pass.
- Manifest still points at both HTML entries unchanged.

### Manual

Reload the unpacked extension, open the side panel, and check the **Errors**
page on `chrome://extensions` — the preload warnings should be gone, and the
panel should look and behave identically.

## Checklist

- [x] `npm run lint` passes
- [x] `npm run typecheck` passes
- [x] `npm test` passes
- [x] `npm run build` succeeds
- [x] No secrets, keys, or personal data committed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved extension page loading by preventing unnecessary resource preload hints during builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->