### PR TITLE
chore(deps): bump github/codeql-action init+analyze to 4.37.7

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -21,13 +21,13 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@5595ccaf912efad79be6eef63a5619ff05969be3 # v4
+        uses: github/codeql-action/init@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4
         with:
           languages: javascript-typescript
           queries: security-and-quality
 
       # JS/TS is interpreted — no build step needed before analysis.
       - name: Perform CodeQL analysis
-        uses: github/codeql-action/analyze@5595ccaf912efad79be6eef63a5619ff05969be3 # v4
+        uses: github/codeql-action/analyze@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4
         with:
           category: '/language:javascript-typescript'


### PR DESCRIPTION
## What & why

Supersedes #247 (`init`) and #246 (`analyze`).

CodeQL requires `init` and `analyze` to run the **same** action version.
Dependabot bumps one path per PR and can't know they're coupled, so each PR
alone leaves a mismatched pair — both are currently red on
`Analyze (javascript-typescript)` and neither can ever go green by itself.

Both refs move to the same SHA (`ff2f1c62…`, v4.37.7) in one commit.

Identical coupling to #212/#213, resolved the same way in #214.

## How I tested

CI on this PR is the test — the `Analyze` job passing is precisely what fails
on the two split PRs.

## Checklist

- [x] No secrets, keys, or personal data committed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated security analysis tooling to a newer verified revision.
  * Existing analysis languages, queries, and reporting configuration remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->