### PR TITLE
fix(content): autofill ATS forms embedded as an iframe

### DIFF
--- a/src/content/index.ts
+++ b/src/content/index.ts
@@ -16,7 +16,13 @@ import { leverAdapter } from './adapters/lever';
 import { workdayAdapter } from './adapters/workday';
 import { ashbyAdapter } from './adapters/ashby';
 import type { SiteAdapter } from './adapters/types';
-import { CONTEXT_LOST_MESSAGE, isContextInvalidated, sendToBackground } from '../lib/messages';
+import {
+  CONTEXT_LOST_MESSAGE,
+  isContextInvalidated,
+  pageMessageRole,
+  sendToBackground,
+  UNSUPPORTED_REPLY_DELAY_MS,
+} from '../lib/messages';
 import type { AIResult, CapturedJob, ContentMessage, FillResult, PageInfo } from '../lib/messages';
 import {
   startSponsorshipWatch,
@@ -56,7 +62,8 @@ const isTopFrame = window.top === window.self;
 // answered by the top frame AND any job-board sub-frame: empty frames poll the full
 // timeout and reply last, so whichever frame really holds the posting wins the
 // sendMessage race. Ad / tracker sub-frames are excluded by host so they can't
-// answer with their own body text. PAGE_INFO / PAGE_FILL stay top-frame only.
+// answer with their own body text. PAGE_INFO / PAGE_FILL use a different rule —
+// see pageMessageRole.
 const JOB_HOSTS = [
   'linkedin.com', 'joinhandshake.com', 'greenhouse.io', 'lever.co',
   'myworkdayjobs.com', 'myworkday.com', 'myworkdaysite.com', 'ashbyhq.com', 'ycombinator.com',
@@ -73,15 +80,44 @@ chrome.runtime.onMessage.addListener((msg: ContentMessage, _sender, sendResponse
     });
     return true;
   }
-  if (!isTopFrame) return false;
+  // PAGE_INFO / PAGE_FILL are answered by whichever frame an adapter matched —
+  // the top frame normally, or the ATS's own iframe when a company careers site
+  // embeds the application form. See pageMessageRole for the race it resolves.
+  const role = pageMessageRole(adapter !== null, isTopFrame);
+  if (role === 'ignore') return false;
+
   if (msg.type === 'PAGE_INFO') {
-    const info: PageInfo = adapter
-      ? { supported: true, site: adapter.id, ...adapter.getPageInfo(), jobText: getScanText() }
-      : { supported: false, site: null, company: '', role: '', jobText: '' };
-    sendResponse(info);
+    if (!adapter) {
+      // role === 'answer-late': concede "unsupported" only after giving an
+      // adapter-matching sub-frame time to answer first.
+      setTimeout(
+        () =>
+          sendResponse({
+            supported: false,
+            site: null,
+            company: '',
+            role: '',
+            jobText: '',
+          } satisfies PageInfo),
+        UNSUPPORTED_REPLY_DELAY_MS,
+      );
+      return true;
+    }
+    sendResponse({
+      supported: true,
+      site: adapter.id,
+      ...adapter.getPageInfo(),
+      jobText: getScanText(),
+    } satisfies PageInfo);
     return false;
   }
   if (msg.type === 'PAGE_FILL') {
+    // Only the adapter's own frame fills. The popup disables Fill unless some
+    // frame reported supported, so an adapter-less frame acting here could only
+    // ever be the wrong one — a careers page filling its own newsletter signup
+    // while the real form sits in the iframe. Restricting it to one frame also
+    // means there are no per-frame summaries to merge.
+    if (!adapter) return false;
     getProfile()
       .then((profile) => {
         const summary = applyStandardFills(profile);

--- a/src/lib/messages.test.ts
+++ b/src/lib/messages.test.ts
@@ -1,5 +1,11 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { CONTEXT_LOST_MESSAGE, isContextInvalidated, sendToBackground } from './messages';
+import {
+  CONTEXT_LOST_MESSAGE,
+  isContextInvalidated,
+  pageMessageRole,
+  sendToBackground,
+  UNSUPPORTED_REPLY_DELAY_MS,
+} from './messages';
 
 afterEach(() => {
   vi.unstubAllGlobals();
@@ -64,5 +70,35 @@ describe('sendToBackground — orphaned content script', () => {
   it('stays readable after the badge truncates it to 32 characters', () => {
     // The AI-check button slices the message; the action must survive.
     expect(CONTEXT_LOST_MESSAGE.slice(0, 32)).toContain('Refresh this page');
+  });
+});
+
+describe('pageMessageRole — which frame answers PAGE_INFO / PAGE_FILL', () => {
+  it('lets the frame an adapter matched answer immediately', () => {
+    // The normal case: a Greenhouse/Lever/Workday/Ashby page opened directly.
+    expect(pageMessageRole(true, true)).toBe('answer');
+  });
+
+  it('lets an adapter-matching SUB-frame answer immediately too', () => {
+    // The bug this fixes: a company careers site embedding the ATS in an
+    // iframe. The sub-frame holds the real form, so it must be allowed to win.
+    expect(pageMessageRole(true, false)).toBe('answer');
+  });
+
+  it('makes the adapter-less top frame concede late rather than never', () => {
+    // It still has to reply — on a genuinely unsupported page nobody else will
+    // and the popup would hang — but late, so an embedded ATS frame beats it.
+    expect(pageMessageRole(false, true)).toBe('answer-late');
+  });
+
+  it('keeps an adapter-less sub-frame silent', () => {
+    // An ad or tracker iframe has nothing to say about the application form,
+    // and letting it answer would let it win the race with an empty reply.
+    expect(pageMessageRole(false, false)).toBe('ignore');
+  });
+
+  it('concedes fast enough to stay imperceptible on an unsupported page', () => {
+    expect(UNSUPPORTED_REPLY_DELAY_MS).toBeGreaterThan(0);
+    expect(UNSUPPORTED_REPLY_DELAY_MS).toBeLessThanOrEqual(1000);
   });
 });

--- a/src/lib/messages.ts
+++ b/src/lib/messages.ts
@@ -82,6 +82,39 @@ export interface AIResult {
   error?: string;
 }
 
+/** What a frame should do with a PAGE_INFO / PAGE_FILL message. */
+export type FrameRole = 'answer' | 'answer-late' | 'ignore';
+
+/**
+ * Decides which frame answers PAGE_INFO / PAGE_FILL.
+ *
+ * chrome.tabs.sendMessage delivers to EVERY frame and keeps only the first
+ * sendResponse, so the frame that actually holds the application form has to
+ * win that race. Normally that's the top frame, but a company careers site can
+ * embed the ATS in an iframe — then the top frame is the company's domain and
+ * matches no adapter, while the sub-frame does.
+ *
+ * - A frame an adapter matched answers straight away, top-level or not.
+ * - The top frame with no adapter answers LATE, so an adapter-matching
+ *   sub-frame beats it. It must still answer eventually: on a genuinely
+ *   unsupported page nobody else will, and the popup needs its "unsupported"
+ *   reply. This is the same deliberate-delay technique the CAPTURE_JOB handler
+ *   already relies on.
+ * - A sub-frame with no adapter stays quiet — an ad or tracker iframe has
+ *   nothing to say about the application form.
+ */
+export function pageMessageRole(hasAdapter: boolean, isTopFrame: boolean): FrameRole {
+  if (hasAdapter) return 'answer';
+  return isTopFrame ? 'answer-late' : 'ignore';
+}
+
+/**
+ * How long the adapter-less top frame waits before conceding "unsupported".
+ * Long enough for an ATS iframe's content script to win the race, short enough
+ * that a genuinely unsupported page still feels instant.
+ */
+export const UNSUPPORTED_REPLY_DELAY_MS = 400;
+
 /**
  * Shown instead of Chrome's internal "Extension context invalidated."
  *


### PR DESCRIPTION
## What & why

Closes #218.

`PAGE_INFO`/`PAGE_FILL` bailed on `if (!isTopFrame) return false`. When a company
careers site embeds the ATS in an iframe, the top frame is the company's domain,
matches no adapter, reports `supported: false`, and the popup's Fill button stays
disabled — even though the content script *is* running in the sub-frame and
`applyStandardFills()` would work there.

## The design decision

The issue laid out two directions and said one had to be chosen. I took the
**frame-race** one — no new permissions, no `frameId` plumbing through
`sendToTab` — but with a refinement that answers the objection recorded against it:

| Frame | Behaviour |
|---|---|
| Adapter matched (top-level **or** sub-frame) | answers immediately |
| Top frame, no adapter | answers **late** — an embedded ATS frame wins the race, but a genuinely unsupported page still gets its reply instead of hanging |
| Sub-frame, no adapter | **silent** — an ad/tracker iframe can never win with an empty reply |

This is the same deliberate-delay technique the `CAPTURE_JOB` handler already
documents and relies on, so it follows existing precedent rather than
introducing a second mechanism.

### The aggregation problem dissolves

The issue flagged that a multi-frame fill "would need to sum summaries rather
than take the first responder." `PAGE_FILL` now additionally **requires** an
adapter, so exactly one frame ever fills — there is nothing to merge.

That restriction is also correct on its own merits: it stops a careers page
autofilling its own unrelated forms (a newsletter signup, say) while the real
application sits in the iframe. It's safe because the popup disables Fill unless
some frame reported `supported`, so an adapter-less frame acting here could only
ever be the wrong one.

## Testability

The routing decision is a pure `pageMessageRole(hasAdapter, isTopFrame)` in
`messages.ts` — `content/index.ts` registers `chrome` listeners at module scope,
so nothing exported from it can be imported under `environment: 'node'`.

## How I tested

- `npm run lint`, `npm run typecheck`, `npm test` (296 passed), `npm run build` — all pass.
- **Mutation-checked**, each failing only its own tests:

| Mutation | Fails |
|---|---|
| Revert to top-frame-only (the original bug) | `lets an adapter-matching SUB-frame answer immediately too`, `makes the adapter-less top frame concede late rather than never` |
| Let adapter-less sub-frames answer too | `keeps an adapter-less sub-frame silent` |

### Manual check needed

The frame behaviour can't be unit-tested end to end. Worth confirming:

1. **No regression** on a directly-opened Greenhouse/Lever/Workday/Ashby posting —
   identical to today (adapter frame answers immediately, no delay).
2. **The fix** on a careers site that embeds an ATS iframe — Fill should now
   enable and fill the embedded form.
3. **A genuinely unsupported page** still shows "Open a Greenhouse, Lever,
   Workday, or Ashby application page…" — just ~400ms later than before.

## Checklist

- [x] `npm run lint` passes
- [x] `npm run typecheck` passes
- [x] `npm test` passes
- [x] `npm run build` succeeds
- [x] Tests added/updated if behavior changed
- [x] No secrets, keys, or personal data committed