### PR TITLE
fix(profile): bound the AI context to a character budget

### DIFF
--- a/src/lib/profile.test.ts
+++ b/src/lib/profile.test.ts
@@ -1,6 +1,16 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { DEFAULT_MODEL, GEMINI_MODELS } from './ai/models';
-import { DEFAULT_PROFILE, onProfileChanged, profileToContext, type Profile } from './profile';
+import {
+  CONTEXT_TEXT_BUDGET,
+  DEFAULT_PROFILE,
+  DOCUMENT_TEXT_BUDGET,
+  RESUME_TEXT_BUDGET,
+  isDocumentTrimmed,
+  onProfileChanged,
+  profileToContext,
+  type Profile,
+  type UploadedDoc,
+} from './profile';
 
 const STORAGE_KEY = 'profile';
 
@@ -203,5 +213,142 @@ describe('profileToContext', () => {
     expect(result).toContain('Skills: TypeScript, React');
     expect(result).toContain('Work history:');
     expect(result).toContain('Acme');
+  });
+
+  // #251: profileToContext used to concatenate resumeText + every document's
+  // full text with no limit, so a few uploaded documents could push the whole
+  // prompt past the proxy's hard MAX_PROMPT_CHARS ceiling and fail every AI
+  // call. These pin the cap.
+  describe('context size budget (#251)', () => {
+    function doc(name: string, length: number): UploadedDoc {
+      return { id: name, name, text: 'x'.repeat(length), addedAt: 0 };
+    }
+
+    // Content is a run of 'x' characters and nothing else in these tests
+    // contains 'x' (labels, filenames, field names), so the maximal 'x' runs in
+    // the output are exactly the per-field contributions, in order — a more
+    // robust way to pin exact lengths than slicing the string on its own labels.
+    function xRuns(s: string): number[] {
+      return (s.match(/x+/g) ?? []).map((run) => run.length);
+    }
+
+    it('is unchanged for a normal-sized profile — no regression for the common case', () => {
+      const p: Profile = {
+        ...DEFAULT_PROFILE,
+        personal: { ...DEFAULT_PROFILE.personal, firstName: 'Jane' },
+        resumeText: 'A modest resume, well under budget.',
+        documents: [doc('cover-letter.pdf', 500), doc('transcript.pdf', 300)],
+      };
+      const result = profileToContext(p);
+      // Every character of both documents survives untouched.
+      expect(result).toContain('x'.repeat(500));
+      expect(result).toContain('x'.repeat(300));
+      expect(result).toContain('A modest resume, well under budget.');
+    });
+
+    it('caps the resume at RESUME_TEXT_BUDGET', () => {
+      const p: Profile = { ...DEFAULT_PROFILE, resumeText: 'x'.repeat(RESUME_TEXT_BUDGET + 5_000) };
+      const result = profileToContext(p);
+      expect(xRuns(result)).toEqual([RESUME_TEXT_BUDGET]);
+    });
+
+    it('caps each document at DOCUMENT_TEXT_BUDGET, degrading every document rather than dropping the tail', () => {
+      const p: Profile = {
+        ...DEFAULT_PROFILE,
+        documents: [doc('a.pdf', DOCUMENT_TEXT_BUDGET + 10_000), doc('b.pdf', DOCUMENT_TEXT_BUDGET + 10_000)],
+      };
+      const result = profileToContext(p);
+      // Both documents are present (neither dropped) and each contributes at
+      // most the per-document cap.
+      expect(result).toContain('Document "a.pdf"');
+      expect(result).toContain('Document "b.pdf"');
+      expect(xRuns(result)).toEqual([DOCUMENT_TEXT_BUDGET, DOCUMENT_TEXT_BUDGET]);
+    });
+
+    it('gives the resume priority: it is never trimmed to make room for documents', () => {
+      const p: Profile = {
+        ...DEFAULT_PROFILE,
+        resumeText: 'x'.repeat(RESUME_TEXT_BUDGET), // uses its full priority slice
+        documents: [doc('huge.pdf', 200_000)],
+      };
+      const result = profileToContext(p);
+      // First run is the resume — full RESUME_TEXT_BUDGET, not shrunk to make
+      // room for the document (which still gets its own DOCUMENT_TEXT_BUDGET
+      // slice out of what's left, not zero).
+      const runs = xRuns(result);
+      expect(runs[0]).toBe(RESUME_TEXT_BUDGET);
+      expect(runs[1]).toBe(DOCUMENT_TEXT_BUDGET);
+    });
+
+    it('shrinks the real regression scenario from the issue well under the proxy limit', () => {
+      // The exact numbers measured in #251: three real documents (~55k/~53k/~8k
+      // chars, ~116k combined) that — with the old resumeText + a modest resume
+      // — added up to ~133k characters of prompt, dangerously close to the
+      // proxy's 200k hard limit and one document away from tipping over it.
+      const p: Profile = {
+        ...DEFAULT_PROFILE,
+        resumeText: 'x'.repeat(5_000),
+        documents: [doc('one.pdf', 55_249), doc('two.pdf', 52_791), doc('three.pdf', 8_288)],
+      };
+      const result = profileToContext(p);
+      expect(result).toContain('Document "one.pdf"');
+      expect(result).toContain('Document "two.pdf"');
+      expect(result).toContain('Document "three.pdf"');
+      expect(result.length).toBeLessThan(35_000); // was ~133k before the cap
+    });
+
+    it('drops documents entirely, in list order, once the shared budget is exhausted', () => {
+      // Resume uses its full RESUME_TEXT_BUDGET (20k), leaving exactly
+      // CONTEXT_TEXT_BUDGET - RESUME_TEXT_BUDGET = 40k shared budget for
+      // documents. Five documents at the 8k per-document cap use exactly that
+      // 40k; a sixth has nothing left and is dropped entirely rather than
+      // appended as a useless sliver.
+      const p: Profile = {
+        ...DEFAULT_PROFILE,
+        resumeText: 'x'.repeat(RESUME_TEXT_BUDGET),
+        documents: Array.from({ length: 6 }, (_, i) => doc(`doc-${i}.pdf`, DOCUMENT_TEXT_BUDGET)),
+      };
+      const result = profileToContext(p);
+      for (let i = 0; i < 5; i++) expect(result).toContain(`Document "doc-${i}.pdf"`);
+      expect(result).not.toContain('Document "doc-5.pdf"');
+      expect(xRuns(result)).toEqual([
+        RESUME_TEXT_BUDGET,
+        DOCUMENT_TEXT_BUDGET,
+        DOCUMENT_TEXT_BUDGET,
+        DOCUMENT_TEXT_BUDGET,
+        DOCUMENT_TEXT_BUDGET,
+        DOCUMENT_TEXT_BUDGET,
+      ]);
+    });
+
+    it('never produces a context longer than CONTEXT_TEXT_BUDGET plus a small, bounded label overhead', () => {
+      const p: Profile = {
+        ...DEFAULT_PROFILE,
+        resumeText: 'x'.repeat(100_000),
+        documents: Array.from({ length: 20 }, (_, i) => doc(`doc-${i}.pdf`, 50_000)),
+      };
+      const result = profileToContext(p);
+      // "\nResume:\n" + "\nDocument \"doc-N.pdf\":\n" per included document is the
+      // only overhead beyond the raw character budget — generously bounded here.
+      expect(result.length).toBeLessThan(CONTEXT_TEXT_BUDGET + 2_000);
+    });
+  });
+});
+
+describe('isDocumentTrimmed', () => {
+  function doc(length: number): UploadedDoc {
+    return { id: 'd', name: 'd.pdf', text: 'x'.repeat(length), addedAt: 0 };
+  }
+
+  it('is false at exactly the budget', () => {
+    expect(isDocumentTrimmed(doc(DOCUMENT_TEXT_BUDGET))).toBe(false);
+  });
+
+  it('is true one character over the budget', () => {
+    expect(isDocumentTrimmed(doc(DOCUMENT_TEXT_BUDGET + 1))).toBe(true);
+  });
+
+  it('is false for a short document', () => {
+    expect(isDocumentTrimmed(doc(100))).toBe(false);
   });
 });

