### PR TITLE
fix(server): detect blocked/truncated AI responses on the managed-proxy path

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -208,8 +208,38 @@ async function generate({ system, prompt, maxOutputTokens, json, thinking, model
     },
   });
   const result = await model.generateContent(prompt);
-  const parts = result?.response?.candidates?.[0]?.content?.parts ?? [];
-  return parts.map((p) => p.text || '').join('').trim();
+  const candidate = result?.response?.candidates?.[0];
+  const parts = candidate?.content?.parts ?? [];
+  return { text: parts.map((p) => p.text || '').join('').trim(), finishReason: candidate?.finishReason };
+}
+
+// Mirrors src/lib/ai/gemini.ts's finishReason handling, so a safety block or a
+// truncated response reads the same to the user whether they're on the BYO-key
+// Gemini path or this managed proxy (#239 — the proxy used to discard
+// finishReason entirely and could only ever say "empty response"). Duplicated
+// rather than imported: server/ is a standalone Cloud Run deployable with its
+// own package.json, not built alongside the extension, so there is no shared
+// module to import from — keep the two in sync by hand if either changes.
+//
+// Wording deliberately does NOT say "Gemini" (unlike gemini.ts) — every other
+// message in this file speaks generically ("the managed AI", "the AI service")
+// since the proxy never discloses which model runs behind it.
+const MIN_VIABLE_ANSWER_LENGTH = 40;
+function classifyFinishReason(finishReason, text) {
+  if (finishReason === 'SAFETY') {
+    return 'This response was blocked for safety reasons. Try rephrasing.';
+  }
+  if (finishReason === 'RECITATION') {
+    return 'This response was blocked because it matched existing content too closely. Try rephrasing.';
+  }
+  // A short MAX_TOKENS answer means the output budget ran out almost
+  // immediately, not that a real answer got clipped near the end — same
+  // reasoning and threshold as gemini.ts. A substantial MAX_TOKENS answer is
+  // returned as-is; discarding a mostly-complete reply would be worse.
+  if (finishReason === 'MAX_TOKENS' && text.length < MIN_VIABLE_ANSWER_LENGTH) {
+    return 'The response was cut off before it could really start (ran out of output budget). Try again.';
+  }
+  return null;
 }
 
 const server = http.createServer(async (req, res) => {
@@ -277,8 +307,17 @@ const server = http.createServer(async (req, res) => {
     // transient hiccup). One retry almost always succeeds and saves the user a
     // manual re-run. The quota was already counted above, so the retry is free
     // to the user and doesn't double-count.
-    let text = await generate(args);
-    if (!text) text = await generate(args);
+    //
+    // A SAFETY/RECITATION block is different: it's deterministic for the same
+    // prompt, so retrying would almost certainly repeat it and just cost a
+    // second Vertex call for nothing. Only the plain-empty case (no finishReason
+    // classification below applies) gets the retry.
+    let { text, finishReason } = await generate(args);
+    if (!text && finishReason !== 'SAFETY' && finishReason !== 'RECITATION') {
+      ({ text, finishReason } = await generate(args));
+    }
+    const blocked = classifyFinishReason(finishReason, text);
+    if (blocked) return send(res, 502, { error: blocked });
     if (!text) return send(res, 502, { error: 'Empty response from Vertex AI' });
     return send(res, 200, { text });
   } catch (err) {

--- a/src/lib/ai/proxy.test.ts
+++ b/src/lib/ai/proxy.test.ts
@@ -1,0 +1,105 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { ProxyProvider } from './proxy';
+import { AIError } from './provider';
+
+function mockProxyResponse(body: unknown, status: number): void {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn().mockResolvedValue({
+      ok: status >= 200 && status < 300,
+      status,
+      json: () => Promise.resolve(body),
+    }),
+  );
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('ProxyProvider — error passthrough vs. wrapping (#239)', () => {
+  const generate = () =>
+    new ProxyProvider('https://proxy.example.com/generate', 'tok').generate({
+      system: 'sys',
+      prompt: 'prompt',
+    });
+
+  /** The thrown AIError's message, for tests that assert on exact wording. */
+  async function generateErrorMessage(): Promise<string> {
+    try {
+      await generate();
+      throw new Error('expected generate() to reject');
+    } catch (e) {
+      return (e as Error).message;
+    }
+  }
+
+  it('returns the text unchanged on 200', async () => {
+    mockProxyResponse({ text: 'A complete answer.' }, 200);
+    await expect(generate()).resolves.toBe('A complete answer.');
+  });
+
+  it('surfaces the sign-in message verbatim, not double-wrapped', async () => {
+    mockProxyResponse({ error: 'Sign in to use the managed AI.' }, 401);
+    await expect(generate()).rejects.toThrow(AIError);
+    await expect(generate()).rejects.toThrow('Sign in to use the managed AI.');
+  });
+
+  it('surfaces the daily-limit message verbatim', async () => {
+    mockProxyResponse({ error: 'Daily limit reached (50/day). Resets at midnight UTC.' }, 429);
+    await expect(generate()).rejects.toThrow('Daily limit reached (50/day). Resets at midnight UTC.');
+  });
+
+  // The three cases below are what #239 added: server/index.js's
+  // classifyFinishReason now curates a full message for a safety/recitation
+  // block or a near-empty MAX_TOKENS truncation, mirroring GeminiProvider's own
+  // finishReason handling. Sent at 502 (see server/index.js), which must pass
+  // through unprefixed the same way 401/429 already do — a user on the BYO-key
+  // Gemini path and a user on the managed proxy should read an identical cause
+  // for an identical failure, not "Proxy error: <the same sentence>".
+  it('surfaces a safety-block message verbatim, without a "Proxy error:" prefix', async () => {
+    mockProxyResponse({ error: 'This response was blocked for safety reasons. Try rephrasing.' }, 502);
+    await expect(generate()).rejects.toThrow(AIError);
+    const message = await generateErrorMessage();
+    expect(message).toBe('This response was blocked for safety reasons. Try rephrasing.');
+    expect(message).not.toMatch(/^Proxy error:/);
+  });
+
+  it('surfaces a recitation-block message verbatim', async () => {
+    mockProxyResponse(
+      { error: 'This response was blocked because it matched existing content too closely. Try rephrasing.' },
+      502,
+    );
+    expect(await generateErrorMessage()).toBe(
+      'This response was blocked because it matched existing content too closely. Try rephrasing.',
+    );
+  });
+
+  it('surfaces a truncated-response message verbatim', async () => {
+    mockProxyResponse(
+      { error: 'The response was cut off before it could really start (ran out of output budget). Try again.' },
+      502,
+    );
+    expect(await generateErrorMessage()).toBe(
+      'The response was cut off before it could really start (ran out of output budget). Try again.',
+    );
+  });
+
+  it('still prefixes an unexpected failure with "Proxy error:" for context', async () => {
+    // Everything that ISN'T one of the curated, complete messages above still
+    // gets the prefix — losing it there would make a bare status code or an
+    // unrelated failure read as if it were the whole story.
+    mockProxyResponse({ error: 'Quota check failed. Try again.' }, 500);
+    expect(await generateErrorMessage()).toBe('Proxy error: Quota check failed. Try again.');
+  });
+
+  it('falls back to the status code when the body has no error field', async () => {
+    mockProxyResponse({}, 500);
+    expect(await generateErrorMessage()).toBe('Proxy error: 500');
+  });
+
+  it('throws when the 200 response has no usable text', async () => {
+    mockProxyResponse({ text: '' }, 200);
+    await expect(generate()).rejects.toThrow(/empty response/i);
+  });
+});

--- a/src/lib/ai/proxy.ts
+++ b/src/lib/ai/proxy.ts
@@ -41,9 +41,12 @@ export class ProxyProvider implements AIProvider {
     if (!res.ok) {
       const detail = await res.json().catch(() => ({}));
       const msg = (detail as { error?: string }).error || `${res.status}`;
-      // The proxy already returns clear messages for sign-in (401) and the daily
-      // quota / rate limit (429), so surface those verbatim.
-      if (res.status === 401 || res.status === 429) throw new AIError(msg);
+      // The proxy already returns clear, complete messages for sign-in (401),
+      // the daily quota / rate limit (429), and a blocked/truncated/empty AI
+      // response (502 — see #239, classifyFinishReason in server/index.js,
+      // mirroring the SAFETY/RECITATION/short-MAX_TOKENS handling below) — so
+      // surface those verbatim instead of double-wrapping with "Proxy error:".
+      if (res.status === 401 || res.status === 429 || res.status === 502) throw new AIError(msg);
       throw new AIError(`Proxy error: ${msg}`);
     }
 


### PR DESCRIPTION
## What & why

Closes #239.

Follow-up to #182/#238. #238 fixed truncation/safety-block detection for the **BYO-key Gemini path only** — the managed-proxy path couldn't report any of it. `server/index.js`'s `generate()` built its response from `parts` alone and threw away `finishReason` before the extension ever saw it, so a SAFETY block, a RECITATION block, or a `"Fellow"`-style near-immediate `MAX_TOKENS` truncation all surfaced identically to a generic empty response.

That matters because the managed proxy is the **default provider for a new install**, so most first-time users were on the exact path that never got #238's fix.

## What changed

**`server/index.js`** — `generate()` now returns `{ text, finishReason }`. A new `classifyFinishReason(finishReason, text)` mirrors `gemini.ts`'s own SAFETY/RECITATION/short-MAX_TOKENS handling — same `MIN_VIABLE_ANSWER_LENGTH = 40` threshold — and the handler returns the curated message at `502` instead of the generic `"Empty response from Vertex AI"`.

Duplicated rather than imported: `server/` is a standalone Cloud Run deployable with its own `package.json`, not built alongside the extension — there's no shared module to import from. The comment says so, and flags that the two need to be kept in sync by hand.

One deliberate refinement beyond a literal port of `gemini.ts`: the existing retry-once-on-empty-response ("Gemini occasionally returns an empty candidate for no real reason") now **skips retrying when the first attempt was SAFETY/RECITATION** — that block is deterministic for the same prompt, so a second Vertex call would almost certainly repeat it for nothing. A genuinely empty response with no bad `finishReason` still retries exactly as before.

Wording deliberately does **not** say "Gemini" (unlike `gemini.ts`) — every other message in this file speaks generically ("the managed AI", "the AI service"), since the proxy never discloses which model runs behind it.

**`src/lib/ai/proxy.ts`** — the new `502` curated messages pass through to the user verbatim, the same way `401`/`429` already do, instead of being wrapped as `"Proxy error: <message>"`. Without this, a proxy user would see a subtly different sentence than a BYO-key Gemini user for the identical underlying failure — which is the whole point of the fix.

## How I verified this

`server/` has **no test runner**, and its only CI check is `node --check` — syntax only, it never imports or exercises the module. So I verified by hand rather than trusting that check:

- Extracted the exact **committed** `classifyFinishReason` into a standalone script and ran it against the full case matrix — SAFETY/RECITATION at any text length, `MAX_TOKENS` at 39/40/500 chars (pinning the `< 40` threshold boundary precisely), no `finishReason`, `STOP` with empty text. All behave as intended.
- Verified the retry-skip decision (`!text && finishReason !== 'SAFETY' && finishReason !== 'RECITATION'`) against 6 cases.
- Simulated the **full handler** end to end across 7 realistic scenarios, asserting both the returned status/body *and* the number of simulated Vertex calls — confirming SAFETY/RECITATION never trigger a wasted second call while a genuine transient emptiness still retries once, exactly as before.

None of that is a substitute for a real test suite, so I added one where it was missing: `npm run lint`, `npm run typecheck`, `npm test` (30 files, **374 tests**), `npm run build` — all green. New `src/lib/ai/proxy.test.ts` (previously **zero** coverage on this file) covers the passthrough change directly — **mutation-tested**: reverting the `502` passthrough fails 3 of 9 new tests.

## Deploy note

**Needs a Cloud Run redeploy of `server/`** to take effect for anyone already running the proxy — this is not a client-only fix. Flagging per the issue's own instruction, so it isn't merged expecting the change to be live immediately.

## Checklist

- [x] `npm run lint` passes
- [x] `npm run typecheck` passes
- [x] `npm test` passes
- [x] `npm run build` succeeds
- [x] `node --check server/index.js` passes
- [x] Tests added/updated if behavior changed
- [x] No secrets, keys, or personal data committed

🤖 Generated with [Claude Code](https://claude.com/claude-code)