### PR TITLE
fix(ai): detect truncated/blocked Gemini responses instead of guessing

### DIFF
--- a/src/lib/ai/gemini.test.ts
+++ b/src/lib/ai/gemini.test.ts
@@ -1,0 +1,86 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { GeminiProvider } from './gemini';
+import { AIError } from './provider';
+
+function mockGeminiResponse(body: unknown, ok = true, status = 200): void {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn().mockResolvedValue({
+      ok,
+      status,
+      json: () => Promise.resolve(body),
+      text: () => Promise.resolve(JSON.stringify(body)),
+    }),
+  );
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('GeminiProvider — finishReason handling (#182)', () => {
+  const generate = () =>
+    new GeminiProvider('fake-key').generate({ system: 'sys', prompt: 'prompt' });
+
+  it('returns the text unchanged on a normal STOP finish', async () => {
+    mockGeminiResponse({
+      candidates: [{ content: { parts: [{ text: 'A complete answer.' }] }, finishReason: 'STOP' }],
+    });
+    await expect(generate()).resolves.toBe('A complete answer.');
+  });
+
+  it('still returns the text when finishReason is absent (older/unversioned responses)', async () => {
+    // No regression for responses that never carried finishReason at all —
+    // this is the entire previous behavior of the function.
+    mockGeminiResponse({ candidates: [{ content: { parts: [{ text: 'Some answer.' }] } }] });
+    await expect(generate()).resolves.toBe('Some answer.');
+  });
+
+  it('names the cause when MAX_TOKENS cuts the response off almost immediately', async () => {
+    // The actual reported failure: the model's thinking budget consumed the
+    // entire output and left a single word.
+    mockGeminiResponse({
+      candidates: [{ content: { parts: [{ text: 'Fellow' }] }, finishReason: 'MAX_TOKENS' }],
+    });
+    await expect(generate()).rejects.toThrow(AIError);
+    await expect(generate()).rejects.toThrow(/cut off/i);
+  });
+
+  it('does NOT throw for MAX_TOKENS once a substantial answer already formed', async () => {
+    // Deliberate: discarding a mostly-complete answer because the budget ran
+    // out right at the end would be worse than returning it. This is the
+    // "leave partial-but-real output alone" half of the issue's proposed fix.
+    const longAnswer =
+      'This is a long, mostly complete answer that ran right up against the ' +
+      'output budget and got cut off at the very end without finishing the l';
+    mockGeminiResponse({
+      candidates: [{ content: { parts: [{ text: longAnswer }] }, finishReason: 'MAX_TOKENS' }],
+    });
+    await expect(generate()).resolves.toBe(longAnswer);
+  });
+
+  it('reports a safety block distinctly instead of "empty response"', async () => {
+    mockGeminiResponse({ candidates: [{ content: {}, finishReason: 'SAFETY' }] });
+    await expect(generate()).rejects.toThrow(AIError);
+    await expect(generate()).rejects.toThrow(/safety/i);
+  });
+
+  it('reports a recitation block distinctly instead of "empty response"', async () => {
+    mockGeminiResponse({ candidates: [{ content: {}, finishReason: 'RECITATION' }] });
+    await expect(generate()).rejects.toThrow(AIError);
+    await expect(generate()).rejects.toThrow(/matched existing content/i);
+  });
+
+  it('falls back to the generic empty-response error for a truly empty, unflagged response', async () => {
+    mockGeminiResponse({ candidates: [{ content: { parts: [{ text: '' }] }, finishReason: 'STOP' }] });
+    await expect(generate()).rejects.toThrow(AIError);
+    await expect(generate()).rejects.toThrow(/empty response/i);
+  });
+
+  it('trims whitespace-only text the same as empty', async () => {
+    mockGeminiResponse({
+      candidates: [{ content: { parts: [{ text: '   \n  ' }] }, finishReason: 'STOP' }],
+    });
+    await expect(generate()).rejects.toThrow(/empty response/i);
+  });
+});

--- a/src/lib/ai/gemini.ts
+++ b/src/lib/ai/gemini.ts
@@ -74,14 +74,46 @@ export class GeminiProvider implements AIProvider {
     }
 
     const data = (await res.json()) as GeminiResponse;
-    const text = data.candidates?.[0]?.content?.parts?.map((p) => p.text).join('') ?? '';
-    if (!text.trim()) {
+    const candidate = data.candidates?.[0];
+    const text = (candidate?.content?.parts?.map((p) => p.text).join('') ?? '').trim();
+    const finishReason = candidate?.finishReason;
+
+    if (finishReason === 'SAFETY') {
+      throw new AIError('Gemini blocked this response for safety reasons. Try rephrasing.');
+    }
+    if (finishReason === 'RECITATION') {
+      throw new AIError(
+        'Gemini blocked this response because it matched existing content too closely. Try rephrasing.',
+      );
+    }
+    // MAX_TOKENS with a substantial answer already in hand is left alone —
+    // the codebase spends real effort tuning thinkingBudget to avoid exactly
+    // this (see above), and discarding a mostly-complete answer because the
+    // budget ran out right at the end would be worse than returning it. Only
+    // the case that matches what was actually observed in the wild — the
+    // budget being exhausted before any real answer formed, e.g. a single
+    // word ("Fellow") — gets its own message rather than the generic one.
+    if (finishReason === 'MAX_TOKENS' && text.length < MIN_VIABLE_ANSWER_LENGTH) {
+      throw new AIError(
+        "Gemini's response was cut off before it could really start (ran out of output budget). Try again.",
+      );
+    }
+    if (!text) {
       throw new AIError('Gemini returned an empty response. Try rephrasing or retry.');
     }
-    return text.trim();
+    return text;
   }
 }
 
