### PR TITLE
chore(ci): sync codeql-action init/analyze to the same version

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -21,13 +21,13 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28 # v4
+        uses: github/codeql-action/init@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4
         with:
           languages: javascript-typescript
           queries: security-and-quality
 
       # JS/TS is interpreted — no build step needed before analysis.
       - name: Perform CodeQL analysis
-        uses: github/codeql-action/analyze@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4
+        uses: github/codeql-action/analyze@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4
         with:
           category: '/language:javascript-typescript'


### PR DESCRIPTION
## What happened

#278 (bump `codeql-action/init` 4.37.7 → 4.37.8) and #279 (bump `codeql-action/analyze` 4.37.7 → 4.37.8) are two independent dependabot PRs, each touching only one of the two `codeql-action` steps in `.github/workflows/codeql.yml`. I merged #278. By the time I went to merge #279, dependabot's `@dependabot rebase` had already re-resolved it to 4.37.9 (codeql-action ships frequent patch releases) — so merging #279 as rebased would have just left `init` on 4.37.8 and `analyze` on 4.37.9, still mismatched.

`codeql-action` hard-fails when its two steps run different versions in the same job:

```
##[error]Loaded a configuration file for version '4.37.8', but running version '4.37.9'
##[error]analyze post-action step failed: ...
CodeQL job status was configuration error.
```

This is exactly what #278/#279 individually did — the workflow itself even warns about it: *"Not all workflow steps that use `github/codeql-action` actions use the same version."*

## Fix

Bump both `init` and `analyze` to the same SHA (4.37.9, the latest as of this PR) in one commit, so a single dependency PR can't leave them apart again. Verified the SHA against the upstream repo before pinning it (`cdf488f...` = PR github/codeql-action#4107, "update-v4.37.9").

Supersedes #278 (already merged) and #279 (closing as superseded, its version is already stale again by the time this merges — the underlying fix is pinning both together, not chasing whichever version dependabot last resolved).

## Verification

This is a workflow-only change — the real verification is the CodeQL job itself running clean on this PR (checked before merge, not just `node --check`-style local checks). `npm run lint`, `npm run typecheck`, `npm test`, `npm run build` unaffected (no source changed).

## Checklist

- [x] `npm run lint` passes
- [x] `npm run typecheck` passes
- [x] `npm test` passes
- [x] `npm run build` succeeds
- [x] No secrets, keys, or personal data committed
