### PR TITLE
fix(content): never offer an AI answer on a dropdown

### DIFF
--- a/src/content/adapters/shared.test.ts
+++ b/src/content/adapters/shared.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect } from 'vitest';
-import { looksLikeQuestion, needsReplaceConfirm, normalize, RULES } from './shared';
+import {
+  isComboboxLike,
+  looksLikeQuestion,
+  needsReplaceConfirm,
+  normalize,
+  RULES,
+} from './shared';
 import { DEFAULT_PROFILE, type Profile } from '../../lib/profile';
 
 describe('normalize — label text canonicalisation', () => {
@@ -247,5 +253,42 @@ describe('RULES — question prose must not be mistaken for a data field', () =>
     // The guard keys off the determiner, not the question mark, so this keeps
     // working — a blunter "questions never autofill" rule would have broken it.
     expect(valueFor('What is your current job title?')).toBe('Data Analyst');
+  });
+});
+
+describe('isComboboxLike — dropdowns never get an AI-answer button', () => {
+  // Reported live: "Have you previously worked at NISC…?" and "How did you hear
+  // about this job?" are dropdowns, but the widget renders a real
+  // <input type="text">, so the question-shaped label let it through and the
+  // button landed on top of the control. An AI sentence is never a valid answer
+  // to a fixed option list.
+  const plain = { role: null, attributeNames: ['type', 'name', 'id'], hasComboboxAncestor: false };
+
+  it('leaves a genuine free-text input alone', () => {
+    expect(isComboboxLike(plain)).toBe(false);
+    expect(isComboboxLike({ ...plain, attributeNames: ['type', 'placeholder', 'required'] })).toBe(false);
+  });
+
+  it('detects the ARIA combobox role on the input itself', () => {
+    expect(isComboboxLike({ ...plain, role: 'combobox' })).toBe(true);
+    expect(isComboboxLike({ ...plain, role: 'listbox' })).toBe(true);
+  });
+
+  it('detects the ARIA combobox attributes', () => {
+    for (const attr of ['aria-haspopup', 'aria-autocomplete', 'aria-expanded', 'aria-controls']) {
+      expect(isComboboxLike({ ...plain, attributeNames: ['type', attr] })).toBe(true);
+    }
+  });
+
+  it('detects a native <datalist> pairing', () => {
+    expect(isComboboxLike({ ...plain, attributeNames: ['type', 'list'] })).toBe(true);
+  });
+
+  it('detects widgets that put the role on a wrapper instead of the input', () => {
+    expect(isComboboxLike({ ...plain, hasComboboxAncestor: true })).toBe(true);
+  });
+
+  it('is case-insensitive about attribute names', () => {
+    expect(isComboboxLike({ ...plain, attributeNames: ['ARIA-EXPANDED'] })).toBe(true);
   });
 });