--- a/src/lib/profile.ts
+++ b/src/lib/profile.ts
@@ -195,6 +195,40 @@ export function onProfileChanged(cb: (profile: Profile) => void): () => void {
 }
 
 /**
+ * Character budget for resume + uploaded documents COMBINED in the AI context
+ * (see #251). The proxy hard-rejects any prompt over MAX_PROMPT_CHARS = 200_000
+ * (server/index.js), and every prompt builder also adds capped job text
+ * (MAX_TEXT = 12_000, savedJobs.ts) plus a system prompt on top — this stays
+ * comfortably under that ceiling with room to spare for future growth.
+ */
+export const CONTEXT_TEXT_BUDGET = 60_000;
+
+/**
+ * The resume is the highest-value context for tailoring, so it gets a generous
+ * budget of its own — taken from CONTEXT_TEXT_BUDGET first, ahead of documents,
+ * so it's the last thing to get trimmed.
+ */
+export const RESUME_TEXT_BUDGET = 20_000;
+
+/**
+ * Per-document cap. Applied before the shared remaining budget so one oversized
+ * upload can't crowd out the others — every document degrades a little instead
+ * of a tail-truncate silently dropping whichever documents sort last.
+ */
+export const DOCUMENT_TEXT_BUDGET = 8_000;
+
+/**
+ * True when this document's own text is long enough that profileToContext will
+ * trim it. Options.tsx shows this next to the document instead of trimming
+ * silently — see #251. (A document under this cap can still end up dropped
+ * entirely if enough earlier resume/document text has already used up
+ * CONTEXT_TEXT_BUDGET; this only flags the common, per-document case.)
+ */
+export function isDocumentTrimmed(doc: UploadedDoc): boolean {
+  return doc.text.trim().length > DOCUMENT_TEXT_BUDGET;
+}
+
+/**
  * Flattens the profile into a single context string the AI can read when
  * answering open-ended questions or tailoring a cover letter.
  */
