### PR TITLE
fix(adapters): don't treat question prose as a current-job data field

### DIFF
--- a/src/content/adapters/shared.test.ts
+++ b/src/content/adapters/shared.test.ts
@@ -195,3 +195,46 @@ describe('needsReplaceConfirm — guarding the applicant\'s own text', () => {
     expect(needsReplaceConfirm('My own draft answer', true)).toBe(false);
   });
 });
+
+describe('RULES — question prose must not be mistaken for a data field', () => {
+  // The employer/title rules read the applicant's CURRENT job. Inside a question
+  // their keywords mean the opposite — the job being applied FOR — so matching
+  // there suppressed the AI-answer button and typed the wrong value into an
+  // essay box. Reported live on a BambooHR form.
+  const P: Profile = {
+    ...DEFAULT_PROFILE,
+    workHistory: [
+      { company: 'Acme', title: 'Data Analyst', startDate: '2024', endDate: '', description: '' },
+    ],
+  };
+  const valueFor = (raw: string): string | undefined =>
+    RULES.find((r) => r.test.test(normalize(raw)))?.value(P);
+
+  it('leaves "why are you interested in this position?" to the AI', () => {
+    expect(valueFor('Why are you interested in this position?')).toBeUndefined();
+    expect(valueFor('Why are you interested in the position?')).toBeUndefined();
+    expect(valueFor('Why this position?')).toBeUndefined();
+    expect(valueFor('Why do you want this role?')).toBeUndefined();
+    expect(valueFor('How did you hear about this position?')).toBeUndefined();
+  });
+
+  it('leaves "why do you want to work at our company?" to the AI', () => {
+    expect(valueFor('Why do you want to work at our company?')).toBeUndefined();
+    expect(valueFor('Why our company?')).toBeUndefined();
+  });
+
+  it('still autofills genuine current-employer and current-title fields', () => {
+    expect(valueFor('Current Title')).toBe('Data Analyst');
+    expect(valueFor('Job Title')).toBe('Data Analyst');
+    expect(valueFor('Position')).toBe('Data Analyst');
+    expect(valueFor('Current Role')).toBe('Data Analyst');
+    expect(valueFor('Current Company')).toBe('Acme');
+    expect(valueFor('Employer name')).toBe('Acme');
+  });
+
+  it('still autofills a data field that happens to be phrased as a question', () => {
+    // The guard keys off the determiner, not the question mark, so this keeps
+    // working — a blunter "questions never autofill" rule would have broken it.
+    expect(valueFor('What is your current job title?')).toBe('Data Analyst');
+  });
+});

--- a/src/content/adapters/shared.test.ts
+++ b/src/content/adapters/shared.test.ts
@@ -223,6 +223,17 @@ describe('RULES — question prose must not be mistaken for a data field', () =>
     expect(valueFor('Why our company?')).toBeUndefined();
   });
 
