### PR TITLE
fix(popup): show per-site badge status in the side panel

### DIFF
--- a/src/content/index.ts
+++ b/src/content/index.ts
@@ -98,6 +98,9 @@ chrome.runtime.onMessage.addListener((msg: ContentMessage, _sender, sendResponse
             company: '',
             role: '',
             jobText: '',
+            // role === 'answer-late' only happens when isTopFrame (see
+            // pageMessageRole), so this is always the real page hostname.
+            hostname: location.hostname,
           } satisfies PageInfo),
         UNSUPPORTED_REPLY_DELAY_MS,
       );
@@ -108,6 +111,10 @@ chrome.runtime.onMessage.addListener((msg: ContentMessage, _sender, sendResponse
       site: adapter.id,
       ...adapter.getPageInfo(),
       jobText: getScanText(),
+      // Unlike the branch above, an adapter can match in a SUB-frame (embedded
+      // ATS) — see the PageInfo docblock for why that frame's own hostname must
+      // not be reported as the page's.
+      hostname: isTopFrame ? location.hostname : '',
     } satisfies PageInfo);
     return false;
   }

--- a/src/lib/host.test.ts
+++ b/src/lib/host.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { addDisabledHost, hostMatches, isHostDisabled, removeDisabledHost } from './host';
+import { addDisabledHost, disabledHostFor, hostMatches, isHostDisabled, removeDisabledHost } from './host';
 
 describe('hostMatches', () => {
   it('matches the exact domain', () => {
@@ -57,6 +57,44 @@ describe('isHostDisabled — per-site eligibility badge off-switch', () => {
     // a stray blank entry must not become "everything with a trailing dot".
     expect(isHostDisabled('', ['boards.greenhouse.io'])).toBe(false);
     expect(isHostDisabled('example.com.', [''])).toBe(false);
+  });
+});
+
+describe('disabledHostFor — which stored entry actually covers this hostname (#273)', () => {
+  it('returns the exact entry when it is the hostname itself', () => {
+    expect(disabledHostFor('boards.greenhouse.io', ['boards.greenhouse.io'])).toBe(
+      'boards.greenhouse.io',
+    );
+  });
+
+  it('returns the broader PARENT entry, not the subdomain visited', () => {
+    // The case removeDisabledHost alone gets wrong: the popup shows "Turned off
+    // for X" and its "Turn back on" button must remove X — but if the user
+    // disabled the parent while ON a subdomain of it, X is the parent, not
+    // whatever subdomain they're standing on right now.
+    expect(disabledHostFor('sub.boards.greenhouse.io', ['boards.greenhouse.io'])).toBe(
+      'boards.greenhouse.io',
+    );
+  });
+
+  it('is undefined for a sibling subdomain, a look-alike, or an empty hostname', () => {
+    expect(disabledHostFor('jobs.greenhouse.io', ['boards.greenhouse.io'])).toBeUndefined();
+    expect(disabledHostFor('evilboards.greenhouse.io', ['boards.greenhouse.io'])).toBeUndefined();
+    expect(disabledHostFor('', ['boards.greenhouse.io'])).toBeUndefined();
+  });
+
+  it('agrees with isHostDisabled on every case above', () => {
+    // isHostDisabled is defined in terms of this function; pin that relationship
+    // directly so the two can never silently drift apart.
+    const cases: [string, string[]][] = [
+      ['boards.greenhouse.io', ['boards.greenhouse.io']],
+      ['sub.boards.greenhouse.io', ['boards.greenhouse.io']],
+      ['jobs.greenhouse.io', ['boards.greenhouse.io']],
+      ['', ['boards.greenhouse.io']],
+    ];
+    for (const [hostname, hosts] of cases) {
+      expect(isHostDisabled(hostname, hosts)).toBe(disabledHostFor(hostname, hosts) !== undefined);
+    }
   });
 });
 

--- a/src/lib/host.ts
+++ b/src/lib/host.ts
@@ -6,14 +6,21 @@ export function hostMatches(hostname: string, domain: string): boolean {
 }
 
 /**
- * True when the eligibility badge is switched off for this hostname — i.e. it
- * exactly matches, or is a subdomain of, an entry the user disabled it on.
- * A sibling subdomain (jobs.example.com when boards.example.com is disabled)
- * is deliberately NOT covered: the control this drives is scoped to "this site
- * only", so silently spreading to sites the user hasn't visited would be
- * surprising.
+ * The stored entry that switches the eligibility badge off for this hostname —
+ * an exact match, or a broader domain `hostname` is a subdomain of — or
+ * undefined when nothing covers it. Note the entry returned may differ from
+ * `hostname` itself: visiting sub.example.com when "example.com" was the entry
+ * disabled returns "example.com", not "sub.example.com" — there is nothing to
+ * remove BY "sub.example.com" in that case, only by the entry that actually
+ * matched. A sibling subdomain (jobs.example.com when boards.example.com is
+ * disabled) is deliberately NOT covered: the control this drives is scoped to
+ * "this site only", so silently spreading to sites the user hasn't visited
+ * would be surprising.
  */
-export function isHostDisabled(hostname: string, disabledHosts: readonly string[]): boolean {
+export function disabledHostFor(
+  hostname: string,
+  disabledHosts: readonly string[],
+): string | undefined {
   // The `d !== ''` guard is what actually matters, not a blank-hostname check on
   // `hostname` itself: hostMatches(h, '') degrades to h.endsWith('.'), true for
   // ANY trailing-dot FQDN ("example.com." is legal and Chrome preserves the
@@ -23,7 +30,12 @@ export function isHostDisabled(hostname: string, disabledHosts: readonly string[
   // future bug). Excluding d === '' also makes a blank `hostname` argument safe
   // for free: hostMatches('', d) is only ever true when d === '', which this
   // already filters out — so no separate `if (!hostname)` check is needed.
-  return disabledHosts.some((d) => d !== '' && hostMatches(hostname, d));
+  return disabledHosts.find((d) => d !== '' && hostMatches(hostname, d));
+}
+
+/** True when the eligibility badge is switched off for this hostname. */
+export function isHostDisabled(hostname: string, disabledHosts: readonly string[]): boolean {
+  return disabledHostFor(hostname, disabledHosts) !== undefined;
 }
 
 /**

--- a/src/lib/messages.ts
+++ b/src/lib/messages.ts
@@ -9,6 +9,16 @@ export interface PageInfo {
   role: string;
   /** Scoped job-posting text, used to tailor AI answers + the cover letter. */
   jobText: string;
+  /**
+   * The TOP FRAME's hostname, so the popup can tell the user whether the
+   * eligibility badge (which only ever runs top-frame) is turned off for this
+   * site — see isHostDisabled in lib/host.ts. Empty when the reply came from an
+   * adapter-matching SUB-frame (a company careers page embedding an ATS in an
+   * iframe): that frame's own hostname is not the badge's hostname, and
+   * reporting it would tell the popup the wrong site is disabled. Empty is
+   * always safe here — isHostDisabled('', …) is unconditionally false.
+   */
+  hostname: string;
 }
 
 export interface FillResult {

--- a/src/popup/Popup.tsx
+++ b/src/popup/Popup.tsx
@@ -698,7 +698,11 @@ const copyTimer = useRef<number | null>(null);
           />
           Scan every page for visa/eligibility (YES/NO badge)
         </label>
-        {siteDisabledEntry && (
+        {/* Gated on scanEnabled too: with the global switch already off, this
+            would be redundant noise on top of the unchecked box above, and
+            "Turn back on" would misleadingly imply it alone restores the
+            badge when the global toggle would still need re-checking. */}
+        {scanEnabled && siteDisabledEntry && (
           <p className="warn" style={{ marginTop: 6 }}>
             Badge turned off for <strong>{siteDisabledEntry}</strong>.{' '}
             <button className="linklike" onClick={() => enableSite(siteDisabledEntry)}>

--- a/src/popup/Popup.tsx
+++ b/src/popup/Popup.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useState } from 'react';
 import { getProfile, saveProfile, onProfileChanged, type Profile } from '../lib/profile';
+import { disabledHostFor, removeDisabledHost } from '../lib/host';
 import {
   getSavedJobs,
   addJob,
@@ -119,6 +120,7 @@ export function Popup() {
   const [busy, setBusy] = useState<'' | 'fill' | 'letter' | 'resume' | 'save'>('');
   const [error, setError] = useState('');
   const [scanEnabled, setScanEnabled] = useState(true);
+  const [disabledHosts, setDisabledHosts] = useState<string[]>([]);
   const [coverLetterEnabled, setCoverLetterEnabled] = useState(true);
   const [resumeEnabled, setResumeEnabled] = useState(true);
   const [jobs, setJobs] = useState<SavedJob[]>([]);
@@ -144,6 +146,13 @@ const copyTimer = useRef<number | null>(null);
     setLocal(value);
     const profile = await getProfile();
     await saveProfile({ ...profile, [key]: value });
+  }
+
+  /** "Turn back on" for the current site's per-site badge opt-out (see #272/#273). */
+  async function enableSite(host: string) {
+    setDisabledHosts((prev) => removeDisabledHost(prev, host));
+    const profile = await getProfile();
+    await saveProfile({ ...profile, disabledHosts: removeDisabledHost(profile.disabledHosts, host) });
   }
 
   async function copyToClipboard(text: string, target: 'letter' | 'resume') {
@@ -196,11 +205,11 @@ const copyTimer = useRef<number | null>(null);
         if (info.company) setCompany((c) => c || info.company);
         if (info.role) setRole((r) => r || info.role);
       } catch {
-        setPage({ supported: false, site: null, company: '', role: '', jobText: '' });
+        setPage({ supported: false, site: null, company: '', role: '', jobText: '', hostname: '' });
       }
     } else {
       setTabId(null);
-      setPage({ supported: false, site: null, company: '', role: '', jobText: '' });
+      setPage({ supported: false, site: null, company: '', role: '', jobText: '', hostname: '' });
     }
   }
 
@@ -210,6 +219,7 @@ const copyTimer = useRef<number | null>(null);
   useEffect(() => {
     const apply = (p: Profile) => {
       setScanEnabled(p.scanEnabled);
+      setDisabledHosts(p.disabledHosts);
       setCoverLetterEnabled(p.coverLetterEnabled);
       setResumeEnabled(p.tailoredResumeEnabled);
       setAiProvider(p.ai.provider);
@@ -384,6 +394,13 @@ const copyTimer = useRef<number | null>(null);
 
   const activeJob = jobs.find((j) => j.id === activeJobId) ?? null;
   const canGenerate = canGenerateDocuments(company, role);
+  // page.hostname is '' when unknown or when an embedded ATS sub-frame answered
+  // PAGE_INFO instead of the top frame (see the PageInfo docblock) — disabledHostFor
+  // is unconditionally undefined for '', so this never shows a wrong-site notice.
+  // The matched ENTRY (not necessarily page.hostname itself — e.g. visiting
+  // sub.example.com when "example.com" is what's disabled) is what "Turn back
+  // on" has to remove; removing page.hostname there would silently no-op.
+  const siteDisabledEntry = disabledHostFor(page?.hostname ?? '', disabledHosts);
   const openOptions = () => chrome.runtime.openOptionsPage();
   const geminiNeedsKey = aiProvider === 'gemini' && !apiKeySet;
   // Proxy mode needs a signed-in account (unless the owner set an admin token).
@@ -681,6 +698,14 @@ const copyTimer = useRef<number | null>(null);
           />
           Scan every page for visa/eligibility (YES/NO badge)
         </label>
+        {siteDisabledEntry && (
+          <p className="warn" style={{ marginTop: 6 }}>
+            Badge turned off for <strong>{siteDisabledEntry}</strong>.{' '}
+            <button className="linklike" onClick={() => enableSite(siteDisabledEntry)}>
+              Turn back on
+            </button>
+          </p>
+        )}
       </div>
 
       <div className="block" style={{ textAlign: 'center' }}>

--- a/src/ui/ui.css
+++ b/src/ui/ui.css
@@ -54,6 +54,14 @@ button.primary:hover { background: var(--primary-hover); }
 button.ghost { background: transparent; color: var(--primary); padding: 6px 8px; }
 button.danger { background: transparent; color: var(--danger); padding: 6px 8px; }
 button:disabled { opacity: .6; cursor: default; }
+/* A button that reads as a link inline with surrounding text (e.g. "Turned off
+   for x.com. Turn back on") — the base button rule's padding/radius/size would
+   otherwise look like a standalone control glued mid-sentence. */
+button.linklike {
+  appearance: none; background: transparent; border: none; padding: 0;
+  font: inherit; font-weight: 700; color: inherit; text-decoration: underline;
+  cursor: pointer; border-radius: 0;
+}
 
 .list-item { border: 1px dashed var(--border); border-radius: 10px; padding: 12px; margin-bottom: 10px; }
 .help { font-size: 12px; color: var(--muted); margin-top: 4px; }


### PR DESCRIPTION
## What & why

Closes #273.

#272 added "Turn off on this site only" to the badge, with an undo list in Options. The side panel wasn't touched, and started telling a small lie: its only badge control is the "Scan every page" checkbox, bound to `scanEnabled` alone. On a site turned off per-site, `scanEnabled` stays `true`, so the box stays checked and the label keeps promising "every page" while the badge is deliberately absent from the page in front of the user. The only repair the UI offered — unchecking the global box — disables the badge everywhere, the wrong fix for a per-site problem.

This adds a notice right below the checkbox on a disabled site:

> Badge turned off for **boards.greenhouse.io**. [Turn back on]

## Two correctness traps I found and closed, not just the happy path

**1. `PageInfo.hostname` had to be top-frame-specific, not "whichever frame answered."** The issue itself flagged the `chrome.tabs.query(...).url` trap; tracing further, `PAGE_INFO` itself has the same shape of problem. When an ATS is embedded in an iframe on a company careers page, `pageMessageRole` lets the adapter-matching **sub-frame** answer `PAGE_INFO` — and the badge only ever runs top-frame. Naively reporting `location.hostname` from whichever frame answers would report the iframe's own hostname (e.g. `boards.greenhouse.io`) instead of the actual top page (`careers.acmecorp.com`) — telling the popup the wrong site is disabled. Fixed by reporting `hostname` only when `isTopFrame`, empty otherwise. `isHostDisabled('', …)` is unconditionally false, so this degrades to simply not showing the notice rather than showing a wrong one — verified in the new test matrix.

**2. The naive "Turn back on" would have silently done nothing** for a real case. If the user disabled the *parent* domain (`greenhouse.io`) while standing on it, then later visits a subdomain (`boards.greenhouse.io`), the notice has to say — and remove — `greenhouse.io`, not `boards.greenhouse.io`. I checked this concretely before shipping:

```
removeDisabledHost(['greenhouse.io'], 'boards.greenhouse.io')
  -> ['greenhouse.io']   // unchanged — the button would visibly do nothing
```

Fixed with a new `disabledHostFor(hostname, disabledHosts)` in `src/lib/host.ts`, extracted from `isHostDisabled` — it returns **which entry** covers a hostname, not just whether one does. `isHostDisabled` is now defined in terms of it, and a test pins that the two can never silently drift apart.

## Also

`button.linklike` added to `ui.css` — the base button rule's padding/radius/font-weight looked like a standalone control glued mid-sentence inside the notice text; this mirrors the badge's own `.off` class (its shadow-DOM stylesheet, not reusable here) so a button can read as an inline link.

## How I tested

`npm run lint`, `npm run typecheck`, `npm test` (29 files, **369 tests**), `npm run build` — all green. 4 new tests in `host.test.ts`.

**Mutation-tested** the subdomain-aware fix: reverting `disabledHostFor` to exact-match-only fails 3 tests, including the specific "returns the broader PARENT entry" case.

**Simulated the full flow** end to end against the real functions (not a mock of them) across four scenarios: exact-site match, parent-domain-while-on-subdomain, the embedded-iframe hostname-empty case, and nothing-disabled. All behave as designed.

**Rendered the actual notice in a browser** against the real `ui.css`, at the popup's real ~340px width — confirmed it sits directly under the checkbox it explains, the link-styled button reads naturally inline, and nothing overflows.

## Checklist

- [x] `npm run lint` passes
- [x] `npm run typecheck` passes
- [x] `npm test` passes
- [x] `npm run build` succeeds
- [x] Tests added/updated if behavior changed
- [x] No secrets, keys, or personal data committed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an inline warning when the site’s eligibility badge is disabled.
  * Added a “Turn back on” action to re-enable the badge for the current site.
  * Improved site detection so embedded frames do not report the wrong hostname.

* **Bug Fixes**
  * Disabled-site matching now correctly handles exact domains, parent domains, and unrelated subdomains.
  * Added clearer inline link styling for the re-enable action.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->