### PR TITLE
fix(profile): extract document dedup logic into a testable upsertDocument

### DIFF
--- a/src/lib/profile.test.ts
+++ b/src/lib/profile.test.ts
@@ -1,6 +1,13 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { DEFAULT_MODEL, GEMINI_MODELS } from './ai/models';
-import { DEFAULT_PROFILE, onProfileChanged, profileToContext, type Profile } from './profile';
+import {
+  DEFAULT_PROFILE,
+  onProfileChanged,
+  profileToContext,
+  upsertDocument,
+  type Profile,
+  type UploadedDoc,
+} from './profile';
 
 const STORAGE_KEY = 'profile';
 
@@ -203,5 +210,54 @@ describe('profileToContext', () => {
     expect(result).toContain('Skills: TypeScript, React');
     expect(result).toContain('Work history:');
     expect(result).toContain('Acme');
+  });
+});
+
+describe('upsertDocument', () => {
+  // Regression test for #267 via #271: this logic used to live inline in
+  // Options.tsx JSX, which can't be imported under vitest's DOM-less test env
+  // (`DOMMatrix is not defined`, via the transitive pdfjs-dist import), so it
+  // shipped with no test. Extracted here so it finally has one.
+  function docs(names: string[]): UploadedDoc[] {
+    return names.map((name, i) => ({ id: `id-${i}`, name, text: `text ${i}`, addedAt: i }));
+  }
+
+  it('appends a document with a new filename', () => {
+    const result = upsertDocument(docs(['resume.pdf']), 'cover.pdf', 'cover text');
+    expect(result.map((d) => d.name)).toEqual(['resume.pdf', 'cover.pdf']);
+    expect(result[1].text).toBe('cover text');
+  });
+
+  it('replaces an existing document with the same filename, moving it to the end', () => {
+    // Pins the current (pre-extraction) behavior: filter-then-append means a
+    // re-upload moves to the end of the list, changing both the Options display
+    // order and where it appears in the AI context — #271 flagged this as
+    // accidental rather than chosen; this test makes it deliberate.
+    const result = upsertDocument(docs(['a.pdf', 'b.pdf', 'c.pdf']), 'a.pdf', 'new a text');
+    expect(result.map((d) => d.name)).toEqual(['b.pdf', 'c.pdf', 'a.pdf']);
+    expect(result[2].text).toBe('new a text');
+  });
+
+  it('matches an existing filename case- and whitespace-insensitively', () => {
+    // Pins the case-insensitivity as intentional (#271) — filesystems are
+    // case-insensitive on macOS/Windows, so "Resume.PDF" and "resume.pdf" are
+    // the same file to a user re-uploading it.
+    const result = upsertDocument(docs(['resume.pdf']), '  Resume.PDF  ', 'updated text');
+    expect(result).toHaveLength(1);
+    expect(result[0].name).toBe('  Resume.PDF  ');
+    expect(result[0].text).toBe('updated text');
+  });
+
+  it('accumulates correctly across a sequence of calls (multi-file upload)', () => {
+    // DocUpload calls onText once per file in a loop for a multi-file upload
+    // (extractTextBatch), so a sequence of calls is a real path, not synthetic.
+    let result: UploadedDoc[] = [];
+    result = upsertDocument(result, 'a.pdf', 'a1');
+    result = upsertDocument(result, 'b.pdf', 'b1');
+    result = upsertDocument(result, 'a.pdf', 'a2');
+    expect(result.map((d) => [d.name, d.text])).toEqual([
+      ['b.pdf', 'b1'],
+      ['a.pdf', 'a2'],
+    ]);
   });
 });

--- a/src/lib/profile.ts
+++ b/src/lib/profile.ts
@@ -40,6 +40,22 @@ export interface UploadedDoc {
   addedAt: number;
 }
 
