### PR TITLE
fix(content): confirm before AI answer replaces the applicant's text

### DIFF
--- a/src/content/adapters/shared.test.ts
+++ b/src/content/adapters/shared.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { looksLikeQuestion, normalize, RULES } from './shared';
+import { looksLikeQuestion, needsReplaceConfirm, normalize, RULES } from './shared';
 import { DEFAULT_PROFILE, type Profile } from '../../lib/profile';
 
 describe('normalize — label text canonicalisation', () => {
@@ -173,5 +173,25 @@ describe('looksLikeQuestion — which text inputs earn an AI-answer button', () 
   it('treats an empty label as not a question', () => {
     expect(asks('')).toBe(false);
     expect(asks('   ')).toBe(false);
+  });
+});
+
+describe('needsReplaceConfirm — guarding the applicant\'s own text', () => {
+  it('generates straight away when the field is empty', () => {
+    expect(needsReplaceConfirm('', false)).toBe(false);
+    expect(needsReplaceConfirm('   \n\t ', false)).toBe(false);
+  });
+
+  it('asks first when the field already holds something', () => {
+    // fillInput() writes through the native value setter, so a replaced draft
+    // is not recoverable via the browser's undo stack. The second click is the
+    // only chance to notice.
+    expect(needsReplaceConfirm('My own draft answer', false)).toBe(true);
+    expect(needsReplaceConfirm('a', false)).toBe(true);
+  });
+
+  it('does not ask twice — an armed button proceeds on the confirming click', () => {
+    // Otherwise the button could never regenerate at all.
+    expect(needsReplaceConfirm('My own draft answer', true)).toBe(false);
   });
 });

--- a/src/content/adapters/shared.ts
+++ b/src/content/adapters/shared.ts
@@ -265,6 +265,20 @@ const QUESTION_MIN_WORDS = 4;
  * id/name/placeholder, which inflates the word count enough that "Pronouns"
  * ("pronouns pronouns type here") would pass on padding alone.
  */
+/**
+ * Whether a click on the AI-answer button should ask before replacing what is
+ * already in the field, instead of generating straight away.
+ *
+ * Writing into an empty field is harmless, so that stays a single click. Once
+ * the field holds anything — the applicant's own draft, or an AI answer they
+ * have since edited — generating would destroy it, and fillInput() assigns
+ * through the native value setter, so the browser's undo stack cannot bring it
+ * back. The second click is the only chance to notice.
+ */
+export function needsReplaceConfirm(currentValue: string, alreadyArmed: boolean): boolean {
+  return !alreadyArmed && currentValue.trim() !== '';
+}
+
 export function looksLikeQuestion(question: string): boolean {
   if (question.includes('?')) return true;
   return question.split(' ').filter(Boolean).length >= QUESTION_MIN_WORDS;

--- a/src/content/index.ts
+++ b/src/content/index.ts
@@ -4,7 +4,13 @@
 import { getProfile, onProfileChanged } from '../lib/profile';
 import { getSavedJobs, onSavedJobsChanged } from '../lib/savedJobs';
 import { hostMatches } from '../lib/host';
-import { applyStandardFills, findOpenQuestions, fillInput, type OpenQuestion } from './adapters/shared';
+import {
+  applyStandardFills,
+  findOpenQuestions,
+  fillInput,
+  needsReplaceConfirm,
+  type OpenQuestion,
+} from './adapters/shared';
 import { greenhouseAdapter } from './adapters/greenhouse';
 import { leverAdapter } from './adapters/lever';
 import { workdayAdapter } from './adapters/workday';
@@ -26,6 +32,15 @@ const ADAPTERS: SiteAdapter[] = [greenhouseAdapter, leverAdapter, workdayAdapter
 const adapter = ADAPTERS.find((a) => a.matches(new URL(location.href))) ?? null;
 
 const BUTTON_CLASS = 'jaf-ai-btn';
+const BUTTON_LABEL = '✨ AI answer';
+const CONFIRM_LABEL = '↻ Replace your text?';
+const CONFIRM_WINDOW_MS = 4000;
+
+// Buttons awaiting a confirming second click → the timer that disarms them.
+// Keyed weakly so a button dropped by injectQuestionButtons' reconciliation
+// takes its armed state with it.
+const armedButtons = new WeakMap<HTMLButtonElement, number>();
+
 // Buttons WE created. Reconciliation and cleanup only ever touch members of this
 // set, so a host page element that happens to share our class can never mark a
 // question as handled or get deleted by us. A WeakSet (not a DOM attribute) means
@@ -133,7 +148,7 @@ function addButtonFor(q: OpenQuestion): void {
   const btn = document.createElement('button');
   btn.type = 'button';
   btn.className = BUTTON_CLASS;
-  btn.textContent = '✨ AI answer';
+  btn.textContent = BUTTON_LABEL;
   ownedButtons.add(btn);
   btn.addEventListener('click', () => generateAnswer(q, btn));
 
@@ -141,8 +156,32 @@ function addButtonFor(q: OpenQuestion): void {
   q.el.insertAdjacentElement('afterend', btn);
 }
 
+function disarm(btn: HTMLButtonElement): void {
+  const timer = armedButtons.get(btn);
+  if (timer !== undefined) window.clearTimeout(timer);
+  armedButtons.delete(btn);
+}
+
 async function generateAnswer(q: OpenQuestion, btn: HTMLButtonElement): Promise<void> {
-  const original = btn.textContent;
+  // Replacing text the applicant already has is destructive and unrecoverable,
+  // so it takes two clicks. Regeneration stays available — it just has to be
+  // deliberate.
+  if (needsReplaceConfirm(q.el.value, armedButtons.has(btn))) {
+    btn.textContent = CONFIRM_LABEL;
+    armedButtons.set(
+      btn,
+      window.setTimeout(() => {
+        armedButtons.delete(btn);
+        btn.textContent = BUTTON_LABEL;
+      }, CONFIRM_WINDOW_MS),
+    );
+    return;
+  }
+  disarm(btn);
+
+  // Revert to the constant, not to whatever the button happened to read on
+  // entry — that could be the confirm prompt or a leftover transient state.
+  const original = BUTTON_LABEL;
   btn.disabled = true;
   btn.textContent = '… thinking';
   try {


### PR DESCRIPTION
## What & why

Closes #201.

`generateAnswer` called `fillInput(q.el, res.text)` unconditionally, so a click
destroyed whatever was already in the field. There's no undo — `fillInput`
assigns through the native `value` setter, which doesn't feed the browser's undo
stack.

What makes it more than a nitpick: the destructive path **is the documented
workflow**. Fill → edit the draft to sound like you → click again for another
angle. Losing work was the normal way to use the feature, not an edge case. And
#228 just widened the button from textareas to qualifying text inputs, so it now
sits beside more fields than before.

## Why not just copy the existing guard

`applyStandardFills` has `if (el.value.trim()) continue; // don't clobber
existing input`, and mirroring it was the obvious move. It's wrong here:
refusing outright **removes regeneration**, forcing the user to clear the box by
hand to get a second draft. That guard is right for autofilling a phone number
and wrong for a draft you're iterating on.

So the destructive step becomes *deliberate* rather than *impossible*:

| Field state | Behaviour |
|---|---|
| Empty | Unchanged — one click generates |
| Has text | First click arms: **`↻ Replace your text?`** for 4s |
| Armed | Second click regenerates |
| Armed, 4s elapse | Reverts to `✨ AI answer`, nothing lost |

This reuses the label mutation the button already performs for `… thinking` /
`✓ filled` / `⚠️ failed`, so it needs no new UI and no modal.

## Drive-by correctness fix

The old code captured its revert label from `btn.textContent` on entry. With a
confirm state that could now capture `↻ Replace your text?` (or a leftover
transient) and leave the button permanently mislabelled. It reverts to the
`BUTTON_LABEL` constant instead.

## On where the logic lives

`needsReplaceConfirm` is in `shared.ts`, not `content/index.ts`. That looks
arbitrary but isn't: `content/index.ts` registers `chrome.runtime.onMessage`
listeners at module scope, so nothing exported from it can be imported under
`environment: 'node'`. `shared.ts` already hosts the sibling AI-answer helper
`looksLikeQuestion` for the same reason.

## How I tested

- `npm run lint`, `npm run typecheck`, `npm test` (261 passed), `npm run build` — all pass.
- **Mutation-checked all three behaviours**, each failing only its own test:

| Mutation | Fails |
|---|---|
| Never confirm (restores the bug) | `asks first when the field already holds something` |
| Ignore the armed flag (could never regenerate) | `does not ask twice — an armed button proceeds on the confirming click` |
| Drop `.trim()` (whitespace-only field prompts) | `generates straight away when the field is empty` |

### Manual

The click path needs a real DOM. On a posting with a free-text question:
1. Empty field → one click still fills.
2. Type something → click → button reads `↻ Replace your text?`, text untouched.
3. Click again within 4s → regenerates.
4. Repeat but wait 4s → button reverts, text still intact.

## Checklist

- [x] `npm run lint` passes
- [x] `npm run typecheck` passes
- [x] `npm test` passes
- [x] `npm run build` succeeds
- [x] Tests added/updated if behavior changed
- [x] No secrets, keys, or personal data committed