### PR TITLE
fix(content): fix the remaining referent-flip false-fills from #230

### DIFF
--- a/src/content/adapters/shared.test.ts
+++ b/src/content/adapters/shared.test.ts
@@ -210,9 +210,16 @@ describe('RULES — question prose must not be mistaken for a data field', () =>
   // essay box. Reported live on a BambooHR form.
   const P: Profile = {
     ...DEFAULT_PROFILE,
+    personal: {
+      ...DEFAULT_PROFILE.personal,
+      city: 'Austin',
+      country: 'USA',
+      portfolio: 'jane.dev',
+    },
     workHistory: [
       { company: 'Acme', title: 'Data Analyst', startDate: '2024', endDate: '', description: '' },
     ],
+    preferences: { ...DEFAULT_PROFILE.preferences, salaryExpectation: '$140,000' },
   };
   const valueFor = (raw: string): string | undefined =>
     RULES.find((r) => r.test.test(normalize(raw)))?.value(P);
@@ -254,6 +261,73 @@ describe('RULES — question prose must not be mistaken for a data field', () =>
     // The guard keys off the determiner, not the question mark, so this keeps
     // working — a blunter "questions never autofill" rule would have broken it.
     expect(valueFor('What is your current job title?')).toBe('Data Analyst');
+  });
+
+  // #231 — the same referent-flip bug, found live in four more rules. Each has
+  // its own trigger word rather than reusing the company/title regex verbatim:
+  // these rules don't share a "current X" framing, so the sentences that trip
+  // them don't share one determiner pattern either.
+
+  it('leaves a travel/opinion question about a city or country to the AI', () => {
+    expect(valueFor('Which city are you most excited to explore?')).toBeUndefined();
+    expect(valueFor('What city is our office located in?')).toBeUndefined();
+    expect(valueFor('What is your favorite country to visit and why?')).toBeUndefined();
+  });
+
+  it('still autofills a genuine city or country field', () => {
+    expect(valueFor('City')).toBe('Austin');
+    expect(valueFor('Home City')).toBe('Austin');
+    expect(valueFor('Current City')).toBe('Austin');
+    // A real screening question, not a travel wish — no "explore/visit/travel"
+    // and no reference to the employer's own office.
+    expect(valueFor('What city do you currently reside in?')).toBe('Austin');
+    // Pins the proximity window itself: a plausible compound label pairs a
+    // relocation question with an UNRELATED travel question far enough away
+    // that "travel" must not disqualify "city" — an unbounded exclusion would
+    // wrongly swallow this.
+    expect(
+      valueFor(
+        'Which state or city are you willing to relocate to, and are you open to travel for this role?',
+      ),
+    ).toBe('Austin');
+    expect(valueFor('Country')).toBe('USA');
+    expect(valueFor('Country of Residence')).toBe('USA');
+    expect(valueFor('What is your country?')).toBe('USA');
+  });
+
+  it('leaves "describe a website you admire" to the AI', () => {
+    // The indefinite article alone isn't the signal — "Do you have a website?"
+    // below is phrased identically and must still fill — the opinion verb is.
+    expect(valueFor('Describe a website or app you admire and why.')).toBeUndefined();
+    expect(valueFor('What website inspires you the most?')).toBeUndefined();
+  });
+
+  it('still autofills a genuine portfolio/website field', () => {
+    expect(valueFor('Portfolio URL')).toBe('jane.dev');
+    expect(valueFor('Website')).toBe('jane.dev');
+    expect(valueFor('Personal Site')).toBe('jane.dev');
+    expect(valueFor('Link to your portfolio')).toBe('jane.dev');
+    expect(valueFor('Do you have a website? If so, please share.')).toBe('jane.dev');
+    expect(valueFor('Do you have a personal website?')).toBe('jane.dev');
+    // Pins the exclusion to the specific preference phrase "like most", not
+    // bare "like" — this is a request, not an opinion about someone else's site.
+    expect(valueFor('What website would you like to link for your application?')).toBe(
+      'jane.dev',
+    );
+  });
+
+  it('leaves the "if pay wasn\'t a factor" hypothetical to the AI', () => {
+    expect(valueFor("If pay wasn't a factor, what would you do?")).toBeUndefined();
+    expect(valueFor("If salary weren't a consideration, what would you do?")).toBeUndefined();
+  });
+
+  it('still autofills a genuine salary field', () => {
+    expect(valueFor('Salary Expectation')).toBe('$140,000');
+    expect(valueFor('Desired Salary')).toBe('$140,000');
+    expect(valueFor('What is your expected salary?')).toBe('$140,000');
+    // "if" appears, but not as the label's opening clause — the leading-
+    // conditional guard must not over-fire on every sentence containing "if".
+    expect(valueFor('What is your expected salary if hired?')).toBe('$140,000');
   });
 });
 