+// Below this, a MAX_TOKENS cutoff reads as "the budget ran out almost
+// immediately" rather than "a real answer got clipped near the end" — chosen
+// well under the shortest legitimate reply this codebase asks for (the
+// free-text answer prompt's own floor is "about 4-6 sentences").
+const MIN_VIABLE_ANSWER_LENGTH = 40;
+
 interface GeminiResponse {
-  candidates?: Array<{ content?: { parts?: Array<{ text?: string }> } }>;
+  candidates?: Array<{
+    content?: { parts?: Array<{ text?: string }> };
+    finishReason?: string;
+  }>;
 }


### PR DESCRIPTION
## What & why

Closes #182.

`GeminiResponse` never declared `finishReason`, so it couldn't be checked. When
the model's thinking budget consumed the entire output — the exact failure this
file already tunes `thinkingConfig` to avoid, per the comment two lines above —
the partial text (observed in the wild as a single word, `"Fellow"`) still
passed the only guard (`!text.trim()`) and was returned as a finished answer.
`SAFETY` and `RECITATION` blocks landed on the same generic *"returned an empty
response. Try rephrasing or retry."*, which is actively wrong advice for a
safety block — retrying identical input against a content filter does nothing.

## Scope

The issue laid out two options: thread a truncation flag through
`AIProvider.generate()`'s `Promise<string>` return type (touches every
provider — Gemini, OnDevice, future Proxy — and every caller), or handle the
smaller, real case. I took the smaller one:

| Case | Behavior |
|---|---|
| `SAFETY` | own `AIError` message |
| `RECITATION` | own `AIError` message |
| `MAX_TOKENS`, text < 40 chars | message naming the actual cause |
| `MAX_TOKENS`, substantial text already formed | **unchanged** — returned as-is |
| No `finishReason` at all (older/unversioned responses) | **unchanged** — same empty check as before |

The `MAX_TOKENS`-with-substantial-text row is deliberate, not an oversight:
discarding a mostly-complete answer because the budget ran out right at the end
would be worse than returning it. That's the "surface a warning on
partial-but-real output" half the issue explicitly said was fine to defer —
doing it means threading state through the return type, which is exactly the
larger change this PR avoids.

The 40-char threshold (`MIN_VIABLE_ANSWER_LENGTH`) is chosen well under this
file's own floor for a legitimate answer — `buildAnswerPrompt`'s system prompt
asks for "about 4-6 sentences" — so it catches "the budget ran out almost
immediately" without risking a real short-but-valid reply.

## How I tested

- `npm run lint`, `npm run typecheck`, `npm test` (280 passed), `npm run build` — all pass.
- New `gemini.test.ts` — `GeminiProvider` had no test coverage at all. 8 cases,
  including the exact reported failure (`MAX_TOKENS` + `"Fellow"`) and the
  no-regression case (no `finishReason` present).
- **Mutation-checked all four branches**, each failing only its own test:

| Mutation | Fails |
|---|---|
| Drop the `SAFETY` branch | `reports a safety block distinctly...` |
| Drop the length guard (would reject substantial truncated answers too) | `does NOT throw for MAX_TOKENS once a substantial answer already formed` |
| Threshold → 0 (never catches the reported bug) | `names the cause when MAX_TOKENS cuts the response off almost immediately` |
| Drop the `RECITATION` branch | `reports a recitation block distinctly...` |

## Scope note carried over from the issue

This covers the **BYO-key path only**. The managed-proxy path can't report this
yet — `server/index.js` builds its response from `parts` alone and discards
`finishReason` server-side before the extension ever sees it. That needs a
server response-shape change and a redeploy, so it's separate work, not part of
this PR.

## Checklist

- [x] `npm run lint` passes
- [x] `npm run typecheck` passes
- [x] `npm test` passes
- [x] `npm run build` succeeds
- [x] Tests added/updated if behavior changed
- [x] No secrets, keys, or personal data committed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved AI response handling for safety and recitation blocks.
  - Prevented nearly empty responses caused by token limits from being treated as valid answers.
  - Preserved substantial answers that are truncated by token limits.
  - Improved handling of empty and whitespace-only responses.

- **Tests**
  - Added comprehensive coverage for response completion and blocking scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->