### PR TITLE
fix: include phone in profileToContext for AI features

### DIFF
--- a/src/lib/profile.ts
+++ b/src/lib/profile.ts
@@ -195,6 +195,7 @@ export function profileToContext(p: Profile): string {
   const fullName = [pi.firstName, pi.lastName].filter(Boolean).join(' ');
   if (fullName) lines.push(`Name: ${fullName}`);
   if (pi.email) lines.push(`Email: ${pi.email}`);
+  if (pi.phone) lines.push(`Phone: ${pi.phone}`);
   if (pi.city || pi.state || pi.country)
     lines.push(`Location: ${[pi.city, pi.state, pi.country].filter(Boolean).join(', ')}`);
   if (pi.linkedin) lines.push(`LinkedIn: ${pi.linkedin}`);


### PR DESCRIPTION
## Summary

fix: include phone in profileToContext for AI features

## Changes

- Emit Phone: lines from personal.phone so resume/cover-letter generation can use it.

Fixes #262


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * AI-generated profile context now includes a phone number when one is provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->