### PR TITLE
feat(options): upload several documents at once

### DIFF
--- a/src/lib/documents.test.ts
+++ b/src/lib/documents.test.ts
@@ -12,7 +12,7 @@ vi.mock('mammoth', () => ({
   convertToHtml: vi.fn().mockResolvedValue({ value: '' }),
 }));
 
-import { extractText } from './documents';
+import { extractText, extractTextBatch } from './documents';
 
 describe('extractText', () => {
   it('warns when a text file is empty', async () => {
@@ -79,5 +79,77 @@ describe('extractText', () => {
       text: '',
       warning: 'Legacy .doc is not supported — please upload a PDF or .docx.',
     });
+  });
+});
+
+describe('extractTextBatch — multi-file upload', () => {
+  const txt = (name: string, body: string) =>
+    new File([body], name, { type: 'text/plain' });
+
+  it('extracts every file in the batch, tagged with its own name', async () => {
+    const results = await extractTextBatch([
+      txt('a.txt', 'first document'),
+      txt('b.txt', 'second document'),
+      txt('c.txt', 'third document'),
+    ]);
+
+    expect(results.map((r) => r.name)).toEqual(['a.txt', 'b.txt', 'c.txt']);
+    expect(results.map((r) => r.text)).toEqual([
+      'first document',
+      'second document',
+      'third document',
+    ]);
+    expect(results.every((r) => r.warning === undefined)).toBe(true);
+  });
+
+  it('keeps going after a bad file instead of losing the whole batch', async () => {
+    // The point of the batch helper: picking one scanned/unsupported PDF
+    // alongside three good files must not discard the three good ones.
+    const results = await extractTextBatch([
+      txt('good-1.txt', 'kept'),
+      new File([], 'legacy.doc', { type: 'application/msword' }),
+      txt('good-2.txt', 'also kept'),
+    ]);
+
+    expect(results).toHaveLength(3);
+    expect(results[0].text).toBe('kept');
+    expect(results[2].text).toBe('also kept');
+    // The bad one is reported, not silently dropped, and names itself.
+    expect(results[1].text).toBe('');
+    expect(results[1].name).toBe('legacy.doc');
+    expect(results[1].warning).toMatch(/Legacy \.doc is not supported/);
+  });
+
+  it('converts a thrown error into that file\'s warning rather than rejecting', async () => {
+    // A PDF whose parse throws would previously abort the entire upload.
+    getDocumentMock.mockReturnValueOnce({
+      promise: Promise.reject(new Error('corrupt pdf')),
+    });
+    const results = await extractTextBatch([
+      new File([], 'broken.pdf', { type: 'application/pdf' }),
+      txt('fine.txt', 'survives'),
+    ]);
+
+    expect(results[0].warning).toMatch(/could not read file/i);
+    expect(results[0].warning).toMatch(/corrupt pdf/);
+    expect(results[1].text).toBe('survives');
+  });
+
+  it('reports progress as each file completes', async () => {
+    const seen: Array<[number, number]> = [];
+    await extractTextBatch([txt('a.txt', 'one'), txt('b.txt', 'two')], (done, total) =>
+      seen.push([done, total]),
+    );
+    // Fires before each file, then once more at the end so the UI can settle
+    // on "2 of 2" rather than stalling at "1 of 2".
+    expect(seen).toEqual([
+      [0, 2],
+      [1, 2],
+      [2, 2],
+    ]);
+  });
+
+  it('handles an empty selection without calling through', async () => {
+    await expect(extractTextBatch([])).resolves.toEqual([]);
   });
 });

--- a/src/lib/documents.ts
+++ b/src/lib/documents.ts
@@ -13,6 +13,45 @@ export interface ExtractResult {
   warning?: string;
 }
 
