### PR TITLE
fix(content): keep the AI-answer button visible against host page CSS

### DIFF
--- a/src/content/aiButtonStyles.test.ts
+++ b/src/content/aiButtonStyles.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'vitest';
+import { AI_BUTTON_CSS, BUTTON_CLASS } from './aiButtonStyles';
+
+/** Declarations of the rule with exactly this selector. */
+function ruleBody(selector: string): string {
+  const escaped = selector.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const m = new RegExp(`${escaped}\\s*\\{([^}]*)\\}`).exec(AI_BUTTON_CSS);
+  if (!m) throw new Error(`no rule for "${selector}"`);
+  return m[1];
+}
+
+/** The declared value for a property, or undefined if the rule doesn't set it. */
+function declaration(body: string, prop: string): string | undefined {
+  const m = new RegExp(`(?:^|;)\\s*${prop}\\s*:([^;]*)`).exec(body);
+  return m?.[1].trim();
+}
+
+const base = () => ruleBody(`button.${BUTTON_CLASS}`);
+
+describe('AI-answer button styling vs. the host page', () => {
+  // Listed here rather than imported from the source on purpose: this is an
+  // independent statement of what must stay protected, so deleting a property
+  // from the stylesheet fails the test instead of quietly shrinking its scope.
+  const mustSurviveHostCss = ['display', 'visibility', 'opacity', 'color', 'background'];
+
+  it.each(mustSurviveHostCss)('wins the cascade for %s', (prop) => {
+    // Losing any of these hides the button or makes it unreadable, so the user
+    // never discovers the feature — a silent failure, unlike a cosmetic clash.
+    const value = declaration(base(), prop);
+    expect(value, `${prop} is not declared`).toBeDefined();
+    expect(value).toContain('!important');
+  });
+
+  it('qualifies the selector with the element so host rules stop outranking it', () => {
+    // A bare `.jaf-ai-btn` is specificity (0,1,0) and loses to commonplace host
+    // rules like `.application button` or `button.btn` at (0,1,1).
+    expect(AI_BUTTON_CSS).toContain(`button.${BUTTON_CLASS}`);
+    expect(AI_BUTTON_CSS).not.toMatch(new RegExp(`(^|[^.\\w-])\\.${BUTTON_CLASS}`, 'm'));
+  });
+
+  it('pins font-family so the surrounding form cannot lend it one', () => {
+    // font-family is inherited, so with no declaration here the button picks up
+    // the host's font without any host rule ever targeting the button.
+    expect(declaration(base(), 'font-family')).toBeDefined();
+  });
+
+  it('keeps the disabled state dimmed despite the hardened base rule', () => {
+    // Base sets `opacity: 1 !important`; without !important here too, the
+    // in-flight button would stop looking disabled.
+    expect(declaration(ruleBody(`button.${BUTTON_CLASS}:disabled`), 'opacity')).toContain(
+      '!important',
+    );
+  });
+
+  it('leaves cosmetic properties overridable so the button can blend in', () => {
+    // Deliberate scope limit: !important is spent only on staying visible.
+    for (const prop of ['padding', 'border-radius', 'font-size']) {
+      expect(declaration(base(), prop), prop).not.toContain('!important');
+    }
+  });
+});

--- a/src/content/aiButtonStyles.ts
+++ b/src/content/aiButtonStyles.ts
@@ -1,0 +1,51 @@
+// Styling for the injected "✨ AI answer" button, kept in its own module so the
+// hardening below can be unit-tested (src/content/index.ts runs side effects at
+// import time and can't be loaded from a test).
+
+export const BUTTON_CLASS = 'jaf-ai-btn';
+
+/**
+ * Stylesheet for the injected button, written to survive the host page's CSS.
+ *
+ * Unlike the eligibility badge, this button can't hide in a Shadow DOM — it has
+ * to sit inline right after its textarea, and injectQuestionButtons' structural
+ * reconciliation depends on it being that literal sibling. So it lives in the
+ * host's cascade, dropped into the middle of an ATS form, which is exactly where
+ * sites style their own buttons hardest.
+ *
+ * Two defences:
+ *
+ * - `button.<class>` rather than `.<class>`, so ordinary host rules like
+ *   `.application button` or `button.btn` no longer outrank us on specificity.
+ * - `!important` on the properties whose loss makes the feature SILENTLY absent
+ *   rather than merely ugly: a host `display: none` / `visibility: hidden` reset
+ *   or a `color` matching our background means the user never learns the button
+ *   exists. Cosmetics (padding, radius, font-size) stay overridable on purpose —
+ *   a slightly off-looking button is a cost worth paying to blend into the form.
+ *
+ * `font-family` is pinned because it's inherited: without a declaration here the
+ * button silently takes whatever font the surrounding form sets, and no host rule
+ * has to target the button at all for that to happen.
+ *
+ * Residual gap: `!important` doesn't beat specificity between two important
+ * declarations, so an ID-scoped host rule (`#app button { display: none
+ * !important }`) still wins. Only Shadow DOM closes that, at the cost of the
+ * sibling reconciliation above.
+ */
+export const AI_BUTTON_CSS = `
+  button.${BUTTON_CLASS} {
+    display: inline-flex !important;
+    visibility: visible !important;
+    opacity: 1 !important;
+    color: #fff !important;
+    background: #44506b !important;
+    align-items: center; gap: 4px;
+    margin: 6px 0; padding: 5px 10px;
+    font-family: ui-sans-serif, system-ui, -apple-system, 'Segoe UI', Roboto, sans-serif;
+    font-size: 12px; font-weight: 600;
+    border: none; border-radius: 6px;
+    cursor: pointer; line-height: 1.2;
+  }
+  button.${BUTTON_CLASS}:hover { background: #333c52 !important; }
+  button.${BUTTON_CLASS}:disabled { opacity: .7 !important; cursor: default; }
+`;

