### PR TITLE
fix: mark trimmed saved job previews

### DIFF
--- a/src/popup/Popup.tsx
+++ b/src/popup/Popup.tsx
@@ -510,7 +510,16 @@ const copyTimer = useRef<number | null>(null);
                   {expanded && (
                     <div className="jobpreview">
                       <div className="jobmeta">
-                        <span>{j.text.length.toLocaleString()} chars</span>
+                        <span
+                          title={
+                            j.text.length >= MAX_TEXT
+                              ? `Saved text reached the ${MAX_TEXT.toLocaleString()}-character cap and may have been trimmed.`
+                              : undefined
+                          }
+                        >
+                          {j.text.length.toLocaleString()} chars
+                          {j.text.length >= MAX_TEXT ? ' (trimmed)' : ''}
+                        </span>
                         <time
                           dateTime={new Date(j.savedAt).toISOString()}
                           title={new Date(j.savedAt).toLocaleString()}

--- a/src/popup/Popup.tsx
+++ b/src/popup/Popup.tsx
@@ -88,6 +88,22 @@ export function timeAgo(ts: number): string {
   return `${years} yr ago`;
 }
 
+export function SavedJobTextMeta({ textLength }: { textLength: number }) {
+  const reachedCap = textLength >= MAX_TEXT;
+
+  return (
+    <span
+      title={
+        reachedCap
+          ? `Saved text reached the ${MAX_TEXT.toLocaleString()}-character cap and may have been trimmed.`
+          : undefined
+      }
+    >
+      {textLength.toLocaleString()} chars{reachedCap ? ' (trimmed)' : ''}
+    </span>
+  );
+}
+
 export function Popup() {
   const [tabId, setTabId] = useState<number | null>(null);
   const [page, setPage] = useState<PageInfo | null>(null);
@@ -510,16 +526,7 @@ const copyTimer = useRef<number | null>(null);
                   {expanded && (
                     <div className="jobpreview">
                       <div className="jobmeta">
-                        <span
-                          title={
-                            j.text.length >= MAX_TEXT
-                              ? `Saved text reached the ${MAX_TEXT.toLocaleString()}-character cap and may have been trimmed.`
-                              : undefined
-                          }
-                        >
-                          {j.text.length.toLocaleString()} chars
-                          {j.text.length >= MAX_TEXT ? ' (trimmed)' : ''}
-                        </span>
+                        <SavedJobTextMeta textLength={j.text.length} />
                         <time
                           dateTime={new Date(j.savedAt).toISOString()}
                           title={new Date(j.savedAt).toLocaleString()}

--- a/src/popup/savedJobTextMeta.test.tsx
+++ b/src/popup/savedJobTextMeta.test.tsx
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { MAX_TEXT } from '../lib/savedJobs';
+import { SavedJobTextMeta } from './Popup';
+
+describe('SavedJobTextMeta', () => {
+  it('shows an ordinary count below the storage cap', () => {
+    const markup = renderToStaticMarkup(<SavedJobTextMeta textLength={MAX_TEXT - 1} />);
+
+    expect(markup).toContain(`${(MAX_TEXT - 1).toLocaleString()} chars`);
+    expect(markup).not.toContain('trimmed');
+    expect(markup).not.toContain('title=');
+  });
+
+  it('marks text that reached the storage cap', () => {
+    const markup = renderToStaticMarkup(<SavedJobTextMeta textLength={MAX_TEXT} />);
+
+    expect(markup).toContain(`${MAX_TEXT.toLocaleString()} chars (trimmed)`);
+    expect(markup).toContain(
+      `title="Saved text reached the ${MAX_TEXT.toLocaleString()}-character cap and may have been trimmed."`,
+    );
+  });
+});


### PR DESCRIPTION
## What & why

Closes #162.

- Mark saved posting text that reached the 12,000-character storage cap as `(trimmed)` so the preview does not look complete when AI context may be missing.
- Add a tooltip that explains the cap without claiming that an exactly 12,000-character posting was definitely truncated.
- Cover the below-cap and at-cap rendering paths with a focused server-rendered component test.

## How I tested

- `npm run lint`
- `npm run typecheck`
- `npm test` (27 files, 311 tests)
- `npm run build`

## Checklist

- [x] `npm run lint` passes
- [x] `npm run typecheck` passes
- [x] `npm test` passes
- [x] `npm run build` succeeds
- [x] Tests added/updated if behavior changed
- [x] No secrets, keys, or personal data committed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Saved-job previews now show the stored text character count.
  - When text reaches the storage limit, the preview indicates that it was trimmed and provides explanatory details on hover.

- **Tests**
  - Added coverage for normal and trimmed text-count displays.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->