### PR TITLE
feat(content): offer AI answers on free-text <input> questions too

### DIFF
--- a/src/content/adapters/shared.test.ts
+++ b/src/content/adapters/shared.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { normalize, RULES } from './shared';
+import { looksLikeQuestion, normalize, RULES } from './shared';
 import { DEFAULT_PROFILE, type Profile } from '../../lib/profile';
 
 describe('normalize — label text canonicalisation', () => {
@@ -134,5 +134,44 @@ describe('RULES — what a label resolves to', () => {
     expect(valueFor('Names')).toBeUndefined();
     // "Company Name" belongs to the employer rule further down RULES.
     expect(valueFor('Company Name')).not.toBe('Ada Lovelace');
+  });
+});
+
+describe('looksLikeQuestion — which text inputs earn an AI-answer button', () => {
+  // Only <input> is filtered by this; a <textarea> is an essay box by
+  // definition. The point is to light up real questions without putting a
+  // button beside every short data field on the form.
+  const asks = (label: string) => looksLikeQuestion(normalize(label));
+
+  it('accepts anything phrased as a question', () => {
+    // Verified live on an Ashby posting — this is the field that had no button.
+    expect(asks('What piece of physical technology invented in the last 500 years do you most admire?')).toBe(true);
+    expect(asks('How did you hear about us?')).toBe(true);
+    expect(asks('Why us?')).toBe(true);
+  });
+
+  it('accepts an unpunctuated prompt that is long enough to be an essay', () => {
+    expect(asks('Tell us about yourself')).toBe(true);
+    expect(asks('Describe a project you are proud of')).toBe(true);
+  });
+
+  it('rejects the short data fields that would just be clutter', () => {
+    expect(asks('Pronouns')).toBe(false);
+    expect(asks('Referral code')).toBe(false);
+    expect(asks('Preferred name')).toBe(false);
+    expect(asks('Start date')).toBe(false);
+  });
+
+  it('is not fooled by the padding getLabelText would add', () => {
+    // getLabelText appends id/name/placeholder, so "Pronouns" becomes
+    // "pronouns pronouns type here" — 5 words, which would sail past the
+    // word-count gate. This is why the caller must pass getQuestionText().
+    expect(asks('Pronouns')).toBe(false);
+    expect(looksLikeQuestion(normalize('pronouns pronouns type here'))).toBe(true);
+  });
+
+  it('treats an empty label as not a question', () => {
+    expect(asks('')).toBe(false);
+    expect(asks('   ')).toBe(false);
   });
 });

--- a/src/content/adapters/shared.ts
+++ b/src/content/adapters/shared.ts
@@ -40,8 +40,13 @@ function humanizeId(s: string): string {
     .trim();
 }
 
