### PR TITLE
docs(privacy): list the stored API key, disabledHosts, and settings

### DIFF
--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -1,6 +1,6 @@
 # Privacy Policy — Little AI Helper
 
-_Last updated: June 18, 2026_
+_Last updated: September 3, 2026_
 
 Little AI Helper ("the extension") is a Chrome extension that fills out
 job applications and drafts answers and cover letters from a profile **you** enter.
@@ -23,6 +23,21 @@ All of the following is saved **locally on your computer** using Chrome's
   and entirely under your control.
 - **Cover-letter template** and **saved job postings.**
 - **Your Google account email**, cached after you choose to sign in (see below).
+- **Your AI provider settings** — if you bring your own Gemini key, or paste an admin
+  token for the managed proxy, that credential is stored locally and sent only to the
+  provider you chose, in a request header, never in a URL or a log.
+- **Sites you've turned the eligibility badge off on** — just the hostnames you chose
+  via "Turn off on this site only" on the badge, so the setting survives a reload. This
+  is a short, user-initiated list, not a browsing history: it only ever contains a site
+  once you've explicitly clicked to disable the badge there, and it's never transmitted
+  anywhere.
+- **Extension settings** — which features are turned on (autofill scanning, cover
+  letter, tailored resume), whether you've dismissed the badge's first-run intro, and
+  which corner of the screen you've dragged the badge to.
+
+This list is kept in step with the `Profile` type in
+[src/lib/profile.ts](https://github.com/ritsth/job-autofill-extension/blob/main/src/lib/profile.ts) —
+any new field stored there should be added here too.
 
 We do **not** use analytics, tracking, advertising, or crash reporting. There is no
 telemetry of any kind.

--- a/STORE_LISTING.md
+++ b/STORE_LISTING.md
@@ -97,10 +97,17 @@ the package.
   location (city/state/country) the user enters for their profile, plus optional
   self-reported demographic fields.
 - **Authentication information** — Google account email/token used for optional managed-
-  proxy sign-in.
+  proxy sign-in, plus the user's own Gemini API key or an admin proxy token, if they
+  choose to enter one.
+- **Website content** — resume text, uploaded documents (PDF/DOCX converted to plain
+  text), work history, education, skills, cover-letter template, and saved job-posting
+  text — all entered or captured by the user for use as AI context.
 
 (We do not collect: health info, financial/payment info, web-browsing history, user
-activity/analytics, or personal communications.)
+activity/analytics, or personal communications. The list of hostnames where the user has
+turned the eligibility badge off — see PRIVACY.md — is a short, user-initiated settings
+list, not browsing history: it only ever contains a site the user explicitly chose to
+disable, it's never transmitted, and it does not log page visits.)
 
 **Required certifications** (all true):
 - ✅ I do not sell or transfer user data to third parties outside of approved use cases.


### PR DESCRIPTION
Closes #274.

## What changed

PRIVACY.md's "what we store" list claimed **"all of the following is saved"** but was missing several things actually written to `chrome.storage.local`. Verified against every `storage.local.set` call in `src/` — the inventory now matches:

| Key | Written by | Was in PRIVACY.md? |
|---|---|---|
| `profile.ai.apiKey` / `profile.ai.proxyToken` | `src/lib/profile.ts` | ❌ → now listed |
| `profile.disabledHosts` (added in #272) | `src/lib/profile.ts` | ❌ → now listed |
| `profile.scanEnabled` / `coverLetterEnabled` / `tailoredResumeEnabled` | `src/lib/profile.ts` | ❌ → now listed |
| `badgeCorner`, `badgeIntroSeen` | `src/content/sponsorship.ts` | ❌ → now listed |
| `signedOut` | `src/lib/auth.ts` | ❌ → covered by "settings" catch-all |

## The two that mattered, not just housekeeping

**The API key.** Previously mentioned exactly once, in "When data leaves your device" — describing where it's *sent*, never that it's *kept*. A reader scanning "what we store" for a credential would find nothing. Now says explicitly that it's stored locally and travels as a request header — verified against the actual code (`x-goog-api-key` in `gemini.ts`, `Authorization: Bearer` in `proxy.ts`), not just asserted.

**`disabledHosts`.** The first field that records which sites the user has been to. It's genuinely benign (short, user-initiated, never transmitted — only ever contains a host once the user explicitly clicked "Turn off on this site only"), but a policy that lists city/skills/EEO answers and silently omits the one browsing-adjacent field invites the worst reading. Said plainly, with the distinction from passive browsing history spelled out — that distinction is also why I didn't touch the "we do not collect... web-browsing history" certification later in the doc; disabledHosts genuinely isn't that.

Added a line tying the list to the `Profile` type in `src/lib/profile.ts`, per the issue's suggestion — #272 added `disabledHosts` without updating this doc, which is exactly how the gap appeared; the note is there so the next field prompts an update instead of drifting again.

## STORE_LISTING.md — per the issue's own scope note

Checked it for the same gap, since it repeats a data inventory for the Chrome Web Store's Privacy Practices tab:

- Added a **"Website content"** category — resume text, documents, work history, cover letter, saved job postings were stored but not declared under *any* Web Store category.
- Extended **"Authentication information"** to cover the stored API key / admin proxy token (that category is Chrome's own bucket for credentials, not just the Google token).
- Added a clarifying parenthetical that the `disabledHosts` list is not the "web-browsing history" the certification right above it disclaims — same reasoning as PRIVACY.md, stated where a reviewer would actually be checking for the contradiction.

Bumped the "Last updated" date since this is a substantive content change to a document a reader would reasonably check the date on.

## Scope

Docs only — `PRIVACY.md` and `STORE_LISTING.md`. No code changes, no tests to run. Checked `README.md` for a duplicate storage inventory that would need the same edit; it doesn't have one.

## Checklist

- [x] No secrets, keys, or personal data committed
- [x] Docs-only change — lint/typecheck/test/build unaffected


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the privacy policy date and expanded disclosures for locally stored AI provider credentials, extension settings, and eligibility badge preferences.
  * Clarified that selected hostnames are user settings, are not transmitted, and do not track page visits.
  * Expanded store listing disclosures to cover managed-proxy authentication and additional website-content data categories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->