--- a/src/content/adapters/shared.ts
+++ b/src/content/adapters/shared.ts
@@ -241,10 +241,33 @@ export const RULES: Rule[] = [
   { test: /\b(phone|mobile|tel)\b/, value: (p) => p.personal.phone },
   { test: /\blinkedin\b/, value: (p) => p.personal.linkedin },
   { test: /\bgithub\b/, value: (p) => p.personal.github },
-  { test: /\b(portfolio|website|personal site)\b/, value: (p) => p.personal.portfolio },
-  { test: /\bcity\b/, value: (p) => p.personal.city },
+  // "Describe A website... you admire" is asking about someone ELSE's site, not
+  // requesting the applicant's own — the referent-flip failure #230 fixed for
+  // company/title, recurring here under a different trigger word. "Do you have
+  // a website?" must still fill: the indefinite article alone isn't the signal,
+  // the opinion verb is.
+  {
+    test: /^(?!.*\b(?:admire|inspir\w*|like (?:the )?most)\b).*\b(portfolio|website|personal site)\b/,
+    value: (p) => p.personal.portfolio,
+  },
+  // "Which city are you most excited to explore?" and "What city is our office
+  // located in?" both ask about a city that ISN'T the applicant's own — a travel
+  // wish or the employer's address. Two independent cues, since they don't share
+  // a determiner the way #230's company/title pair did: a nearby travel verb, or
+  // a possessive naming the employer's site rather than "your".
+  {
+    test: /^(?!.*\bcity\b[^.!?]{0,30}\b(?:explore|visit|travel)\b)(?!.*\b(?:our|the company.?s)\s+(?:office|headquarters|location)\b).*\bcity\b/,
+    value: (p) => p.personal.city,
+  },
   { test: /\b(state|province|region)\b/, value: (p) => p.personal.state, selectOk: true },
-  { test: /\bcountry\b/, value: (p) => p.personal.country, selectOk: true },
+  // "What is your favorite country to visit and why?" asks for a travel wish,
+  // not a residence. "favorite" is the sole trigger — a plain "What is your
+  // country?" carries none of it and must still fill.
+  {
+    test: /^(?!.*\bfavorite\b[^.!?]{0,15}\bcountry\b).*\bcountry\b/,
+    value: (p) => p.personal.country,
+    selectOk: true,
+  },
   // These two read the applicant's CURRENT employer/title, but their keywords
   // flip referent inside question prose: in "Why are you interested in this
   // position?" the position is the *employer's* job, and in "Why do you want to
@@ -266,7 +289,15 @@ export const RULES: Rule[] = [
     test: /^(?!.*\b(?:this|the|that|our|a|an)\s+(?:current\s+)?(?:title|role|position)\b).*?\b(current\s*)?(title|role|position)\b/,
     value: (p) => p.workHistory[0]?.title ?? '',
   },
-  { test: /\b(salary|compensation|pay)\b/, value: (p) => p.preferences.salaryExpectation },
+  // "If pay wasn't a factor, what would you do?" is a hypothetical about career
+  // motivation, not a request for a number. Anchored to the START of the label:
+  // the leading conditional is the specific cue, so "What is your expected
+  // salary if hired?" — "if" appears, but not as the opening clause — must
+  // still fill.
+  {
+    test: /^(?!\s*if\b[^.!?]{0,20}\b(?:pay|salary|compensation)\b[^.!?]{0,10}\b(?:wasn.?t|weren.?t|isn.?t|was not|were not)\b).*\b(salary|compensation|pay)\b/,
+    value: (p) => p.preferences.salaryExpectation,
+  },
   {
     test: /\b(work\s*authoriz|authoriz.*work|legally.*work|eligible.*work)\b/,
     value: (p) => p.preferences.workAuthorization,


### PR DESCRIPTION
## What & why

Closes #231.

`city`, `country`, `portfolio`, and `salary` shared #230's failure: each rule's keyword also appears inside unrelated essay prose, and matching there both hid the AI-answer button and silently typed the applicant's own profile value into a question about something else entirely. Confirmed against the real rules (verbatim from the issue):

| Rule | Sentence | Old behavior |
|---|---|---|
| `city` | "Which city are you most excited to explore?" | filled with home city |
| `city` | "What city is our office located in?" | filled with home city |
| `country` | "What is your favorite country to visit and why?" | filled with home country |
| `salary` | "If pay wasn't a factor, what would you do?" | filled with salary expectation |
| `portfolio` | "Describe a website or app you admire and why." | filled with portfolio URL |

## Why #230's regex doesn't drop in cleanly here

Per the issue: these rules don't share a "current X" framing, so the sentences that trip them don't share one determiner pattern either. Each gets its own guard, keyed to the specific referent-flip cue in its own failing sentence — not a mechanical copy of #230's regex:

- **portfolio** — an opinion verb (`admire`/`inspire`/`like most`) about someone *else's* site. Not the indefinite article: "Do you have a website?" uses "a" too and must still fill — the opinion verb is the actual signal.
- **city** — a nearby travel verb (`explore`/`visit`/`travel`), *or* a possessive naming the **employer's** office/headquarters rather than the applicant's own city. Two independent cues, since the two failing sentences don't share one.
- **country** — the word `favorite`. A plain "What is your country?" carries none of it.
- **salary** — a **leading** conditional ("If pay wasn't a factor…"). Anchored to the start of the label on purpose — "if" showing up later in a genuine salary question ("…if hired?") isn't the same failure and must still fill.

All four keep #230's leading-negative-lookahead-over-the-whole-label construction (`^(?!.*PATTERN).*\bKEYWORD\b`), for the same reason #230 used it: a trailing lookbehind gets defeated because the regex engine retries the match starting *after* the determiner, so the exclusion has to scan the whole label from position 0 instead.

## How I tested

`npm run lint`, `npm run typecheck`, `npm test` (28 files, **344 tests**), `npm run build` — all green. 14 new assertions across 6 tests, extending the existing `RULES — question prose must not be mistaken for a data field` block.

**Mutation-tested in both directions**, per the issue's explicit instruction not to treat "looks right" as sufficient:

1. Reverting each of the four guards to its original bare regex fails the corresponding new test — confirms the guards actually do something.
2. A second pass **broadened** two guards (dropped the city proximity window; widened portfolio's `like most` to bare `like`) to check an *over*-exclusion would also be caught, not just an absent one.

The second pass initially found a real gap: both over-broadening mutations passed silently, meaning my first test matrix couldn't tell a correctly-scoped guard from an overly aggressive one. Rather than ship that, I added two more realistic cases — a compound label pairing a relocation question with an unrelated travel question far enough away that proximity has to matter (`"Which state or city are you willing to relocate to, and are you open to travel for this role?"`), and a genuine portfolio request phrased with bare "like" (`"What website would you like to link for your application?"`) — and reran both mutations to confirm they now fail as they should.

## Checklist

- [x] `npm run lint` passes
- [x] `npm run typecheck` passes
- [x] `npm test` passes
- [x] `npm run build` succeeds
- [x] Tests added/updated if behavior changed
- [x] No secrets, keys, or personal data committed

🤖 Generated with [Claude Code](https://claude.com/claude-code)