+/**
+ * Adds a document, replacing any existing one with the same filename
+ * (case- and whitespace-insensitive, so "Resume.PDF" replaces "resume.pdf" —
+ * filesystems are case-insensitive on macOS/Windows, so this matches user
+ * expectations for "the same file, re-uploaded"). A re-uploaded document moves
+ * to the end of the list — most-recently-uploaded last — which also changes
+ * where it appears in the AI context; that's the behavior this already had
+ * before being extracted here, now pinned as intentional rather than
+ * accidental. A distinct filename is appended, never merged (see #267/#271).
+ */
+export function upsertDocument(docs: UploadedDoc[], name: string, text: string): UploadedDoc[] {
+  const norm = name.trim().toLowerCase();
+  const without = docs.filter((d) => d.name.trim().toLowerCase() !== norm);
+  return [...without, { id: crypto.randomUUID(), name, text, addedAt: Date.now() }];
+}
+
 export interface Preferences {
   workAuthorization: string;
   requiresSponsorship: string;

--- a/src/options/Options.tsx
+++ b/src/options/Options.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react';
 import { Field } from './Field';
 import { DisabledSites } from './DisabledSites';
-import type { EducationEntry, Profile, WorkEntry } from '../lib/profile';
+import { upsertDocument, type EducationEntry, type Profile, type WorkEntry } from '../lib/profile';
 import { removeDisabledHost } from '../lib/host';
 import { useProfile } from '../ui/useProfile';
 import { extractText, extractTextBatch } from '../lib/documents';
@@ -502,19 +502,7 @@ function OptionsView({
         <h2>Additional documents (extra AI context)</h2>
         <DocUpload
           onText={(name, text) =>
-            update((prev) => {
-              const norm = name.trim().toLowerCase();
-              const without = prev.documents.filter(
-                (d) => d.name.trim().toLowerCase() !== norm,
-              );
-              return {
-                ...prev,
-                documents: [
-                  ...without,
-                  { id: crypto.randomUUID(), name, text, addedAt: Date.now() },
-                ],
-              };
-            })
+            update((prev) => ({ ...prev, documents: upsertDocument(prev.documents, name, text) }))
           }
         />
         {p.documents.length > 0 && (


### PR DESCRIPTION
Closes #271.

## What changed

`upsertDocument(docs, name, text)` extracted from inline JSX in `Options.tsx` into `src/lib/profile.ts`, next to the `UploadedDoc` type it operates on (which imports nothing browser-specific, so it's freely importable under vitest).

Behavior is unchanged — this is a pure extraction, not a rewrite. `Options.tsx`'s `DocUpload.onText` now just calls it.

## Why it needed extracting rather than just adding a test where it lived

`Options.tsx` can't be imported under `environment: 'node'` at all:

```
import failed -> DOMMatrix is not defined
```

That's `Options.tsx` → `lib/documents.ts` → `pdfjs-dist`, which needs browser globals. So #268's dedup fix (for #267) shipped with zero seam to test against, even though I'd verified it against six scenarios by hand before merging.

## The one thing pinned deliberately

Per #271's callout: re-uploading a file **moves it to the end of the list** (filter-then-append), which both reorders the Options display and changes where the document appears in the AI context. That was accidental rather than chosen. Kept as-is (harmless, arguably reasonable — "most recently touched, last"), but now there's a test (`replaces an existing document with the same filename, moving it to the end`) making it an intentional, protected behavior instead of something a future refactor could silently flip.

## Tests

4 new tests in `profile.test.ts`, matching #271's suggested matrix: new filename appends; same filename replaces + reorders; case/whitespace-insensitive match (`Resume.PDF` replaces `resume.pdf`); a sequence of calls accumulates correctly (the real multi-file-upload path — `DocUpload` calls `onText` once per file in a loop).

**Mutation-tested**: reverting the case-insensitive match back to a bare `!==` comparison fails the case-insensitivity test, confirming the test actually pins that behavior rather than passing vacuously.

`npm run lint`, `npm run typecheck`, `npm test` (30 files, **382 tests**), `npm run build` — all green.

## Checklist

- [x] `npm run lint` passes
- [x] `npm run typecheck` passes
- [x] `npm test` passes
- [x] `npm run build` succeeds
- [x] Tests added/updated if behavior changed
- [x] No secrets, keys, or personal data committed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved additional document uploads to consistently handle duplicate filenames, regardless of capitalization or surrounding spaces.
  * Re-uploaded documents now replace earlier versions and appear at the end of the document list.
  * Multiple document uploads now accumulate correctly without unintentionally overwriting unrelated documents.

* **Tests**
  * Added coverage for document replacement, filename matching, ordering, and repeated uploads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->