### PR TITLE
fix: handle storage write errors in job pick and delete handlers

### DIFF
--- a/src/popup/Popup.tsx
+++ b/src/popup/Popup.tsx
@@ -273,6 +273,30 @@ const copyTimer = useRef<number | null>(null);
     }
   }
 
+  async function onPickJob(id: string) {
+    setError('');
+    try {
+      await setActiveJob(id === activeJobId ? null : id);
+      if (id === activeJobId) {
+        flashFillMsg('Now using the current page for AI answers.');
+      } else {
+        flashFillMsg('Using saved job for AI answers.');
+      }
+    } catch {
+      setError('Could not update the active job. Try again.');
+    }
+  }
+
+  async function onDeleteJob(id: string) {
+    setError('');
+    try {
+      await deleteJob(id);
+      flashFillMsg('Job deleted.');
+    } catch {
+      setError('Could not delete the job. Try again.');
+    }
+  }
+
   async function onCoverLetter() {
     setBusy('letter');
     setError('');
@@ -452,7 +476,7 @@ const copyTimer = useRef<number | null>(null);
                     <button
                       className="jobpick"
                       title="Use this posting as the context for AI answers & documents"
-                      onClick={() => setActiveJob(j.id === activeJobId ? null : j.id)}
+                      onClick={() => onPickJob(j.id)}
                       aria-label={`${j.id === activeJobId ? 'Stop using' : 'Use'} ${j.role || 'saved job'}${j.company ? ` at ${j.company}` : ''} as AI context`}
                     >
                       <span className="dot" />
@@ -476,7 +500,7 @@ const copyTimer = useRef<number | null>(null);
   aria-label={`Delete ${j.role || 'saved job'}…`}
   onClick={() => {
     if (window.confirm(`Delete the saved job "${j.role || 'this job'}"? This can't be undone.`)) {
-      void deleteJob(j.id);
+      onDeleteJob(j.id);
     }
   }}
 >


### PR DESCRIPTION
## Summary

Fixes #252 by extracting two inline `onClick` handlers into named async functions that properly `await` storage writes and surface errors to the user.

## The Bug

Two handlers in the saved-job list fired off promises and discarded the results:

1. **Job pick toggle** (line ~455): `onClick={() => setActiveJob(j.id === activeJobId ? null : j.id)}` — called `setActiveJob` directly without awaiting, so storage write failures were silently swallowed.
2. **Delete handler** (line ~479): `onClick={() => { ... void deleteJob(j.id); }}` — explicitly used `void` to discard the promise, so deletions that failed due to quota exceeded would appear to succeed.

Both call `chrome.storage.local.set` which can reject when the extension's storage quota is reached. The sibling handler `onUseCurrentPage` already did this correctly with try/catch — these two just weren't following the same pattern.

## The Fix

Extract both into named async handlers:

- `onPickJob(id: string)` — wraps `setActiveJob` with await + try/catch, shows "Could not update the active job" on failure
- `onDeleteJob(id: string)` — wraps `deleteJob` with await + try/catch, shows "Could not delete the job" on failure

Both also use `flashFillMsg` for success feedback, matching the existing UX pattern.

## Test Plan

- `npm test` — 291 tests pass
- `npm run typecheck` — clean
- Manual verification: temporarily make `saveSavedJobs` throw and confirm both actions show an error toast

Closes #252


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for selecting a saved job and making it active.
  * Added the ability to delete saved jobs directly from the popup.

* **Bug Fixes**
  * Improved feedback by displaying success messages and surfacing errors when saved-job actions fail.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->