### PR TITLE
chore(server): override transitive uuid to 11.1.1 (GHSA-w5hq-g745-h8pq)

### DIFF
--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -1440,17 +1440,16 @@
       "license": "MIT"
     },
     "node_modules/uuid": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
-      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
       ],
       "license": "MIT",
       "bin": {
-        "uuid": "dist/bin/uuid"
+        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/web-streams-polyfill": {

--- a/server/package.json
+++ b/server/package.json
@@ -14,5 +14,8 @@
     "@google-cloud/firestore": "^8.7.1",
     "@google-cloud/vertexai": "^1.9.3",
     "protobufjs": "^7.6.5"
+  },
+  "overrides": {
+    "uuid": "^11.1.1"
   }
 }


### PR DESCRIPTION
## What & why

Addresses #235, but I'm deliberately **not** writing "Closes" — the issue itself asks that this specific call (forcing an `overrides`) be a judgment call for whoever owns the deploy, not something decided silently in a dependency PR. This PR does the verification legwork; the merge decision is yours.

`uuid@9.0.1` (moderate CVE, [GHSA-w5hq-g745-h8pq](https://github.com/advisories/GHSA-w5hq-g745-h8pq)) can't be reached by a normal bump — it's pulled in by `gaxios@6.7.1` ← `google-auth-library@9.15.1` ← `@google-cloud/vertexai@1.12.0` (**the current latest release** — I checked first, per the issue's own instruction, and upstream hasn't moved off `google-auth-library` 9.x yet). `gaxios` declares `uuid@^9.0.1`, which excludes 11.x, and npm's resolver agrees: `npm audit fix` reports the identical finding before and after.

## What I verified before reaching for `overrides`

The issue was explicit that "probably low risk" isn't good enough to decide silently, so I checked rather than guessed:

1. **Where `uuid` is actually used.** Grepped gaxios's own source — its only call is `v4()`, for a multipart request's boundary string ([`gaxios.js:417`](https://github.com/googleapis/gaxios/blob/main/src/gaxios.ts)). Neither Firestore nor the Vertex AI calls this proxy makes use multipart request bodies, so this code path is likely never even exercised here. gaxios's own comment on that line says it intends to drop `uuid` entirely for `crypto.randomUUID()` once Node 16 is the floor — they already consider it interchangeable.
2. **Whether the CVE even applies to this call site.** The advisory is a missing buffer bounds check in `v3`/`v5`/`v6` **when a `buf` is passed**. gaxios calls `v4()` with no `buf` argument — this specific call was never in the vulnerable path to begin with.
3. **API compatibility.** `require('uuid').v4()` on 11.1.1 produces a valid RFC4122 v4 string, same shape as today. No signature change for this call.
4. **The full chain still resolves.** Imported `@google-cloud/vertexai` → `google-auth-library` → `gaxios` → the overridden `uuid` end to end with no errors.

## How I tested

- `npm ci` in `server/` is reproducible with the override in place.
- `npm audit` in `server/`: **0 vulnerabilities** (was 2 moderate).
- `node --check index.js` — syntax clean.
- Full module-resolution smoke test through the real dependency chain (see commit message for the exact output).

I could not exercise a live request against Vertex AI/Firestore (needs real GCP credentials), so this stops short of a true integration test — worth knowing given `server/`'s only CI check is syntax-only.

## Checklist

- [x] `npm run lint` / `npm run typecheck` / `npm test` / `npm run build` — unaffected (server-only change, no root package touched)
- [x] `Server syntax check` — passes locally (`node --check`)
- [x] No secrets, keys, or personal data committed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the application’s UUID package version to improve consistency and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->