### PR TITLE
fix(adapters): stop Workday reporting its own pod id as the company

### DIFF
--- a/src/content/adapters/workday.test.ts
+++ b/src/content/adapters/workday.test.ts
@@ -14,6 +14,22 @@ describe('companyFromWorkdayUrl — tenant extraction across all three Workday d
       expect(companyFromWorkdayUrl('workday.wd5.myworkdayjobs.com', '/Workday')).toBe('Workday');
       expect(companyFromWorkdayUrl('path.wd1.myworkdayjobs.com', '/External')).toBe('Path');
     });
+
+    it('caught in review: a path that happens to contain "recruiting" must not steal the tenant from another domain\'s rule', () => {
+      // Before the fix, the /recruiting/ rule ran unconditionally regardless
+      // of domain, so this returned "Acme" (myworkdaysite.com's rule) instead
+      // of "Nvidia" (myworkdayjobs.com's own, correct rule).
+      expect(companyFromWorkdayUrl('nvidia.wd5.myworkdayjobs.com', '/recruiting/acme')).toBe(
+        'Nvidia',
+      );
+    });
+
+    it('caught in review: a bare apex with no tenant subdomain reports no company', () => {
+      // hostMatches('myworkdayjobs.com', 'myworkdayjobs.com') is true (exact
+      // match), but there's no subdomain to read a tenant from. Before the
+      // fix this returned "Myworkdayjobs" — the domain's own label.
+      expect(companyFromWorkdayUrl('myworkdayjobs.com', '/something')).toBe('');
+    });
   });
 
   describe('*.myworkday.com — the subdomain is an infra pod, the tenant is path segment 0', () => {

--- a/src/content/adapters/workday.test.ts
+++ b/src/content/adapters/workday.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect } from 'vitest';
+import { companyFromWorkdayUrl } from './workday';
+
+// Every hostname/pathname pair below is copied from a real, currently-live
+// Workday-hosted URL (found via web search while working on #178), not
+// invented — see the function's doc comment for why the three domains need
+// different rules.
+describe('companyFromWorkdayUrl — tenant extraction across all three Workday domains', () => {
+  describe('*.myworkdayjobs.com — the tenant is the subdomain', () => {
+    it('reads the tenant straight off the subdomain', () => {
+      expect(
+        companyFromWorkdayUrl('nvidia.wd5.myworkdayjobs.com', '/NVIDIAExternalCareerSite'),
+      ).toBe('Nvidia');
+      expect(companyFromWorkdayUrl('workday.wd5.myworkdayjobs.com', '/Workday')).toBe('Workday');
+      expect(companyFromWorkdayUrl('path.wd1.myworkdayjobs.com', '/External')).toBe('Path');
+    });
+  });
+
+  describe('*.myworkday.com — the subdomain is an infra pod, the tenant is path segment 0', () => {
+    it('extracts the tenant from the path when the subdomain is a wdN pod', () => {
+      expect(companyFromWorkdayUrl('wd5.myworkday.com', '/unf/d/task/1422$1841.htmld')).toBe(
+        'Unf',
+      );
+      expect(companyFromWorkdayUrl('wd12.myworkday.com', '/bsu/wdhelp/helpcenter')).toBe('Bsu');
+      expect(
+        companyFromWorkdayUrl('wd108.myworkday.com', '/msk/d/task/2998$46522.htmld'),
+      ).toBe('Msk');
+      expect(companyFromWorkdayUrl('wd10.myworkday.com', '/nait/d/task/2998$46522.htmld')).toBe(
+        'Nait',
+      );
+      expect(
+        companyFromWorkdayUrl('wd115.myworkday.com', '/saintfrancis/d/task/2998$46522.htmld'),
+      ).toBe('Saintfrancis');
+      expect(companyFromWorkdayUrl('wd503.myworkday.com', '/svsu/d/home.htmld')).toBe('Svsu');
+    });
+
+    it('was the reported bug: the pod id alone used to leak through as the company', () => {
+      // No path — nothing to fall back to, so the correct result is empty, not
+      // the pod id. An empty company surfaces the "enter a company" prompt
+      // instead of silently shipping a cover letter addressed to "Wd5".
+      expect(companyFromWorkdayUrl('wd5.myworkday.com', '/')).toBe('');
+      expect(companyFromWorkdayUrl('wd5.myworkday.com', '')).toBe('');
+    });
+
+    it('treats an impl/staging environment subdomain the same way', () => {
+      expect(companyFromWorkdayUrl('impl.wd5.myworkday.com', '/')).toBe('');
+      expect(companyFromWorkdayUrl('impl-services.wd5.myworkday.com', '/')).toBe('');
+    });
+  });
+
+  describe('*.myworkdaysite.com — the tenant follows "/recruiting/" in the path', () => {
+    it('reads the tenant after /recruiting/, regardless of the subdomain', () => {
+      // jobs.* subdomain, no locale prefix.
+      expect(
+        companyFromWorkdayUrl(
+          'jobs.myworkdaysite.com',
+          '/recruiting/acme/Search',
+        ),
+      ).toBe('Acme');
+      // wdN.* subdomain, no locale prefix.
+      expect(
+        companyFromWorkdayUrl(
+          'wd5.myworkdaysite.com',
+          '/recruiting/aaregional/Search/0/refreshFacet/318c8bb6f553100021d223d9780d30be',
+        ),
+      ).toBe('Aaregional');
+      // wdN.* subdomain WITH a locale segment before "recruiting" — this is
+      // exactly the case a naive "first path segment" rule gets wrong, since
+      // segment 0 here is "en-US", not the tenant.
+      expect(
+        companyFromWorkdayUrl('wd1.myworkdaysite.com', '/en-US/recruiting/abinbev/Search'),
+      ).toBe('Abinbev');
+    });
+
+    it('was the reported bug: the pod id used to leak through here too', () => {
+      expect(companyFromWorkdayUrl('wd1.myworkdaysite.com', '/')).toBe('');
+    });
+  });
+
+  describe('edge cases', () => {
+    it('still excludes a bare www subdomain', () => {
+      expect(companyFromWorkdayUrl('www.myworkday.com', '/')).toBe('');
+    });
+
+    it('does not treat a trailing "recruiting" with nothing after it as a match', () => {
+      // Caught by this test suite during development: the fix's first draft
+      // fell through to the segment-0 fallback here and returned "Recruiting"
+      // — the literal marker word, not a tenant.
+      expect(companyFromWorkdayUrl('wd5.myworkdaysite.com', '/recruiting')).toBe('');
+      expect(companyFromWorkdayUrl('wd5.myworkdaysite.com', '/recruiting/')).toBe('');
+      // Same failure mode with a locale prefix ahead of "recruiting" — must not
+      // fall through and return "En Us" either.
+      expect(companyFromWorkdayUrl('wd1.myworkdaysite.com', '/en-US/recruiting')).toBe('');
+    });
+
+    it('matches "recruiting" case-insensitively', () => {
+      expect(companyFromWorkdayUrl('wd5.myworkdaysite.com', '/Recruiting/acme')).toBe('Acme');
+    });
+  });
+});

--- a/src/content/adapters/workday.ts
+++ b/src/content/adapters/workday.ts
@@ -1,6 +1,53 @@
 import { type SiteAdapter, textOf, titleCaseSlug } from './types';
 import { hostMatches } from '../../lib/host';
 
+// Workday's own pod/environment subdomains and generic path prefixes — never a
+// customer tenant name.
+const INFRA_LABEL = /^(www|jobs|impl(-\w+)?|wd\d+)$/;
+
+/**
+ * Derives the tenant/company name from a Workday URL. The three domains this
+ * adapter matches put the tenant in different places — verified against real
+ * Workday-hosted URLs on each, not assumed:
+ *
+ * - `*.myworkdayjobs.com`: the tenant IS the subdomain, e.g.
+ *   `nvidia.wd5.myworkdayjobs.com/NVIDIAExternalCareerSite` → "Nvidia".
+ * - `*.myworkday.com`: the subdomain is Workday's own pod id (wd5, wd12, …),
+ *   and the tenant is the first path segment instead, e.g.
+ *   `wd5.myworkday.com/unf/d/task/…` → "Unf",
+ *   `wd12.myworkday.com/bsu/wdhelp/helpcenter` → "Bsu".
+ * - `*.myworkdaysite.com`: career sites are keyed off `/recruiting/{tenant}/`
+ *   in the PATH, regardless of subdomain — both `jobs.*` and `wd{N}.*` are
+ *   seen in the wild, and an optional locale segment can sit before
+ *   `recruiting`, e.g. `wd5.myworkdaysite.com/recruiting/aaregional/…` →
+ *   "Aaregional", `wd1.myworkdaysite.com/en-US/recruiting/abinbev/…` →
+ *   "Abinbev". This is why a single "always use path segment 0" rule doesn't
+ *   work across all three domains.
+ */
+export function companyFromWorkdayUrl(hostname: string, pathname: string): string {
+  const segs = pathname.split('/').filter(Boolean);
+
+  // Once "recruiting" appears anywhere in the path, commit to reading the
+  // tenant relative to it — this is unambiguously a myworkdaysite.com-style
+  // URL. Falling through to the segment-0 fallback below when there's nothing
+  // after "recruiting" would grab the literal word "recruiting" itself (or a
+  // locale prefix like "en-US"), not a tenant, so a bare listing page
+  // correctly yields '' instead of a fake company name.
+  const recruitingIdx = segs.findIndex((s) => s.toLowerCase() === 'recruiting');
+  if (recruitingIdx !== -1) {
+    return segs[recruitingIdx + 1] ? titleCaseSlug(segs[recruitingIdx + 1]) : '';
+  }
+
+  const sub = hostname.split('.')[0] ?? '';
+  if (sub && !INFRA_LABEL.test(sub)) return titleCaseSlug(sub);
+
+  // Subdomain is an infra/pod label rather than the tenant — myworkday.com
+  // puts the tenant as the first path segment instead. An empty result here
+  // (no path, or the whole subdomain+path is infra) is the correct outcome:
+  // it surfaces the "enter a company" prompt instead of shipping a wrong one.
+  return segs.length ? titleCaseSlug(segs[0]) : '';
+}
+
 // Workday application forms (*.myworkdayjobs.com, *.myworkday.com). Unlike
 // Greenhouse/Lever, Workday identifies fields with data-automation-id attributes
 // rather than <label> elements — the shared label reader humanizes those so the
@@ -26,13 +73,10 @@ export const workdayAdapter: SiteAdapter = {
       'h2',
     ]);
 
