### PR TITLE
test(adapters): cover ATS host matching

### DIFF
--- a/src/content/adapters/greenhouse.test.ts
+++ b/src/content/adapters/greenhouse.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect } from 'vitest';
+import { greenhouseAdapter } from './greenhouse';
+
+describe('greenhouseAdapter.matches', () => {
+  const matches = (href: string): boolean => greenhouseAdapter.matches(new URL(href));
+
+  it('matches classic and newer Greenhouse job boards', () => {
+    expect(matches('https://boards.greenhouse.io/acme/jobs/123')).toBe(true);
+    expect(matches('https://job-boards.greenhouse.io/acme/jobs/123')).toBe(true);
+  });
+
+  it('matches other Greenhouse subdomains', () => {
+    expect(matches('https://custom.greenhouse.io/acme/jobs/123')).toBe(true);
+  });
+
+  it('does not match unrelated or lookalike hosts', () => {
+    expect(matches('https://jobs.lever.co/acme/123')).toBe(false);
+    expect(matches('https://greenhouse.io.evil.test/acme/jobs/123')).toBe(false);
+  });
+});

--- a/src/content/adapters/lever.test.ts
+++ b/src/content/adapters/lever.test.ts
@@ -1,0 +1,15 @@
+import { describe, it, expect } from 'vitest';
+import { leverAdapter } from './lever';
+
+describe('leverAdapter.matches', () => {
+  const matches = (href: string): boolean => leverAdapter.matches(new URL(href));
+
+  it('matches the Lever job board', () => {
+    expect(matches('https://jobs.lever.co/acme/123')).toBe(true);
+  });
+
+  it('does not match Lever-adjacent or lookalike hosts', () => {
+    expect(matches('https://lever.co/acme/123')).toBe(false);
+    expect(matches('https://jobs.lever.co.evil.test/acme/123')).toBe(false);
+  });
+});


### PR DESCRIPTION
## What & why

Adds direct unit coverage for the Greenhouse and Lever adapter routing logic.

- Pins classic, newer, and arbitrary Greenhouse subdomains.
- Pins the exact Lever job-board host.
- Covers unrelated and lookalike hosts for both adapters.

Closes #291.

## How I tested

- `npx vitest run src/content/adapters/greenhouse.test.ts src/content/adapters/lever.test.ts`
- `npm run lint`
- `npm run typecheck`
- `npm test`
- `npm run build`

## Checklist

- [x] `npm run lint` passes
- [x] `npm run typecheck` passes
- [x] `npm test` passes
- [x] `npm run build` succeeds
- [x] Tests added/updated if behavior changed
- [x] No secrets, keys, or personal data committed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Expanded validation coverage for Greenhouse and Lever job board URL recognition.
  - Confirmed support for standard, newer, and custom job board domains.
  - Added safeguards against unrelated, lookalike, and potentially unsafe domains being recognized incorrectly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->