+/** One file's outcome from extractTextBatch, tagged with which file it was. */
+export interface BatchExtractResult extends ExtractResult {
+  name: string;
+}
+
+/**
+ * Extracts text from several files, one after another.
+ *
+ * A failure on one file must NOT abandon the rest: with multi-select a user can
+ * easily pick a scanned PDF alongside three good ones, and losing all four to
+ * the first thrown error would be worse than reporting the one that failed. So
+ * a throw is converted into that file's own `warning` and the loop continues.
+ *
+ * Sequential rather than Promise.all on purpose — PDF parsing is CPU-heavy, and
+ * running several at once would jam the options page and make the progress
+ * count meaningless.
+ */
+export async function extractTextBatch(
+  files: readonly File[],
+  onProgress?: (done: number, total: number) => void,
+): Promise<BatchExtractResult[]> {
+  const out: BatchExtractResult[] = [];
+  for (const [i, file] of files.entries()) {
+    onProgress?.(i, files.length);
+    try {
+      const { text, warning } = await extractText(file);
+      out.push({ name: file.name, text, warning });
+    } catch (err) {
+      out.push({
+        name: file.name,
+        text: '',
+        warning: `Could not read file: ${(err as Error).message}`,
+      });
+    }
+  }
+  onProgress?.(files.length, files.length);
+  return out;
+}
+
 export async function extractText(file: File): Promise<ExtractResult> {
   const name = file.name.toLowerCase();
   let result: ExtractResult;

--- a/src/options/Options.tsx
+++ b/src/options/Options.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from 'react';
 import { Field } from './Field';
 import type { EducationEntry, Profile, WorkEntry } from '../lib/profile';
 import { useProfile } from '../ui/useProfile';
-import { extractText } from '../lib/documents';
+import { extractText, extractTextBatch } from '../lib/documents';
 import { sendToBackground } from '../lib/messages';
 import type { AIResult } from '../lib/messages';
 import { parseResumeJson } from '../lib/resumeImport';
@@ -659,32 +659,45 @@ function ResumeUpload({
 }
 
 function DocUpload({ onText }: { onText: (name: string, text: string) => void }) {
-  const [busy, setBusy] = useState(false);
-  const [warn, setWarn] = useState('');
+  const [progress, setProgress] = useState<{ done: number; total: number } | null>(null);
+  // One entry per file that had a problem, so a bad file in a batch of good
+  // ones is identifiable rather than a single anonymous "could not read file".
+  const [warnings, setWarnings] = useState<string[]>([]);
 
   async function handle(e: React.ChangeEvent<HTMLInputElement>) {
-    const file = e.target.files?.[0];
+    const files = Array.from(e.target.files ?? []);
     e.target.value = '';
-    if (!file) return;
-    setBusy(true);
-    setWarn('');
-    try {
-      const { text, warning } = await extractText(file);
-      if (warning) setWarn(warning);
-      if (text) onText(file.name, text);
-    } catch (err) {
-      setWarn(`Could not read file: ${(err as Error).message}`);
-    } finally {
-      setBusy(false);
+    if (!files.length) return;
+
+    setWarnings([]);
+    setProgress({ done: 0, total: files.length });
+
+    const results = await extractTextBatch(files, (done, total) => setProgress({ done, total }));
+
+    for (const r of results) {
+      if (r.text) onText(r.name, r.text);
     }
+    setProgress(null);
+    setWarnings(results.filter((r) => r.warning).map((r) => `${r.name}: ${r.warning}`));
   }
 
+  const busy = progress !== null;
   return (
     <div className="field">
-      <label>Upload PDF / DOCX / TXT</label>
-      <input type="file" accept=".pdf,.docx,.txt,.md" onChange={handle} disabled={busy} />
-      {busy && <div className="help">Extracting text…</div>}
-      {warn && <div className="warn">{warn}</div>}
+      <label>Upload PDF / DOCX / TXT — you can pick several at once</label>
+      <input type="file" accept=".pdf,.docx,.txt,.md" multiple onChange={handle} disabled={busy} />
+      {progress && (
+        <div className="help">
+          {progress.total === 1
+            ? 'Extracting text…'
+            : `Extracting text… ${progress.done} of ${progress.total}`}
+        </div>
+      )}
+      {warnings.map((w) => (
+        <div className="warn" key={w}>
+          {w}
+        </div>
+      ))}
     </div>
   );
 }


### PR DESCRIPTION
## What & why

The **Additional documents** picker took one file per click, so adding three
PDFs meant three round trips through the file dialog.

## Adding `multiple` alone would have made things worse

The old handler wrapped its single `extractText` call in one `try/catch`:

```ts
const file = e.target.files?.[0];
try {
  const { text, warning } = await extractText(file);
  ...
} catch (err) {
  setWarn(`Could not read file: ${(err as Error).message}`);
}
```

Fine for one file. With a batch, the **first** file that throws abandons every
file after it — pick one scanned PDF alongside three good ones and you'd
silently lose all four. The single `setWarn` would also collapse a whole
batch's problems into one anonymous message with no indication of which file
failed.

So the batching lives in `extractTextBatch()` in `documents.ts`, which converts
a per-file throw into that file's own `warning` and carries on.

## Behaviour

| | Before | After |
|---|---|---|
| Selection | one file per dialog | several at once |
| One file fails | rest of batch lost | rest still imported |
| Warning | anonymous, overwritten | one per file, names the file |
| Progress | "Extracting text…" | "Extracting text… 2 of 3" (unchanged for a single file) |

Sequential rather than `Promise.all` on purpose — PDF parsing is CPU-heavy and
running several at once would jam the options page and make the progress count
meaningless.

## Why the logic went in `documents.ts`

`documents.test.ts` already mocks `pdfjs`/`mammoth` and constructs real `File`
objects, so putting the batch loop there makes it genuinely testable under
`environment: 'node'` — rather than stranding it inside a React component where
it couldn't be covered at all.

`ResumeUpload` is deliberately left single-file: the resume **replaces**
`resumeText` rather than appending, so multi-select there has no meaning.

## How I tested

- `npm run lint`, `npm run typecheck`, `npm test` (296 passed), `npm run build` — all pass.
- 5 new cases, including the two that describe the actual point of the change:
  a bad file mid-batch not costing the good ones, and a *thrown* PDF error
  becoming a warning rather than rejecting the whole promise.
- **Mutation-checked both**, each failing only its own test:

| Mutation | Fails |
|---|---|
| Remove the per-file `catch` (one bad file kills the batch) | `converts a thrown error into that file's warning rather than rejecting` |
| Drop the terminal progress call (UI stalls at "1 of 2") | `reports progress as each file completes` |

### Manual

Options → Additional documents → **Choose Files** → select several PDFs at once.
All should appear in the list with their char counts, and the progress line
should count through them.

## Checklist

- [x] `npm run lint` passes
- [x] `npm run typecheck` passes
- [x] `npm test` passes
- [x] `npm run build` succeeds
- [x] Tests added/updated if behavior changed
- [x] No secrets, keys, or personal data committed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for selecting and importing multiple documents at once.
  - Added extraction progress feedback while files are being processed.
  - Successfully extracted documents are added individually and retain their filenames.
  - Processing continues when a file is unsupported or extraction fails, with per-file warnings displayed.

- **Bug Fixes**
  - Empty file selections are handled without errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->