### PR TITLE
fix: validate on-device AI availability in options

### DIFF
--- a/src/lib/ai/index.ts
+++ b/src/lib/ai/index.ts
@@ -6,7 +6,7 @@ import { ProxyProvider } from './proxy';
 
 export { AIError } from './provider';
 export type { AIProvider, GenerateInput } from './provider';
-export { isOnDeviceAvailable } from './onDevice';
+export { isOnDeviceAvailable, onDeviceAvailabilityMessage } from './onDevice';
 
 /** Selects the concrete provider from the user's settings. */
 export function getProvider(settings: AISettings): AIProvider {

--- a/src/lib/ai/onDevice.test.ts
+++ b/src/lib/ai/onDevice.test.ts
@@ -1,5 +1,9 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { isOnDeviceAvailable, OnDeviceProvider } from './onDevice';
+import {
+  isOnDeviceAvailable,
+  onDeviceAvailabilityMessage,
+  OnDeviceProvider,
+} from './onDevice';
 
 function installLanguageModel(response = '{"ok":true}') {
   const prompt = vi.fn().mockResolvedValue(response);
@@ -116,5 +120,17 @@ describe('isOnDeviceAvailable', () => {
   it('is false, not a rejected promise, when capabilities() throws', async () => {
     installAvailability({ capabilities: vi.fn().mockRejectedValue(new Error('boom')) });
     await expect(isOnDeviceAvailable()).resolves.toBe(false);
+  });
+});
+
+describe('onDeviceAvailabilityMessage', () => {
+  it('explains that supported models may still need a download', () => {
+    expect(onDeviceAvailabilityMessage(true)).toBe(
+      'Supported — Chrome may download the model on first use.',
+    );
+  });
+
+  it('gives a recovery path when the model is unavailable', () => {
+    expect(onDeviceAvailabilityMessage(false)).toContain('Switch to Gemini in options');
   });
 });

--- a/src/lib/ai/onDevice.ts
+++ b/src/lib/ai/onDevice.ts
@@ -46,6 +46,12 @@ export async function isOnDeviceAvailable(): Promise<boolean> {
   return false;
 }
 
+export function onDeviceAvailabilityMessage(available: boolean): string {
+  return available
+    ? 'Supported — Chrome may download the model on first use.'
+    : "Chrome's built-in AI isn't available here. Switch to Gemini in options, or enable the on-device model in a supported Chrome build.";
+}
+
 export class OnDeviceProvider implements AIProvider {
   readonly id = 'onDevice';
 
@@ -53,8 +59,7 @@ export class OnDeviceProvider implements AIProvider {
     const lm = getLanguageModel();
     if (!lm) {
       throw new AIError(
-        "Chrome's built-in AI isn't available here. Switch to Gemini in options, or " +
-          'enable the on-device model in a supported Chrome build.',
+        onDeviceAvailabilityMessage(false),
       );
     }
 

--- a/src/options/Options.tsx
+++ b/src/options/Options.tsx
@@ -10,7 +10,7 @@ import type { AIResult } from '../lib/messages';
 import { parseResumeJson } from '../lib/resumeImport';
 import { ProxyProvider } from '../lib/ai/proxy';
 import { GEMINI_MODELS } from '../lib/ai/models';
-import { AIError } from '../lib/ai';
+import { AIError, isOnDeviceAvailable, onDeviceAvailabilityMessage } from '../lib/ai';
 import { signIn, signOut, reconcileAuthUser, onAuthChanged, getCachedToken, type AuthUser } from '../lib/auth';
 
 export function Options() {
@@ -67,6 +67,20 @@ function OptionsView({
   });
   const [showApiKey, setShowApiKey] = useState(false);
   const [showProxyToken, setShowProxyToken] = useState(false);
+  const [onDeviceAvailable, setOnDeviceAvailable] = useState<boolean | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    setOnDeviceAvailable(null);
+    if (p.ai.provider === 'onDevice') {
+      isOnDeviceAvailable().then((available) => {
+        if (!cancelled) setOnDeviceAvailable(available);
+      });
+    }
+    return () => {
+      cancelled = true;
+    };
+  }, [p.ai.provider]);
 
   // Google sign-in state for the managed proxy.
   const [authUser, setAuthUser] = useState<AuthUser | null>(null);
@@ -208,6 +222,11 @@ function OptionsView({
             </Field>
           )}
         </div>
+        {p.ai.provider === 'onDevice' && onDeviceAvailable !== null && (
+          <div className={onDeviceAvailable ? 'saved' : 'warn'}>
+            {onDeviceAvailabilityMessage(onDeviceAvailable)}
+          </div>
+        )}
         {p.ai.provider === 'gemini' && (
           <Field label="Gemini API key">
             <div style={{ display: 'flex', gap: 8 }}>


### PR DESCRIPTION
## What & why

Fixes #281.

The Options page allowed users to select Chrome's on-device AI provider without checking whether the browser supported it. The resulting failure appeared only during a real application task, even though the availability helper already handled both Chrome API shapes.

## Implementation

- Check on-device availability when the provider is selected in Options.
- Show a clear supported message that covers models which may still need downloading.
- Show the existing recovery guidance when the provider is unavailable.
- Ignore stale asynchronous availability results when the user switches providers.
- Export and test the message formatter used by the UI; existing availability-state coverage remains unchanged.
- No dependency, storage, or provider API changes.

## How verified

- `npm ci` — installed from the committed lockfile.
- `npm test` — 29 test files, 365 tests passed.
- `npm run lint` — passed.
- `npm run typecheck` — passed.
- `npm run build` — passed; Vite production bundle generated successfully.
- `git diff --check` — passed.

## Notes

The Options component is not imported directly by the existing Vitest setup because its transitive PDF dependency requires browser-only `DOMMatrix`; the pure message helper is covered in `src/lib/ai/onDevice.test.ts`, while the availability API itself retains its existing branch and failure coverage.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an on-device AI availability status to the Options page.
  * Displays clear messaging when the on-device model is available or unavailable.
  * Improved messaging when on-device generation cannot be used.

* **Bug Fixes**
  * Ensured on-device availability messages are consistently shown across settings and generation flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->