--- a/src/content/index.ts
+++ b/src/content/index.ts
@@ -16,6 +16,7 @@ import { leverAdapter } from './adapters/lever';
 import { workdayAdapter } from './adapters/workday';
 import { ashbyAdapter } from './adapters/ashby';
 import type { SiteAdapter } from './adapters/types';
+import { AI_BUTTON_CSS, BUTTON_CLASS } from './aiButtonStyles';
 import {
   CONTEXT_LOST_MESSAGE,
   isContextInvalidated,
@@ -37,7 +38,6 @@ import {
 const ADAPTERS: SiteAdapter[] = [greenhouseAdapter, leverAdapter, workdayAdapter, ashbyAdapter];
 const adapter = ADAPTERS.find((a) => a.matches(new URL(location.href))) ?? null;
 
-const BUTTON_CLASS = 'jaf-ai-btn';
 const BUTTON_LABEL = '✨ AI answer';
 const CONFIRM_LABEL = '↻ Replace your text?';
 const CONFIRM_WINDOW_MS = 4000;
@@ -254,16 +254,7 @@ const observer = new MutationObserver(() => {
 
 function injectStyles(): void {
   const style = document.createElement('style');
-  style.textContent = `
-    .${BUTTON_CLASS} {
-      display: inline-flex; align-items: center; gap: 4px;
-      margin: 6px 0; padding: 5px 10px; font-size: 12px; font-weight: 600;
-      color: #fff; background: #44506b; border: none; border-radius: 6px;
-      cursor: pointer; line-height: 1.2;
-    }
-    .${BUTTON_CLASS}:hover { background: #333c52; }
-    .${BUTTON_CLASS}:disabled { opacity: .7; cursor: default; }
-  `;
+  style.textContent = AI_BUTTON_CSS;
   document.documentElement.appendChild(style);
 }
 


### PR DESCRIPTION
## What & why

Closes #226.

The ✨ AI answer button is injected inline into an ATS form and styled by a single class selector — specificity `(0,1,0)`, no `!important`. Commonplace host rules outrank that, and a `display: none` / `visibility: hidden` button reset made the button **invisible**, so the feature silently didn't exist for that user. `font-family` was also leaking in, since nothing pinned it.

Takes **option 1** from the issue (harden the CSS), not option 2 (Shadow DOM): the button has to stay the literal next sibling of its textarea for `injectQuestionButtons`' structural reconciliation, so shadow-hosting it needs that rework and remains a separate call.

- Qualify the selector as `button.jaf-ai-btn` so host rules stop outranking it on specificity.
- Spend `!important` only on the properties whose loss makes the button **absent rather than ugly**: `display`, `visibility`, `opacity`, `color`, `background`. Cosmetics (padding, radius, font-size) stay overridable on purpose so the button still blends into the form.
- Pin `font-family` to stop the inheritance leak.
- Extract the stylesheet to `src/content/aiButtonStyles.ts` so it's unit-testable — `src/content/index.ts` runs side effects at import time and can't be loaded from a node test.

### Residual gap (documented in the source)

`!important` doesn't beat specificity *between two important declarations*, so an ID-scoped host rule (`#app button { display: none !important }`) still wins. Only Shadow DOM closes that.

## How I tested

`npm run lint`, `npm run typecheck`, `npm test` (28 files, **320 tests**), `npm run build` — all green.

**Cascade verified in a real browser**, since this is CSS behaviour the node test env can't exercise. I built a harness reproducing the button inside a hostile form carrying every rule the issue names at once:

```css
button { display: none !important; }
.application button { background: red; color: red; }
#app button { visibility: hidden; opacity: 0; }
form { font-family: 'Comic Sans MS', cursive; }
```

| | old CSS (control) | this PR |
|---|---|---|
| `display` | `none` | `inline-flex` |
| `visibility` | `hidden` | `visible` |
| `opacity` | `0` | `1` |
| `color` / `background` | red on red | `#fff` on `#44506b` |
| rendered box | **0×0 — invisible** | visible |

The control run confirms the harness genuinely reproduces the reported bug rather than just passing. The `:disabled` state still dims correctly (`opacity: 0.7`) — it needed `!important` too, or the hardened base rule would have defeated it.

**Mutation-tested** the 9 new assertions — dropping `!important` from `display`, reverting the selector to the bare class, removing the `font-family` pin, dropping `!important` from `:disabled`, and over-hardening `padding` each fail the suite. The test hardcodes its own list of protected properties rather than importing one from the source, so deleting a property from the stylesheet fails instead of quietly shrinking the test's scope.

## Checklist

- [x] `npm run lint` passes
- [x] `npm run typecheck` passes
- [x] `npm test` passes
- [x] `npm run build` succeeds
- [x] Tests added/updated if behavior changed
- [x] No secrets, keys, or personal data committed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a consistent, self-contained style for the AI button, including layout, colors, typography, hover effects, and disabled states.
  - Improved button visibility and appearance when used on pages with conflicting site-wide styles.

- **Tests**
  - Added coverage confirming button styles remain reliable across different host-page CSS conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->