-    // Workday has no reliable company element; the tenant subdomain is the best
-    // signal, e.g. nvidia.wd5.myworkdayjobs.com → "Nvidia".
+    // Workday has no reliable company element; fall back to the URL. See
+    // companyFromWorkdayUrl for how the tenant is found — it differs by domain.
     let company = textOf(['[data-automation-id="company"]', "[class*='company']"]);
-    if (!company) {
-      const sub = location.hostname.split('.')[0];
-      if (sub && sub !== 'www') company = titleCaseSlug(sub);
-    }
+    if (!company) company = companyFromWorkdayUrl(location.hostname, location.pathname);
 
     return { company, role };
   },

--- a/src/content/adapters/workday.ts
+++ b/src/content/adapters/workday.ts
@@ -22,29 +22,45 @@ const INFRA_LABEL = /^(www|jobs|impl(-\w+)?|wd\d+)$/;
  *   `recruiting`, e.g. `wd5.myworkdaysite.com/recruiting/aaregional/…` →
  *   "Aaregional", `wd1.myworkdaysite.com/en-US/recruiting/abinbev/…` →
  *   "Abinbev". This is why a single "always use path segment 0" rule doesn't
- *   work across all three domains.
+ *   work across all three domains — the function below dispatches on which
+ *   domain matched before applying any rule, rather than applying one rule's
+ *   path shape to another domain's URLs.
  */
 export function companyFromWorkdayUrl(hostname: string, pathname: string): string {
   const segs = pathname.split('/').filter(Boolean);
 
-  // Once "recruiting" appears anywhere in the path, commit to reading the
-  // tenant relative to it — this is unambiguously a myworkdaysite.com-style
-  // URL. Falling through to the segment-0 fallback below when there's nothing
-  // after "recruiting" would grab the literal word "recruiting" itself (or a
-  // locale prefix like "en-US"), not a tenant, so a bare listing page
-  // correctly yields '' instead of a fake company name.
-  const recruitingIdx = segs.findIndex((s) => s.toLowerCase() === 'recruiting');
-  if (recruitingIdx !== -1) {
-    return segs[recruitingIdx + 1] ? titleCaseSlug(segs[recruitingIdx + 1]) : '';
+  // Dispatch on domain FIRST. The three rules above are domain-specific
+  // contracts, not universal heuristics — applying the /recruiting/ path rule
+  // regardless of domain, as an earlier version of this function did, let a
+  // myworkdayjobs.com URL whose site name happened to contain "recruiting"
+  // hijack a perfectly good subdomain-derived tenant (caught in review).
+  if (hostMatches(hostname, 'myworkdaysite.com')) {
+    // The tenant follows "recruiting" in the path; there is no subdomain
+    // fallback on this domain; a page with no "recruiting" segment (or
+    // nothing after it) has no tenant to report.
+    const recruitingIdx = segs.findIndex((s) => s.toLowerCase() === 'recruiting');
+    return recruitingIdx !== -1 && segs[recruitingIdx + 1]
+      ? titleCaseSlug(segs[recruitingIdx + 1])
+      : '';
   }
 
+  if (hostMatches(hostname, 'myworkdayjobs.com')) {
+    // The tenant IS the subdomain — but only when there IS one. A bare
+    // `myworkdayjobs.com` (also caught in review) has `labels.length === 2`,
+    // so `sub` would be the domain's own first label ("myworkdayjobs"), not a
+    // tenant.
+    const labels = hostname.split('.');
+    const sub = labels[0] ?? '';
+    return labels.length > 2 && sub && !INFRA_LABEL.test(sub) ? titleCaseSlug(sub) : '';
+  }
+
+  // myworkday.com: the subdomain is Workday's own pod id (wd5, wd12, …), not
+  // the tenant. The tenant is the first path segment instead. An empty result
+  // here (no path, or the pod id has no path to fall back to) is the correct
+  // outcome: it surfaces the "enter a company" prompt instead of shipping a
+  // wrong one.
   const sub = hostname.split('.')[0] ?? '';
   if (sub && !INFRA_LABEL.test(sub)) return titleCaseSlug(sub);
-
-  // Subdomain is an infra/pod label rather than the tenant — myworkday.com
-  // puts the tenant as the first path segment instead. An empty result here
-  // (no path, or the whole subdomain+path is infra) is the correct outcome:
-  // it surfaces the "enter a company" prompt instead of shipping a wrong one.
   return segs.length ? titleCaseSlug(segs[0]) : '';
 }
 


### PR DESCRIPTION
## What & why

Closes #178.

`getPageInfo()`'s URL fallback only excluded `www` from the hostname label, so
`*.myworkday.com` and `*.myworkdaysite.com` postings reported Workday's own
infrastructure labels as the company — `"Wd5"`, `"Impl"`, `"Wd1"`. That value
feeds the popup's company field, the AI prompts' `TARGET COMPANY:`, and the
cover-letter/resume filenames — and `canGenerateDocuments` only checks for
non-blank text, so a wrong value sails through with no warning. The user gets
a cover letter addressed to "Wd5".

## The fix needed real-URL verification, not just a wider regex

The issue's own draft proposed excluding `wd\d+`/`impl` from the hostname and
falling back to "path segment 0" uniformly. I verified that against real,
currently-live Workday-hosted URLs (via web search) before implementing, and
it would have been wrong for one of the three domains:

| Domain | Tenant location | Verified example |
|---|---|---|
| `*.myworkdayjobs.com` | the subdomain itself (already worked) | `nvidia.wd5.myworkdayjobs.com/NVIDIAExternalCareerSite` → **Nvidia** |
| `*.myworkday.com` | path segment 0 | `wd5.myworkday.com/unf/…` → **Unf**, `wd12.myworkday.com/bsu/…` → **Bsu** |
| `*.myworkdaysite.com` | whatever follows `/recruiting/` in the path | `wd1.myworkdaysite.com/en-US/recruiting/abinbev/…` → **Abinbev** |

That last row is why "always use path segment 0" doesn't generalize:
`myworkdaysite.com` URLs can carry a locale segment (`en-US`) before
`recruiting`, so segment 0 is frequently a locale code or the literal word
`recruiting` — never the tenant.

## A bug my own tests caught mid-implementation

The first version fell through to the segment-0 fallback when the path was a
bare `/recruiting` with nothing after it, and returned **`"Recruiting"`** — the
marker word itself, not a tenant. Fixed by committing to the
recruiting-relative extraction the moment `recruiting` is found anywhere in the
path, rather than falling through on a missing next segment. Both the buggy
case and the fix are in the test file with a comment explaining what broke.

## Implementation

Extracted `companyFromWorkdayUrl(hostname, pathname)` as a pure function per
the issue's suggestion, so it's testable under `environment: 'node'` without a
DOM — same pattern as `clampAxis`/`badgeSignature` elsewhere in this file.

## How I tested

- `npm run lint`, `npm run typecheck`, `npm test` (281 passed), `npm run build` — all pass.
- New `workday.test.ts` — every case is a real, verified live URL (cited in the
  function's doc comment), not invented, plus the four originally-reported bad
  cases and the recruiting-fallthrough edge case.
- **Mutation-checked all three load-bearing decisions**, each failing only its
  own tests:

| Mutation | Fails |
|---|---|
| Revert `INFRA_LABEL` to just `www` (the original bug) | 4 tests, incl. the reported bad cases |
| Restore the recruiting-fallthrough bug | `does not treat a trailing "recruiting" with nothing after it as a match` |
| Use the infra subdomain itself instead of path segment 0 | 5 tests, incl. `still excludes a bare www subdomain` |

## Checklist

- [x] `npm run lint` passes
- [x] `npm run typecheck` passes
- [x] `npm test` passes
- [x] `npm run build` succeeds
- [x] Tests added/updated if behavior changed
- [x] No secrets, keys, or personal data committed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for identifying company names from a wider range of Workday URL formats.
  * Company information can now be determined when it isn’t available directly on the page.

* **Bug Fixes**
  * Improved handling of tenant names, regional paths, staging environments, and locale prefixes.
  * Prevented infrastructure subdomains and unrelated path segments from being misidentified as company names.

* **Tests**
  * Added comprehensive coverage for Workday URL parsing scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->