+  it('is not fooled by "current" sitting between the determiner and the keyword', () => {
+    // Caught in review: a trailing lookbehind only inspects the text right
+    // before wherever the match attempt starts, and the regex engine retries
+    // starting AFTER "current" — so "this current position" matched with
+    // "current " as the immediate prefix instead of "this ", slipping past a
+    // lookbehind that only knew to reject "this ". Same failure for company.
+    expect(valueFor('Why are you interested in this current position?')).toBeUndefined();
+    expect(valueFor('Tell us why you want this current role?')).toBeUndefined();
+    expect(valueFor('What are you looking for in our current company?')).toBeUndefined();
+  });
+
   it('still autofills genuine current-employer and current-title fields', () => {
     expect(valueFor('Current Title')).toBe('Data Analyst');
     expect(valueFor('Job Title')).toBe('Data Analyst');

--- a/src/content/adapters/shared.ts
+++ b/src/content/adapters/shared.ts
@@ -167,14 +167,20 @@ export const RULES: Rule[] = [
   // position?" the position is the *employer's* job, and in "Why do you want to
   // work at our company?" the company is theirs too. Matching there both hid the
   // AI-answer button and typed the applicant's current job into an essay box.
-  // The lookbehind drops exactly that reading while leaving real data fields
-  // ("Current Title", "Job Title", even "What is your current job title?") alone.
+  //
+  // A trailing lookbehind isn't enough on its own: the regex engine retries the
+  // whole pattern starting after the determiner, so "this current position"
+  // matches "position" with "current " (not "this ") as its immediate prefix —
+  // the very phrasing this rule exists to exclude. A leading negative lookahead
+  // over the WHOLE determiner-phrase, scanned across the entire label rather
+  // than anchored to one match attempt, closes that gap; "current" is optional
+  // inside it for the same reason.
   {
-    test: /(?<!\b(?:this|the|that|our|a|an)\s)\b(current\s*)?(company|employer)\b/,
+    test: /^(?!.*\b(?:this|the|that|our|a|an)\s+(?:current\s+)?(?:company|employer)\b).*?\b(current\s*)?(company|employer)\b/,
     value: (p) => p.workHistory[0]?.company ?? '',
   },
   {
-    test: /(?<!\b(?:this|the|that|our|a|an)\s)\b(current\s*)?(title|role|position)\b/,
+    test: /^(?!.*\b(?:this|the|that|our|a|an)\s+(?:current\s+)?(?:title|role|position)\b).*?\b(current\s*)?(title|role|position)\b/,
     value: (p) => p.workHistory[0]?.title ?? '',
   },
   { test: /\b(salary|compensation|pay)\b/, value: (p) => p.preferences.salaryExpectation },

--- a/src/content/adapters/shared.ts
+++ b/src/content/adapters/shared.ts
@@ -162,8 +162,21 @@ export const RULES: Rule[] = [
   { test: /\bcity\b/, value: (p) => p.personal.city },
   { test: /\b(state|province|region)\b/, value: (p) => p.personal.state, selectOk: true },
   { test: /\bcountry\b/, value: (p) => p.personal.country, selectOk: true },
-  { test: /\b(current\s*)?(company|employer)\b/, value: (p) => p.workHistory[0]?.company ?? '' },
-  { test: /\b(current\s*)?(title|role|position)\b/, value: (p) => p.workHistory[0]?.title ?? '' },
+  // These two read the applicant's CURRENT employer/title, but their keywords
+  // flip referent inside question prose: in "Why are you interested in this
+  // position?" the position is the *employer's* job, and in "Why do you want to
+  // work at our company?" the company is theirs too. Matching there both hid the
+  // AI-answer button and typed the applicant's current job into an essay box.
+  // The lookbehind drops exactly that reading while leaving real data fields
+  // ("Current Title", "Job Title", even "What is your current job title?") alone.
+  {
+    test: /(?<!\b(?:this|the|that|our|a|an)\s)\b(current\s*)?(company|employer)\b/,
+    value: (p) => p.workHistory[0]?.company ?? '',
+  },
+  {
+    test: /(?<!\b(?:this|the|that|our|a|an)\s)\b(current\s*)?(title|role|position)\b/,
+    value: (p) => p.workHistory[0]?.title ?? '',
+  },
   { test: /\b(salary|compensation|pay)\b/, value: (p) => p.preferences.salaryExpectation },
   {
     test: /\b(work\s*authoriz|authoriz.*work|legally.*work|eligible.*work)\b/,


### PR DESCRIPTION
## What & why

Reported on a live BambooHR form: questions 2–4 had **✨ AI answer** buttons,
question 1 — *"Why are you interested in this position?"* — did not.

The cause is worse than a missing button. `/\b(current\s*)?(title|role|position)\b/`
matches the word **"position"**, so `matchRule` claims the field. That does two
things at once:

1. `findOpenQuestions` skips it as a "standard field" → **no AI button**
2. `applyStandardFills` writes `workHistory[0].title` into it → **"Fill this page"
   types your job title into an essay box**

Verified against the real labels:

```
RULE MATCH -> autofills "Data Analyst" | Why are you interested in this position?
open question                          | Describe your experience working with computers.
open question                          | Will you be able to reliably commute to Covington…
open question                          | Please list 2-3 days you would be available…
```

**The keywords flip referent inside question prose.** These two rules read the
applicant's *current* employer/title, but "this position" and "our company" mean
the *employer's*. So matching there isn't just a miss — it's the opposite value.

## The fix

A determiner lookbehind on the title and company rules:

```diff
-{ test: /\b(current\s*)?(title|role|position)\b/,  … }
+{ test: /(?<!\b(?:this|the|that|our|a|an)\s)\b(current\s*)?(title|role|position)\b/, … }
```

Same for `company|employer`.

**Why keyed on the determiner and not the question mark.** The obvious rule — "a
question never autofills" — would have broken *"What is your current job title?"*,
a legitimate data field that happens to be phrased as a question. The determiner
distinguishes the two cleanly:

| Label | Before | After |
|---|---|---|
| "Why are you interested in **this** position?" | fills "Data Analyst" | AI question ✅ |
| "Why do you want to work at **our** company?" | fills "Acme" | AI question ✅ |
| "Why **this** position?" / "Why do you want **this** role?" | fills | AI question ✅ |
| "How did you hear about **this** position?" | fills | AI question ✅ |
| "Current Title" / "Job Title" / "Position" / "Current Role" | fills | fills ✅ |
| "Current Company" / "Employer name" | fills | fills ✅ |
| "What is your **current job** title?" | fills | **fills** ✅ |

## How I tested

- `npm run lint`, `npm run typecheck`, `npm test` (265 passed), `npm run build` — all pass.
- **Mutation-checked three ways**, each failing only its own test:

| Mutation | Fails |
|---|---|
| Revert the title guard (restores the bug) | `leaves "why are you interested in this position?" to the AI` |
| Revert the company guard | `leaves "why do you want to work at our company?" to the AI` |
| Swap in the blunt "no questions ever autofill" variant | `still autofills a data field that happens to be phrased as a question` |

That third one is the point: the tests reject the simpler design as well as the
bug, so the *reasoning* is pinned and not just the output.

### Manual

On that BambooHR form: question 1 should now have an AI-answer button, and
**Fill this page** should no longer write your job title into it. Worth a check
on a Greenhouse/Lever posting with a real "Current Title" / "Current Company"
field to confirm those still populate.

## Checklist

- [x] `npm run lint` passes
- [x] `npm run typecheck` passes
- [x] `npm test` passes
- [x] `npm run build` succeeds
- [x] Tests added/updated if behavior changed
- [x] No secrets, keys, or personal data committed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved form autofill accuracy for employment fields.
  * Prevented job-application essay questions from being incorrectly treated as current employer or job title fields.
  * Preserved autofill for genuine company, title, and qualifying data-field questions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->