### PR TITLE
fix: Deduplicate additional documents by filename on re-upload

### DIFF
--- a/src/options/Options.tsx
+++ b/src/options/Options.tsx
@@ -481,10 +481,19 @@ function OptionsView({
         <h2>Additional documents (extra AI context)</h2>
         <DocUpload
           onText={(name, text) =>
-            update((prev) => ({
-              ...prev,
-              documents: [...prev.documents, { id: crypto.randomUUID(), name, text, addedAt: Date.now() }],
-            }))
+            update((prev) => {
+              const norm = name.trim().toLowerCase();
+              const without = prev.documents.filter(
+                (d) => d.name.trim().toLowerCase() !== norm,
+              );
+              return {
+                ...prev,
+                documents: [
+                  ...without,
+                  { id: crypto.randomUUID(), name, text, addedAt: Date.now() },
+                ],
+              };
+            })
           }
         />
         {p.documents.length > 0 && (


### PR DESCRIPTION
## Summary

Deduplicate additional documents by filename on re-upload

## Changes

- Replace same-name document instead of appending a duplicate
- Avoids doubling AI context cost for the same file

Fixes #267


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented duplicate document entries when uploading files with the same name, regardless of capitalization or surrounding spaces.
  * Re-uploaded documents now replace the existing matching document while retaining the latest content and upload details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->