### PR TITLE
chore(server): bump protobufjs to 7.6.5 (GHSA medium)

### DIFF
--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -9,7 +9,8 @@
       "version": "0.1.0",
       "dependencies": {
         "@google-cloud/firestore": "^8.7.1",
-        "@google-cloud/vertexai": "^1.9.3"
+        "@google-cloud/vertexai": "^1.9.3",
+        "protobufjs": "^7.6.5"
       },
       "engines": {
         "node": ">=20"
@@ -1126,9 +1127,9 @@
       }
     },
     "node_modules/protobufjs": {
-      "version": "7.6.4",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.4.tgz",
-      "integrity": "sha512-RJJPTTpvFfHcWLkIa2JFWK4XvtSzS0yEWDmunqHXli1h3JlkbcQZXDZdcWxv+JK3Xsl5/UFDPZ0iGm7DAengYw==",
+      "version": "7.6.5",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.5.tgz",
+      "integrity": "sha512-/FPD0nUc9jH6rfFjji9IBqOz4pcSE3CsT1m7Ep6Mdb0LxSUMj8hgl6GomOvZzpNpAqqGaXA0P3VSrZLFzIhQrw==",
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
       "dependencies": {

--- a/server/package.json
+++ b/server/package.json
@@ -12,6 +12,7 @@
   },
   "dependencies": {
     "@google-cloud/firestore": "^8.7.1",
-    "@google-cloud/vertexai": "^1.9.3"
+    "@google-cloud/vertexai": "^1.9.3",
+    "protobufjs": "^7.6.5"
   }
 }


### PR DESCRIPTION
## What & why

Follow-up to today's Dependabot alert review. Two medium-severity alerts were
open with no PR yet: `protobufjs` and `uuid`, both transitive under
`@google-cloud/firestore`. I checked each independently rather than treating
them as a pair — they resolve very differently.

**`protobufjs` 7.6.4 → 7.6.5** is safe: every parent in the tree (`google-gax`,
`@grpc/proto-loader`, `proto3-json-serializer`, `@google/genai`) declares a
`^7.x` range that already permits 7.6.5 —

```
node -e "require('semver').satisfies('7.6.5','^7.5.3')"  → true
node -e "require('semver').satisfies('7.6.5','^7.5.4')"  → true
node -e "require('semver').satisfies('7.6.5','^7.5.5')"  → true
node -e "require('semver').satisfies('7.6.5','^7.4.0')"  → true
```

so this is a lockfile-level patch, not a breaking bump. `npm install
protobufjs@7.6.5` added it as an **explicit** `server/package.json` dependency
rather than leaving it purely transitive — worth noting plainly since it does
change the dependency list, though the reasoning is that pinning it directly
means a future lockfile regen can't silently regress the patched version if a
parent's declared range shifts.

**`uuid` 9.0.1 → 11.1.1 is NOT included here.** `gaxios` declares `uuid@^9.0.1`,
which does not permit 11.x —

```
node -e "require('semver').satisfies('11.1.1','^9.0.1')"  → false
```

`npm audit fix --dry-run` confirms npm itself can't resolve it either — the
finding is unchanged before and after. Forcing it would need an `overrides`
entry against what `gaxios` itself declares, an unverified combination I'm not
willing to make silently. Filing that as its own tracking issue rather than
bundling a forced override into this PR.

## How I tested

- `cd server && node --check index.js` — passes.
- `npm audit` in `server/` no longer lists `protobufjs` (only the pre-existing,
  separately-tracked `uuid` finding remains).
- `npm ls @google-cloud/firestore @google-cloud/vertexai` — both still resolve
  cleanly.
- Root gate — `npm run lint`, `npm run typecheck`, `npm test` (266 passed),
  `npm run build` — unaffected, since this only touches `server/`.

## Checklist

- [x] `node --check server/index.js` passes
- [x] No secrets, keys, or personal data committed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added support for Protocol Buffers at runtime.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->