@@ -231,12 +265,23 @@ export function profileToContext(p: Profile): string {
     }
   }
 
-  if (p.resumeText.trim()) {
-    lines.push('\nResume:\n' + p.resumeText.trim());
+  const resume = p.resumeText.trim();
+  if (resume) {
+    lines.push('\nResume:\n' + resume.slice(0, RESUME_TEXT_BUDGET));
   }
 
+  // Remaining shared budget after the resume's priority slice. Each document is
+  // further capped at DOCUMENT_TEXT_BUDGET so a single huge upload can't eat the
+  // whole thing; once the shared budget itself runs out, later documents (in
+  // list order) are dropped entirely rather than appended as a useless sliver.
+  let remaining = CONTEXT_TEXT_BUDGET - Math.min(resume.length, RESUME_TEXT_BUDGET);
   for (const doc of p.documents) {
-    if (doc.text.trim()) lines.push(`\nDocument "${doc.name}":\n${doc.text.trim()}`);
+    if (remaining <= 0) break;
+    const text = doc.text.trim();
+    if (!text) continue;
+    const cap = Math.min(DOCUMENT_TEXT_BUDGET, remaining);
+    lines.push(`\nDocument "${doc.name}":\n${text.slice(0, cap)}`);
+    remaining -= Math.min(text.length, cap);
   }
 
   return lines.join('\n');

--- a/src/options/Options.tsx
+++ b/src/options/Options.tsx
@@ -1,7 +1,13 @@
 import { useEffect, useState } from 'react';
 import { Field } from './Field';
 import { DisabledSites } from './DisabledSites';
-import type { EducationEntry, Profile, WorkEntry } from '../lib/profile';
+import {
+  DOCUMENT_TEXT_BUDGET,
+  isDocumentTrimmed,
+  type EducationEntry,
+  type Profile,
+  type WorkEntry,
+} from '../lib/profile';
 import { removeDisabledHost } from '../lib/host';
 import { useProfile } from '../ui/useProfile';
 import { extractText, extractTextBatch } from '../lib/documents';
@@ -523,6 +529,15 @@ function OptionsView({
               <div key={d.id} className="list-item" style={{ display: 'flex', alignItems: 'center' }}>
                 <span style={{ flex: 1 }}>
                   📄 {d.name} <span className="help">({d.text.length.toLocaleString()} chars)</span>
+                  {isDocumentTrimmed(d) && (
+                    <span
+                      className="warn"
+                      title={`Only the first ${DOCUMENT_TEXT_BUDGET.toLocaleString()} characters are sent to the AI.`}
+                    >
+                      {' '}
+                      — trimmed for AI context
+                    </span>
+                  )}
                 </span>
                 <button
                   className="danger"


### PR DESCRIPTION
Closes #251.

## What changed

`profileToContext` used to concatenate `resumeText` + every uploaded document's full text with no limit, while every prompt builder already caps job text at `MAX_TEXT` (12,000, `savedJobs.ts`). The proxy hard-rejects any prompt over `MAX_PROMPT_CHARS` (200,000, `server/index.js:53`) with a flat `413 "Request too large."` that surfaces to the user as `Proxy error: Request too large.` — no hint the cause was their own uploaded documents.

Measured from a real Options screenshot in the issue: three ordinary documents alone totaled **~116,328 chars**, ~133,000 with resume + capped job text on top — roughly one more document of headroom before *every* AI feature (answers, cover letter, resume, eligibility check) failed for that user, permanently, until they worked out what to delete.

## The three deliberate decisions the issue called out

**Where to cap** — both, per the issue's own tradeoff analysis: a per-document cap so one oversized upload can't crowd out the others (every document degrades a little, instead of a tail-truncate silently dropping whichever sorts last), *and* a shared total ceiling so an unbounded number of documents still can't blow past the proxy's limit.

```
CONTEXT_TEXT_BUDGET = 60_000   // resume + documents combined
RESUME_TEXT_BUDGET  = 20_000   // resume's own priority slice
DOCUMENT_TEXT_BUDGET = 8_000   // per-document cap
```

`CONTEXT_TEXT_BUDGET` + job text (12,000) + system prompt (a couple KB at most) lands around 74–76k — comfortably under the 200k ceiling, with over 100k of headroom for growth (multi-file upload from #248 makes reaching any ceiling easier).

**What to prioritize** — the resume gets its own budget, taken from the shared total first, so it's the last thing trimmed. Documents share whatever's left after the resume, each capped individually; once that remaining budget hits zero, later documents (in list order) are dropped entirely rather than appended as a useless few-character sliver.

**Tell the user** — not silent. `isDocumentTrimmed(doc)` is exported so `Options.tsx` can flag it: any document over the per-document cap now shows **"— trimmed for AI context"** next to its existing character count, with a tooltip naming the exact cutoff. (This flags the common per-document case; a document that gets dropped entirely because earlier documents already used up the shared budget isn't separately called out — flagged as a known simplification in the code comment. Full order-dependent tracking felt like scope creep for what the issue asked for; happy to extend if wanted.)

## Tests

10 new tests in `profile.test.ts`:
- normal-sized profile is untouched — no regression for the common case (every character of modest documents/resume survives)
- resume capped at `RESUME_TEXT_BUDGET`
- each document capped at `DOCUMENT_TEXT_BUDGET`, none dropped when they fit
- resume never trimmed to make room for documents
- the issue's own real-world numbers (55,249 / 52,791 / 8,288 char documents) shrink from ~133k to well under 35k
- documents are dropped entirely, in list order, once the shared budget is exhausted (exact accounting: resume uses its full 20k slice, 5 documents at the 8k cap exhaust the remaining 40k exactly, a 6th is absent from the output)
- total output never exceeds the budget plus a small bounded label overhead
- `isDocumentTrimmed` boundary at exactly the cap, one over, and a short document

**Mutation-tested**: reverted the resume cap (`resume.slice(0, RESUME_TEXT_BUDGET)` → `resume`) — 2 of the new tests fail as expected (the resume-cap test and the total-budget test), confirming they actually pin the behavior rather than passing vacuously.

`npm run lint`, `npm run typecheck`, `npm test` (30 files, **388 tests**), `npm run build` — all green.

## Checklist

- [x] `npm run lint` passes
- [x] `npm run typecheck` passes
- [x] `npm test` passes
- [x] `npm run build` succeeds
- [x] Tests added/updated if behavior changed
- [x] No secrets, keys, or personal data committed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * AI context is now limited to defined character budgets, prioritizing resume content and including additional documents only while space remains.
  * Individual documents are capped, and empty or excess documents may be excluded from AI context.
  * Additional documents that exceed the limit now display a warning with the applicable character budget.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->