-/** Best-effort human label for a form control. */
-export function getLabelText(el: FillableField): string {
+/**
+ * The label sources a human actually reads. Kept separate from the attribute
+ * noise below because two callers want different things: rule matching wants
+ * every scrap of text it can get, while the AI-answer feature wants the question
+ * as written — not the question with a UUID glued to the end.
+ */
+function visibleLabelParts(el: FillableField): string[] {
   const parts: string[] = [];
 
   if (el.id) {
@@ -59,8 +64,27 @@ export function getLabelText(el: FillableField): string {
     }
   }
 
+  const aria = el.getAttribute('aria-label');
+  if (aria) parts.push(aria);
+
+  return parts;
+}
+
+/**
+ * The question as the applicant sees it, with none of the id/name/placeholder
+ * text getLabelText folds in. That noise is fine for regex matching but ruins
+ * anything that reads the label as prose: on Ashby the field id is a UUID, so
+ * getLabelText yields "…do you most admire? b2a0a4af-ab88-43f6-…".
+ */
+export function getQuestionText(el: FillableField): string {
+  return normalize(visibleLabelParts(el).join(' '));
+}
+
+/** Best-effort human label for a form control. */
+export function getLabelText(el: FillableField): string {
+  const parts = visibleLabelParts(el);
+
   parts.push(
-    el.getAttribute('aria-label') ?? '',
     el.getAttribute('placeholder') ?? '',
     el.getAttribute('name') ?? '',
     el.id ?? '',
@@ -219,18 +243,58 @@ function isFillable(el: FillableField): boolean {
 }
 
 export interface OpenQuestion {
-  el: HTMLTextAreaElement;
+  el: HTMLTextAreaElement | HTMLInputElement;
   label: string;
 }
 
-/** Finds free-text (textarea) questions that aren't covered by a standard rule. */
+/**
+ * Input types that hold prose. Everything else an <input> can be (email, tel,
+ * url, number, date…) is a structured value the AI has no business drafting,
+ * even when the label reads like a question.
+ */
+const FREE_TEXT_INPUT_TYPES = new Set(['text', 'search']);
+
+/** Words a non-question label needs before it counts as an essay prompt. */
+const QUESTION_MIN_WORDS = 4;
+
+/**
+ * True when a label reads like a free-text question rather than a short data
+ * field. Only consulted for <input>: a <textarea> is a question by definition.
+ *
+ * Must be given getQuestionText(), NOT getLabelText() — the latter appends the
+ * id/name/placeholder, which inflates the word count enough that "Pronouns"
+ * ("pronouns pronouns type here") would pass on padding alone.
+ */
+export function looksLikeQuestion(question: string): boolean {
+  if (question.includes('?')) return true;
+  return question.split(' ').filter(Boolean).length >= QUESTION_MIN_WORDS;
+}
+
+/** Finds free-text questions that aren't covered by a standard rule. */
 export function findOpenQuestions(root: ParentNode = document): OpenQuestion[] {
   const out: OpenQuestion[] = [];
-  for (const el of Array.from(root.querySelectorAll<HTMLTextAreaElement>('textarea'))) {
+  const fields = root.querySelectorAll<HTMLTextAreaElement | HTMLInputElement>('textarea, input');
+
+  for (const el of Array.from(fields)) {
     if (!isFillable(el)) continue;
+
+    const isInput = el instanceof HTMLInputElement;
+    if (isInput && !FREE_TEXT_INPUT_TYPES.has((el.getAttribute('type') || 'text').toLowerCase())) {
+      continue;
+    }
+
     const label = getLabelText(el);
     if (matchRule(label, el)) continue; // a standard field, not an essay question
-    out.push({ el, label });
+
+    // A textarea is an essay box by definition. An input is only one when it
+    // reads like a question — otherwise every "Pronouns" or "Referral code" box
+    // would sprout a button.
+    const question = getQuestionText(el);
+    if (isInput && !looksLikeQuestion(question)) continue;
+
+    // Prefer the clean question for the AI prompt; fall back to the matching
+    // label on markup that exposes no real label at all.
+    out.push({ el, label: question || label });
   }
   return out;
 }


### PR DESCRIPTION
## What & why

The **✨ AI answer** button never appeared on questions rendered as
`<input type="text">`. `findOpenQuestions` only ever queried `'textarea'`, so
this had nothing to do with how long the question was.

Confirmed on a live Ashby posting:

| Question | Element | Button? |
|---|---|---|
| "What piece of physical technology invented in the last 500 years do you most admire?" | `<input type="text">` | ❌ |
| "Anything else? (Optional)" | `<textarea rows="4">` | ✅ |

## How inputs qualify

The obvious fix — a button on every input — would put one beside Name, Email and
Phone. So an input needs all three:

1. **type is `text`/`search`** — `email`, `tel`, `url`, `number`, `date` are
   structured values the AI has no business drafting, however the label reads.
2. **No `RULES` entry matches.** This does most of the work for free; I checked
   against the real labels on that form and it already excludes Name, Email,
   Phone Number, Your GitHub, Your LinkedIn, Your Personal Website and the
   work-authorization question.
3. **The label reads like a question** — contains `?`, or is ≥ 4 words.

Gate 3 is what stops the leftovers becoming clutter:

| Label | Result |
|---|---|
| "…do you most admire?" | ✅ button |
| "How did you hear about us?" | ✅ button |
| "Tell us about yourself" | ✅ button (4 words, no `?`) |
| "Pronouns" / "Referral code" / "Preferred name" | ❌ no button |

A `<textarea>` still qualifies unconditionally — it's an essay box by definition.

## The label split (load-bearing, not tidying)

`getLabelText` concatenates the label with the field's `id`/`name`/`placeholder`.
That's right for regex matching and wrong for anything reading the label as
prose — on Ashby the id is a UUID, so the AI was being asked:

> …do you most admire? **b2a0a4af-ab88-43f6-b90f-f88279d1cc6d**

So this adds `getQuestionText`, returning the visible label only. It's what the
heuristic counts words on and what now reaches the prompt (a drive-by
improvement for textareas too, which had the same UUID noise).

Using it for the word count isn't cosmetic: `"Pronouns"` concatenates to
`"pronouns pronouns type here"` — **5 words**, which would sail past the gate on
padding alone. There's a test pinning exactly that contrast.

## How I tested

- `npm run lint`, `npm run typecheck`, `npm test` (258 passed), `npm run build` — all pass.
- New `looksLikeQuestion` tests use the real labels from the reported form.
- **Mutation-checked both halves of the heuristic:**

| Mutation | Fails |
|---|---|
| Drop the `?` signal | `accepts anything phrased as a question` |
| Lower `QUESTION_MIN_WORDS` 4 → 2 | `rejects the short data fields that would just be clutter` |

### Manual

`findOpenQuestions` needs a real DOM, so please check on that Ashby posting: the
500-years question should now have a button, and Name / Email / Phone / GitHub /
LinkedIn / Website should still have none.

## Note

Worth pairing with #201 — the button overwrites whatever is already in the field,
which matters more now that it appears on more of them.

## Checklist

- [x] `npm run lint` passes
- [x] `npm run typecheck` passes
- [x] `npm test` passes
- [x] `npm run build` succeeds
- [x] Tests added/updated if behavior changed
- [x] No secrets, keys, or personal data committed