### PR TITLE
fix(auth): send revoke token in POST body

### DIFF
--- a/src/lib/auth.test.ts
+++ b/src/lib/auth.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { onAuthChanged, type AuthUser } from './auth';
+import { onAuthChanged, signOut, type AuthUser } from './auth';
 
 const AUTH_KEY = 'auth';
 
@@ -87,5 +87,38 @@ describe('onAuthChanged', () => {
 
     expect(callback).not.toHaveBeenCalled();
     expect(chrome.storage.onChanged.removeListener).toHaveBeenCalledOnce();
+  });
+});
+
+describe('signOut', () => {
+  it('sends the encoded OAuth token in a POST body, not the URL', async () => {
+    const token = 'token+with/slash?&= ü';
+    const fetchMock = vi.fn().mockResolvedValue({});
+    vi.stubGlobal('fetch', fetchMock);
+    vi.stubGlobal('chrome', {
+      runtime: { lastError: undefined },
+      identity: {
+        getAuthToken: vi.fn((_options: unknown, callback: (result: string) => void) =>
+          callback(token),
+        ),
+        removeCachedAuthToken: vi.fn((_details: unknown, callback: () => void) => callback()),
+        clearAllCachedAuthTokens: vi.fn((callback: () => void) => callback()),
+      },
+      storage: {
+        local: {
+          set: vi.fn().mockResolvedValue(undefined),
+          remove: vi.fn().mockResolvedValue(undefined),
+        },
+      },
+    });
+
+    await signOut();
+
+    expect(fetchMock).toHaveBeenCalledOnce();
+    expect(fetchMock).toHaveBeenCalledWith('https://oauth2.googleapis.com/revoke', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      body: 'token=token%2Bwith%2Fslash%3F%26%3D%20%C3%BC',
+    });
   });
 });

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -82,9 +82,11 @@ export async function signOut(): Promise<void> {
     const token = await getToken(false);
     // Revoke at Google — revoking the access token also revokes its refresh
     // token, killing the grant so a silent getAuthToken can't mint a new one.
-    await fetch('https://oauth2.googleapis.com/revoke?token=' + encodeURIComponent(token)).catch(
-      () => {},
-    );
+    await fetch('https://oauth2.googleapis.com/revoke', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      body: `token=${encodeURIComponent(token)}`,
+    }).catch(() => {});
     await new Promise<void>((resolve) =>
       chrome.identity.removeCachedAuthToken({ token }, () => resolve()),
     );


### PR DESCRIPTION
## What & why

Closes #236.

The Google OAuth access token currently travels in the revocation URL, where URL logging can capture it before revocation completes. This changes the best-effort revoke call to the documented POST form:

- keep the endpoint URL free of credentials
- send the encoded token only in an application/x-www-form-urlencoded body
- preserve the existing non-fatal revoke behavior and local cache/sign-out cleanup

A focused regression test uses reserved characters and Unicode to verify the exact URL, method, content type, and encoded body.

## How I tested

- npx vitest run src/lib/auth.test.ts — 1 file, 6 tests passed
- npm run lint
- npm run typecheck
- npm test — 27 files, 312 tests passed
- npm run build
- git diff --check

I did not perform a live Chrome OAuth sign-out; request construction and the unchanged cleanup path are covered deterministically.

## Checklist

- [x] npm run lint passes
- [x] npm run typecheck passes
- [x] npm test passes
- [x] npm run build succeeds
- [x] Tests added/updated if behavior changed
- [x] No secrets, keys, or personal data committed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sign-out security by sending OAuth token revocation requests in the request body instead of the URL.
  * Preserved best-effort sign-out behavior when token revocation fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->