--- a/src/content/adapters/shared.ts
+++ b/src/content/adapters/shared.ts
@@ -277,6 +277,44 @@ const FREE_TEXT_INPUT_TYPES = new Set(['text', 'search']);
 const QUESTION_MIN_WORDS = 4;
 
 /**
+ * Attributes that mark an <input> as the text box of a dropdown widget rather
+ * than a free-text field. A native <select> is never a candidate (it isn't in
+ * findOpenQuestions' selector), but React combobox libraries render a real
+ * <input type="text"> with a styled option list — and its label is usually a
+ * question, so it would otherwise pass looksLikeQuestion.
+ *
+ * `list` is the native pairing with <datalist>; the rest are the ARIA combobox
+ * pattern, which any of these widgets sets in order to be operable at all.
+ */
+const COMBOBOX_ATTRS = ['aria-haspopup', 'aria-autocomplete', 'aria-expanded', 'aria-controls', 'list'];
+
+/**
+ * Whether an input is really a dropdown in disguise. Pure so the rule is
+ * testable without a DOM; isCombobox() below feeds it from a live element.
+ *
+ * An AI-drafted sentence is never a valid answer to a fixed option list, and
+ * the button also lands on top of the control, so these get no button at all.
+ */
+export function isComboboxLike(el: {
+  role: string | null;
+  attributeNames: readonly string[];
+  hasComboboxAncestor: boolean;
+}): boolean {
+  if (el.role === 'combobox' || el.role === 'listbox') return true;
+  if (el.attributeNames.some((a) => COMBOBOX_ATTRS.includes(a.toLowerCase()))) return true;
+  return el.hasComboboxAncestor;
+}
+
+function isCombobox(el: HTMLInputElement): boolean {
+  return isComboboxLike({
+    role: el.getAttribute('role'),
+    attributeNames: el.getAttributeNames(),
+    // Widgets that put the role on a wrapper instead of the input itself.
+    hasComboboxAncestor: el.closest('[role="combobox"], [role="listbox"]') !== null,
+  });
+}
+
+/**
  * True when a label reads like a free-text question rather than a short data
  * field. Only consulted for <input>: a <textarea> is a question by definition.
  *
@@ -315,6 +353,8 @@ export function findOpenQuestions(root: ParentNode = document): OpenQuestion[] {
     if (isInput && !FREE_TEXT_INPUT_TYPES.has((el.getAttribute('type') || 'text').toLowerCase())) {
       continue;
     }
+    // A dropdown's answer comes from its option list, never from the AI.
+    if (isInput && isCombobox(el)) continue;
 
     const label = getLabelText(el);
     if (matchRule(label, el)) continue; // a standard field, not an essay question


### PR DESCRIPTION
## What & why

Reported live — three dropdowns each got an **✨ AI answer** button, rendered on
top of the control:

- "Have you previously worked at NISC or any of its subsidiaries in the past?"
- "Are you currently employed at an NISC Member site?"
- "How did you hear about this job?"

A native `<select>` was never a candidate — `findOpenQuestions` queries
`'textarea, input'`. But React combobox widgets render a real
`<input type="text">` as their search box (hence the "Select…" placeholder and
chevron in the report), and because these labels are questions they sailed
straight through the `looksLikeQuestion` gate added in #228.

An AI-drafted sentence is never a valid answer to a fixed option list, so these
get no button at all.

## The fix

Exclude inputs that carry the ARIA combobox contract:

| Signal | Why |
|---|---|
| `role="combobox"` / `role="listbox"` on the input | the standard pattern |
| …or on an ancestor | libraries often put the role on a wrapper |
| `aria-haspopup`, `aria-autocomplete`, `aria-expanded`, `aria-controls` | any keyboard-operable widget sets at least one |
| `list` | native `<datalist>` pairing |

## Testing — and one honest gap

- `npm run lint`, `npm run typecheck`, `npm test` (272 passed), `npm run build` — all pass.
- The pure `isComboboxLike()` is covered and mutation-checked:

| Mutation | Fails |
|---|---|
| Ignore a role on the wrapper | `detects widgets that put the role on a wrapper instead of the input` |
| Drop case-insensitive attribute matching | `is case-insensitive about attribute names` |

**But a third mutation survived, and that's worth flagging rather than hiding:**
deleting the `if (isInput && isCombobox(el)) continue;` call site in
`findOpenQuestions` fails **no** test. The predicate is pinned; the wiring is
not. That path needs a real DOM (`isFillable` uses `instanceof
HTMLInputElement`), which `environment: 'node'` doesn't provide, so it can't be
unit-tested as things stand. The one-line gate has to be verified by hand.

### Manual check needed

I inferred the markup from the screenshot rather than reading the DOM, so please
confirm on that form: the three dropdowns should have **no** button, while a
genuine free-text question still does.

If a button still shows, that widget isn't exposing any ARIA combobox attribute
— run this on the page and send me the output, and I'll widen the check:

```bash
copy(`[...document.querySelectorAll('input')].map(i=>({id:i.id,type:i.type,role:i.getAttribute('role'),attrs:i.getAttributeNames().join(','),ancestor:!!i.closest('[role=combobox],[role=listbox]')}))`)
```

## Checklist

- [x] `npm run lint` passes
- [x] `npm run typecheck` passes
- [x] `npm test` passes
- [x] `npm run build` succeeds
- [x] Tests added/updated if behavior changed
- [x] No secrets, keys, or personal data committed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of dropdown and combobox controls, including ARIA-based widgets and native datalists.
  * Prevented dropdown inputs from being incorrectly treated as free-text questions for AI-generated answers.
  * Preserved support for genuine free-text input fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->