### PR TITLE
feat: add "Turn off on this site only" to the eligibility badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,8 +58,11 @@ runs on **every page** (so no job board is missed): it shows a bold YES / NO / M
 verdict when the page mentions sponsorship, citizenship, or clearance requirements, and a
 neutral gray "no eligibility info" card otherwise. It stays current on single-page boards
 as you click between postings. Toggle it on/off any time from the side panel ("Scan every
-page for visa/eligibility") or via the badge's own "Turn off on all sites" link. Because
-it runs everywhere, Chrome shows the "read and change your data on all websites"
+page for visa/eligibility"), via the badge's own "Turn off on all sites" link, or — if it's
+just one site you'd rather not see it on — "Turn off on this site only" right below it,
+which remembers your choice for that site (and its subdomains) across reloads. Turn a site
+back on from the extension's Options page, under "Sites where the badge is turned off".
+Because it runs everywhere, Chrome shows the "read and change your data on all websites"
 permission.
 
 All your data stays on your machine (`chrome.storage.local`). The AI layer is

--- a/src/content/index.ts
+++ b/src/content/index.ts
@@ -3,7 +3,7 @@
 
 import { getProfile, onProfileChanged } from '../lib/profile';
 import { getSavedJobs, onSavedJobsChanged } from '../lib/savedJobs';
-import { hostMatches } from '../lib/host';
+import { hostMatches, isHostDisabled } from '../lib/host';
 import {
   applyStandardFills,
   findOpenQuestions,
@@ -308,12 +308,17 @@ if (window.top === window.self && !scannerGlobal.__jafScannerStarted) {
       setBadgeIntroSeen(Boolean(badgeIntroSeen));
       setBadgeCorner(badgeCorner);
       setBadgeFeatures({ coverLetter: profile.coverLetterEnabled, resume: profile.tailoredResumeEnabled });
-      setScannerEnabled(profile.scanEnabled);
+      // Gate on both the global switch and this host's per-site opt-out
+      // ("⚙ Turn off on this site only" on the badge itself). Top frame only
+      // (see the guard above), so this is always the URL-bar host the user
+      // sees, even on a page whose posting text comes from a same-origin iframe.
+      setScannerEnabled(profile.scanEnabled && !isHostDisabled(location.hostname, profile.disabledHosts));
     } catch (e) {
       // A failed storage read (e.g. an extension-update limbo) must not silently
-      // kill the scanner — fall back to defaults. scanEnabled defaults ON in
-      // withDefaults, so this matches a fresh profile; force the coachmark to
-      // "seen" so a fallback never flashes the intro bubble.
+      // kill the scanner — fall back to defaults, including for the per-site
+      // opt-out: scanEnabled defaults ON in withDefaults, so this matches a
+      // fresh profile with no disabled hosts. Force the coachmark to "seen" so
+      // a fallback never flashes the intro bubble.
       console.warn('[Little AI Helper] scanner init failed; starting with defaults', e);
       setBadgeIntroSeen(true);
       setScannerEnabled(true);
@@ -322,6 +327,6 @@ if (window.top === window.self && !scannerGlobal.__jafScannerStarted) {
   })();
   onProfileChanged((profile) => {
     setBadgeFeatures({ coverLetter: profile.coverLetterEnabled, resume: profile.tailoredResumeEnabled });
-    setScannerEnabled(profile.scanEnabled);
+    setScannerEnabled(profile.scanEnabled && !isHostDisabled(location.hostname, profile.disabledHosts));
   });
 }

--- a/src/content/sponsorship.ts
+++ b/src/content/sponsorship.ts
@@ -10,7 +10,7 @@ import { parseEligibilityJson } from '../lib/jobEligibility';
 import { downloadLetter } from '../lib/coverLetter';
 import { downloadResume } from '../lib/resume';
 import { getProfile, saveProfile } from '../lib/profile';
-import { hostMatches } from '../lib/host';
+import { addDisabledHost, hostMatches } from '../lib/host';
 
 export type Verdict = 'yes' | 'no' | 'caution' | 'unknown';
 
@@ -603,6 +603,18 @@ async function disableScannerEverywhere(): Promise<void> {
   await saveProfile({ ...p, scanEnabled: false });
 }
 
+/**
+ * Turns the badge off for this host only ("⚙ Turn off on this site only").
+ * Same propagation as the global off-switch above: write storage and let
+ * index.ts's profile listener recompute the gate, so every open tab on this
+ * host updates in lockstep and the choice survives a reload. Undone from the
+ * Options page's "Sites where the badge is turned off" list.
+ */
+async function disableScannerForThisHost(): Promise<void> {
+  const p = await getProfile();
+  await saveProfile({ ...p, disabledHosts: addDisabledHost(p.disabledHosts, location.hostname) });
+}
+
 /** Which generators the badge shows (driven by the user's settings). */
 export function setBadgeFeatures(opts: { coverLetter: boolean; resume: boolean }): void {
   showCoverLetterInBadge = opts.coverLetter;
@@ -1128,8 +1140,10 @@ function renderBadge(a: SponsorAnalysis, meta: JobMeta): HTMLElement {
     .ai:disabled { opacity: .7; cursor: default; }
     .aitag { font-size: 11px; color: #44506b; font-weight: 700; }
     .tag { margin-top: 8px; font-size: 11px; color: #94a3b8;
-           display: flex; justify-content: space-between; align-items: center; gap: 8px;
+           display: flex; flex-direction: column; gap: 6px;
            border-top: 1px solid #eef2f7; padding-top: 7px; }
+    .tag-row { display: flex; justify-content: space-between; align-items: center; gap: 8px; }
+    .tag-row--end { justify-content: flex-end; }
     .off { appearance: none; border: 0; background: transparent; padding: 0; font: inherit;
            color: #44506b; font-weight: 600; cursor: pointer; white-space: nowrap; }
     .off:hover { text-decoration: underline; }
@@ -1273,16 +1287,39 @@ function renderBadge(a: SponsorAnalysis, meta: JobMeta): HTMLElement {
 
   // Footer: brand tag + an always-available "turn the scanner off everywhere"
   // link, so the global off-switch is reachable from the badge itself (not only
-  // the side-panel toggle a new user may never open).
+  // the side-panel toggle a new user may never open) — plus a narrower "this
+  // site only" switch on its own row below, so the 230px card never has to fit
+  // two off-switch labels on one line.
   const foot = document.createElement('div');
   foot.className = 'tag';
-  foot.appendChild(el('span', '', 'Little AI Helper'));
+
+  const footTop = document.createElement('div');
+  footTop.className = 'tag-row';
+  footTop.appendChild(el('span', '', 'Little AI Helper'));
   const off = el('button', 'off', '⚙ Turn off on all sites');
   off.setAttribute('type', 'button');
   off.title = 'Stop showing this badge on every page';
   off.setAttribute('aria-label', 'Turn off the eligibility badge on all sites');
   off.addEventListener('click', () => void disableScannerEverywhere());
-  foot.appendChild(off);
+  footTop.appendChild(off);
+  foot.appendChild(footTop);
+
+  // Omitted when there's no host to key the opt-out on — file:// and about:
+  // pages report location.hostname === '' (addDisabledHost already no-ops on a
+  // blank hostname), so a visible button there would silently do nothing.
+  const siteHost = location.hostname;
+  if (siteHost) {
+    const footBottom = document.createElement('div');
+    footBottom.className = 'tag-row tag-row--end';
+    const offSite = el('button', 'off', '⚙ Turn off on this site only');
+    offSite.setAttribute('type', 'button');
+    offSite.title = `Stop showing this badge on ${siteHost}. Turn it back on from the extension's Settings page.`;
+    offSite.setAttribute('aria-label', `Turn off the eligibility badge on ${siteHost} only`);
+    offSite.addEventListener('click', () => void disableScannerForThisHost());
+    footBottom.appendChild(offSite);
+    foot.appendChild(footBottom);
+  }
+
   card.appendChild(foot);
 
   // Stack the card and (optionally) the coachmark in a fixed column anchored to

--- a/src/lib/host.test.ts
+++ b/src/lib/host.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { hostMatches } from './host';
+import { addDisabledHost, hostMatches, isHostDisabled, removeDisabledHost } from './host';
 
 describe('hostMatches', () => {
   it('matches the exact domain', () => {
@@ -20,5 +20,77 @@ describe('hostMatches', () => {
 
   it('rejects an unrelated host', () => {
     expect(hostMatches('example.com', 'linkedin.com')).toBe(false);
+  });
+});
+
+describe('isHostDisabled — per-site eligibility badge off-switch', () => {
+  it('is disabled for the exact stored host', () => {
+    expect(isHostDisabled('boards.greenhouse.io', ['boards.greenhouse.io'])).toBe(true);
+  });
+
+  it('is disabled for a deeper subdomain of a stored host', () => {
+    expect(isHostDisabled('sub.boards.greenhouse.io', ['boards.greenhouse.io'])).toBe(true);
+  });
+
+  it('leaves a SIBLING subdomain on — "this site only" must not spread', () => {
+    // jobs.greenhouse.io and boards.greenhouse.io are different sites to the
+    // user even though they share a parent domain; disabling one must not
+    // silently disable the other.
+    expect(isHostDisabled('jobs.greenhouse.io', ['boards.greenhouse.io'])).toBe(false);
+  });
+
+  it('leaves the parent domain on', () => {
+    expect(isHostDisabled('greenhouse.io', ['boards.greenhouse.io'])).toBe(false);
+  });
+
+  it('rejects a look-alike host, same guard as hostMatches', () => {
+    expect(isHostDisabled('evilboards.greenhouse.io', ['boards.greenhouse.io'])).toBe(false);
+  });
+
+  it('is never disabled against an empty list', () => {
+    expect(isHostDisabled('boards.greenhouse.io', [])).toBe(false);
+  });
+
+  it('never matches on a blank hostname or a blank entry', () => {
+    // hostMatches(h, '') degrades to h.endsWith('.'), which is true for any
+    // trailing-dot FQDN ("example.com." is legal and Chrome keeps the dot) — so
+    // a stray blank entry must not become "everything with a trailing dot".
+    expect(isHostDisabled('', ['boards.greenhouse.io'])).toBe(false);
+    expect(isHostDisabled('example.com.', [''])).toBe(false);
+  });
+});
+
+describe('addDisabledHost — "turn off on this site only"', () => {
+  it('appends a new host', () => {
+    expect(addDisabledHost(['a.com'], 'b.com')).toEqual(['a.com', 'b.com']);
+  });
+
+  it('does not duplicate an entry that is already disabled', () => {
+    expect(addDisabledHost(['b.com'], 'b.com')).toEqual(['b.com']);
+  });
+
+  it('is a no-op when a broader parent already covers the host', () => {
+    expect(addDisabledHost(['greenhouse.io'], 'boards.greenhouse.io')).toEqual(['greenhouse.io']);
+  });
+
+  it('rejects a blank hostname without mutating the list', () => {
+    // location.hostname is "" on a file:// page — there is nothing meaningful
+    // to disable, and storing "" would make every hostMatches(h, "") check
+    // behave oddly (a blank domain suffix matches everything).
+    expect(addDisabledHost(['a.com'], '')).toEqual(['a.com']);
+  });
+});
+
+describe('removeDisabledHost — "turn back on" in Options', () => {
+  it('removes the matching entry', () => {
+    expect(removeDisabledHost(['a.com', 'b.com'], 'a.com')).toEqual(['b.com']);
+  });
+
+  it('leaves other entries untouched', () => {
+    expect(removeDisabledHost(['a.com', 'b.com', 'c.com'], 'b.com')).toEqual(['a.com', 'c.com']);
+  });
+
+  it('is a no-op when the host is not in the list', () => {
+    expect(removeDisabledHost(['a.com'], 'z.com')).toEqual(['a.com']);
   });
 });

--- a/src/lib/host.ts
+++ b/src/lib/host.ts
@@ -4,3 +4,39 @@
 export function hostMatches(hostname: string, domain: string): boolean {
   return hostname === domain || hostname.endsWith(`.${domain}`);
 }
+
+/**
+ * True when the eligibility badge is switched off for this hostname — i.e. it
+ * exactly matches, or is a subdomain of, an entry the user disabled it on.
+ * A sibling subdomain (jobs.example.com when boards.example.com is disabled)
+ * is deliberately NOT covered: the control this drives is scoped to "this site
+ * only", so silently spreading to sites the user hasn't visited would be
+ * surprising.
+ */
+export function isHostDisabled(hostname: string, disabledHosts: readonly string[]): boolean {
+  // The `d !== ''` guard is what actually matters, not a blank-hostname check on
+  // `hostname` itself: hostMatches(h, '') degrades to h.endsWith('.'), true for
+  // ANY trailing-dot FQDN ("example.com." is legal and Chrome preserves the
+  // dot) — so a stray blank entry would otherwise silently kill the badge on
+  // unrelated sites. addDisabledHost never stores a blank entry, but this stays
+  // defensive against one reaching storage some other way (a manual edit, a
+  // future bug). Excluding d === '' also makes a blank `hostname` argument safe
+  // for free: hostMatches('', d) is only ever true when d === '', which this
+  // already filters out — so no separate `if (!hostname)` check is needed.
+  return disabledHosts.some((d) => d !== '' && hostMatches(hostname, d));
+}
+
+/**
+ * Adds a host to the off-list. A no-op when the hostname is blank (location.hostname
+ * is "" on a file:// page — nothing meaningful to disable there) or already
+ * covered by an existing entry (exact match or a broader parent already disabled).
+ */
+export function addDisabledHost(hosts: readonly string[], hostname: string): string[] {
+  if (!hostname || isHostDisabled(hostname, hosts)) return [...hosts];
+  return [...hosts, hostname];
+}
+
+/** Removes a host from the off-list ("turn the badge back on here"). */
+export function removeDisabledHost(hosts: readonly string[], hostname: string): string[] {
+  return hosts.filter((h) => h !== hostname);
+}

--- a/src/lib/profile.test.ts
+++ b/src/lib/profile.test.ts
@@ -105,6 +105,23 @@ describe('onProfileChanged', () => {
     });
   });
 
+  it('falls back to an empty disabledHosts list for a profile stored before the field existed', () => {
+    // Migration guard: every existing user's stored profile predates this
+    // field entirely. Without the explicit fallback in withDefaults, this
+    // would resolve to `undefined` and crash the `.some()` in isHostDisabled.
+    const callback = vi.fn();
+    onProfileChanged(callback);
+
+    emitStorageChange(
+      { [STORAGE_KEY]: { newValue: { personal: { firstName: 'Jane' } } } },
+      'local',
+    );
+
+    expect(callback).toHaveBeenCalledWith(
+      expect.objectContaining({ disabledHosts: [] }),
+    );
+  });
+
   it.each([
     ['unknown', 'gemini-2.0-flash', DEFAULT_MODEL],
     ['known', GEMINI_MODELS[0].id, GEMINI_MODELS[0].id],

--- a/src/lib/profile.ts
+++ b/src/lib/profile.ts
@@ -80,6 +80,13 @@ export interface Profile {
   ai: AISettings;
   /** Master on/off for the eligibility scanner (runs on every page when on). */
   scanEnabled: boolean;
+  /**
+   * Hostnames the eligibility badge is switched off on ("turn off on this site
+   * only"), matched via hostMatches (exact-or-subdomain) in src/lib/host.ts.
+   * Independent of scanEnabled — this narrows where the scanner runs while
+   * scanEnabled is the global master switch.
+   */
+  disabledHosts: string[];
   /** Show the tailored-resume generator in the side panel. */
   tailoredResumeEnabled: boolean;
   /** Show the tailored cover-letter generator in the side panel. */
@@ -130,6 +137,7 @@ export const DEFAULT_PROFILE: Profile = {
     proxyToken: '',
   },
   scanEnabled: true,
+  disabledHosts: [],
   tailoredResumeEnabled: true,
   coverLetterEnabled: true,
 };
@@ -155,6 +163,7 @@ function withDefaults(stored: Partial<Profile> | undefined): Profile {
     skills: stored.skills ?? DEFAULT_PROFILE.skills,
     documents: stored.documents ?? DEFAULT_PROFILE.documents,
     scanEnabled: stored.scanEnabled ?? DEFAULT_PROFILE.scanEnabled,
+    disabledHosts: stored.disabledHosts ?? DEFAULT_PROFILE.disabledHosts,
     tailoredResumeEnabled: stored.tailoredResumeEnabled ?? DEFAULT_PROFILE.tailoredResumeEnabled,
     coverLetterEnabled: stored.coverLetterEnabled ?? DEFAULT_PROFILE.coverLetterEnabled,
   };

--- a/src/options/DisabledSites.test.tsx
+++ b/src/options/DisabledSites.test.tsx
@@ -1,0 +1,36 @@
+import { describe, expect, it, vi } from 'vitest';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { DisabledSites } from './DisabledSites';
+
+// renderToStaticMarkup needs no DOM, so this stays in the default node env —
+// see the file header on DisabledSites.tsx for why the list has to live in its
+// own module to be testable at all.
+const html = (node: React.ReactElement): string => renderToStaticMarkup(node);
+
+describe('DisabledSites — the badge off-list on the Options page', () => {
+  it('shows the empty-state copy and no rows when nothing is disabled', () => {
+    const markup = html(<DisabledSites hosts={[]} onEnable={vi.fn()} />);
+    expect(markup).toContain('No sites turned off');
+    expect(markup).not.toContain('<button');
+  });
+
+  it('renders one row per disabled host', () => {
+    const markup = html(<DisabledSites hosts={['b.com', 'a.com']} onEnable={vi.fn()} />);
+    expect(markup).toContain('a.com');
+    expect(markup).toContain('b.com');
+    expect((markup.match(/<button/g) ?? []).length).toBe(2);
+  });
+
+  it('lists hosts alphabetically regardless of input (storage) order', () => {
+    // Storage order is insertion order — most-recently-disabled last — which
+    // isn't a useful reading order for a list the user scans to find one site.
+    const markup = html(<DisabledSites hosts={['z.com', 'a.com', 'm.com']} onEnable={vi.fn()} />);
+    const order = [...markup.matchAll(/🚫 ([^<]+)</g)].map((m) => m[1]);
+    expect(order).toEqual(['a.com', 'm.com', 'z.com']);
+  });
+
+  it('gives each row an aria-label naming its own host', () => {
+    const markup = html(<DisabledSites hosts={['boards.greenhouse.io']} onEnable={vi.fn()} />);
+    expect(markup).toContain('aria-label="Turn the badge back on for boards.greenhouse.io"');
+  });
+});

--- a/src/options/DisabledSites.tsx
+++ b/src/options/DisabledSites.tsx
@@ -1,0 +1,41 @@
+// The Options-page list of sites where the eligibility badge is turned off, plus
+// each row's "Turn back on" button. Kept in its own module so it can be
+// unit-tested without pulling in the rest of Options.tsx, which transitively
+// imports pdfjs-dist and therefore needs browser globals unavailable in the
+// node test env.
+
+export function DisabledSites({
+  hosts,
+  onEnable,
+}: {
+  hosts: string[];
+  onEnable: (host: string) => void;
+}) {
+  // Storage order is insertion order (most-recently-turned-off last); sort for
+  // a stable, scannable list instead.
+  const sorted = [...hosts].sort((a, b) => a.localeCompare(b));
+
+  return (
+    <section className="card">
+      <h2>Sites where the badge is turned off</h2>
+      <p className="help">
+        Add a site with "⚙ Turn off on this site only" on the badge itself. An entry also
+        covers that site's subdomains — the page path doesn't matter.
+      </p>
+      {sorted.length === 0 ? (
+        <p className="help">No sites turned off — the badge shows wherever scanning is on.</p>
+      ) : (
+        <div style={{ margin: '10px 0' }}>
+          {sorted.map((host) => (
+            <div key={host} className="list-item" style={{ display: 'flex', alignItems: 'center' }}>
+              <span style={{ flex: 1 }}>🚫 {host}</span>
+              <button onClick={() => onEnable(host)} aria-label={`Turn the badge back on for ${host}`}>
+                Turn back on
+              </button>
+            </div>
+          ))}
+        </div>
+      )}
+    </section>
+  );
+}

--- a/src/options/Options.tsx
+++ b/src/options/Options.tsx
@@ -1,6 +1,8 @@
 import { useEffect, useState } from 'react';
 import { Field } from './Field';
+import { DisabledSites } from './DisabledSites';
 import type { EducationEntry, Profile, WorkEntry } from '../lib/profile';
+import { removeDisabledHost } from '../lib/host';
 import { useProfile } from '../ui/useProfile';
 import { extractText, extractTextBatch } from '../lib/documents';
 import { sendToBackground } from '../lib/messages';
@@ -550,6 +552,14 @@ function OptionsView({
           On a job page, the popup substitutes the company/role/date placeholders.
         </div>
       </section>
+
+      <DisabledSites
+        hosts={p.disabledHosts}
+        onEnable={(host) =>
+          update((prev) => ({ ...prev, disabledHosts: removeDisabledHost(prev.disabledHosts, host) }))
+        }
+      />
+
       <footer className="help" style={{ marginTop: 16, textAlign: 'center' }}>
         Little AI Helper v{chrome.runtime.getManifest().version}
       </footer>


### PR DESCRIPTION
## What & why

The eligibility badge runs on every page — that's why the extension needs the "read and change your data on all websites" permission. The README already treats its off-switches as a deliberate trust affordance for that permission, but they were all-or-nothing: the side-panel checkbox and the badge's own "Turn off on all sites" link. A user annoyed by the badge on one site had to kill it everywhere.

This adds the missing middle option: **"⚙ Turn off on this site only"**, right below the existing global link, remembered across reloads — plus an undo list in Options, since once the badge is hidden on a site it can no longer offer its own switch back on.

## Scope

Stores the full `location.hostname`, matched via the existing `hostMatches` (exact-or-subdomain). Verified against the real function:

| Visited host | Stored: `boards.greenhouse.io` |
|---|---|
| `boards.greenhouse.io` (any path) | disabled |
| `sub.boards.greenhouse.io` | disabled |
| `jobs.greenhouse.io` (sibling) | **still on** |
| `greenhouse.io` (parent) | **still on** |

Page paths never enter into it, since they don't affect the hostname. Sibling subdomains are deliberately *not* covered — the button says "this site only", and spreading to a site the user hasn't visited would be surprising.

## Files

- **`src/lib/host.ts`** — `isHostDisabled` / `addDisabledHost` / `removeDisabledHost`, pure and node-testable.
- **`src/lib/profile.ts`** — new `disabledHosts: string[]`, independent of the existing `scanEnabled` global switch. `withDefaults` falls back to `[]` for every profile stored before this field existed (a real migration concern — every existing user's stored profile predates it).
- **`src/content/index.ts`** — the scanner's single gate becomes `scanEnabled && !isHostDisabled(location.hostname, disabledHosts)`.
- **`src/content/sponsorship.ts`** — `disableScannerForThisHost()` mirrors the existing `disableScannerEverywhere()`: write storage, let `index.ts`'s profile listener recompute the gate, so every open tab on the host (and the Options list) update in lockstep. New button sits on its own row below the existing one; omitted entirely on a blank hostname (`file://`, `about:`), where it would otherwise silently do nothing.
- **`src/options/DisabledSites.tsx`** — the undo list, in its **own module**, not inline in `Options.tsx`. `Options.tsx` transitively imports `pdfjs-dist` and can't be loaded under vitest's node env at all — I'd filed #271 about exactly this anti-pattern from a prior PR, so this one doesn't repeat it.

## A redundant guard I found and removed

`isHostDisabled` originally had two defensive checks: an explicit `if (!hostname) return false`, plus excluding blank entries in the stored list (`d !== ''`). Mutation-testing showed removing the *entry* guard broke a test, but removing the separate *hostname* guard broke nothing — because `hostMatches('', d)` is only ever `true` when `d` is itself `''`, which the entry guard already excludes. Proved it numerically before cutting it, then re-ran the mutation to confirm the remaining single guard is what's actually load-bearing (see commit message for the exact traces).

## How I verified this

`npm run lint`, `npm run typecheck`, `npm test` (29 files, **363 tests**, 24 new), `npm run build` — all green.

**Mutation-tested** every new predicate in both directions: reverting a guard (caught), and over-broadening one to check the tests would catch that too, not just an absence.

**End-to-end in a browser**, since the badge is shadow-DOM and the unit tests can't reach it. Rather than hand-approximate the markup, I extracted the *real* CSS and footer-assembly code straight out of `sponsorship.ts` programmatically and ran it in a harness page, swapping only the two `chrome.storage`-dependent handler bodies for instrumentation:
- Both buttons render in the requested order, "this site only" directly below "all sites".
- Measured the new label at **158px** against the card's 195px content budget — fits on one line, no wrap needed (this drove a CSS simplification: `.tag` became a flex column instead of a second sibling row with its own margin).
- Clicking the new button fires the right handler with the right hostname.
- On a blank hostname (simulating `file://`), only the global button renders — confirms the guard.

I could not exercise the real `chrome.storage` propagation path in a live extension from this environment. I traced it by hand instead: `saveProfile` → `chrome.storage.onChanged` → `onProfileChanged` in `index.ts` (registered in the same top-frame-only block) → `setScannerEnabled(false)` → `removeBadge()`. Worth a manual smoke test after merge: click the button, confirm the badge disappears immediately, then **reload the page and confirm it stays gone** — that's the actual "remembers it" requirement and the one thing I couldn't verify end-to-end myself.

## Known, pre-existing limitation (not introduced here, not fixed here)

`disableScannerForThisHost` mirrors `disableScannerEverywhere` exactly, including its lack of error handling on `saveProfile` — an orphaned extension context (reload/update with the tab still open) would fail this silently, same as the existing global button. This matches the codebase's actual convention elsewhere (`Popup.tsx`'s `toggleSetting`, the saved-jobs helpers all use a bare `await saveProfile(...)` too), so I didn't add bespoke error handling to just this one new button — flagging it rather than silently deciding either way.

## Checklist

- [x] `npm run lint` passes
- [x] `npm run typecheck` passes
- [x] `npm test` passes
- [x] `npm run build` succeeds
- [x] Tests added/updated if behavior changed
- [x] No secrets, keys, or personal data committed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an option to disable eligibility badges on specific sites.
  * Site-specific settings persist across reloads and subdomains.
  * Added an Options page section to view disabled sites and re-enable them.
  * Preserved the existing global disable controls.

* **Bug Fixes**
  * Older saved profiles now continue working correctly with the new site-specific settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->