### PR TITLE
fix(server): extract classifyFinishReason into a testable module

### DIFF
--- a/server/classify.d.ts
+++ b/server/classify.d.ts
@@ -1,0 +1,13 @@
+// Hand-written type declaration for classify.js (plain JS, matching the rest
+// of server/'s Node/ESM convention — see eslint.config.js's "Server — plain
+// JavaScript" block). This lets a TypeScript test import it with real type
+// checking (tsc --noEmit can't infer types across a .js import without one:
+// TS7016 "implicitly has an 'any' type") without turning on `allowJs` for the
+// whole project or pulling server/ into tsconfig's `include`.
+//
+// Keep in sync with classify.js by hand — there's no build step wiring the two
+// together automatically, same as classify.js and gemini.ts are kept in sync
+// by hand for the same underlying reason (server/ ships standalone).
+
+export const MIN_VIABLE_ANSWER_LENGTH: number;
+export function classifyFinishReason(finishReason: string | undefined, text: string): string | null;

--- a/server/classify.js
+++ b/server/classify.js
@@ -1,0 +1,45 @@
+// Pure classification of a Vertex AI finishReason into the message the user
+// sees, if any. Split out from index.js (see #285) so it can be imported
+// directly by a test — index.js itself can't be imported for testing: it has
+// unconditional top-level side effects (new VertexAI(...), new Firestore(...),
+// server.listen(...)) that fire the moment the module loads. This file has
+// none, so it's freely importable.
+//
+// Mirrors src/lib/ai/gemini.ts's finishReason handling, so a safety block or a
+// truncated response reads the same to the user whether they're on the BYO-key
+// Gemini path or this managed proxy (#239 — the proxy used to discard
+// finishReason entirely and could only ever say "empty response"). Duplicated
+// rather than imported from gemini.ts: server/ is a standalone Cloud Run
+// deployable with its own package.json, not built alongside the extension, so
+// there is no shared module to import from — keep the two in sync by hand if
+// either changes.
+//
+// Wording deliberately does NOT say "Gemini" (unlike gemini.ts) — every other
+// message in this file speaks generically ("the managed AI", "the AI service")
+// since the proxy never discloses which model runs behind it.
+
+export const MIN_VIABLE_ANSWER_LENGTH = 40;
+
+/**
+ * @param {string | undefined} finishReason
+ * @param {string} text
+ * @returns {string | null} the curated message to show the user, or null when
+ *   the response should be treated as usable (including "genuinely empty",
+ *   which the caller retries separately).
+ */
+export function classifyFinishReason(finishReason, text) {
+  if (finishReason === 'SAFETY') {
+    return 'This response was blocked for safety reasons. Try rephrasing.';
+  }
+  if (finishReason === 'RECITATION') {
+    return 'This response was blocked because it matched existing content too closely. Try rephrasing.';
+  }
+  // A short MAX_TOKENS answer means the output budget ran out almost
+  // immediately, not that a real answer got clipped near the end — same
+  // reasoning and threshold as gemini.ts. A substantial MAX_TOKENS answer is
+  // returned as-is; discarding a mostly-complete reply would be worse.
+  if (finishReason === 'MAX_TOKENS' && text.length < MIN_VIABLE_ANSWER_LENGTH) {
+    return 'The response was cut off before it could really start (ran out of output budget). Try again.';
+  }
+  return null;
+}

--- a/server/index.js
+++ b/server/index.js
@@ -19,6 +19,7 @@ import http from 'node:http';
 import { timingSafeEqual } from 'node:crypto';
 import { VertexAI } from '@google-cloud/vertexai';
 import { Firestore, FieldValue } from '@google-cloud/firestore';
+import { classifyFinishReason } from './classify.js';
 
 const PORT = process.env.PORT || 8080;
 const PROJECT = process.env.GOOGLE_CLOUD_PROJECT;
@@ -213,34 +214,10 @@ async function generate({ system, prompt, maxOutputTokens, json, thinking, model
   return { text: parts.map((p) => p.text || '').join('').trim(), finishReason: candidate?.finishReason };
 }
 
-// Mirrors src/lib/ai/gemini.ts's finishReason handling, so a safety block or a
-// truncated response reads the same to the user whether they're on the BYO-key
-// Gemini path or this managed proxy (#239 — the proxy used to discard
-// finishReason entirely and could only ever say "empty response"). Duplicated
-// rather than imported: server/ is a standalone Cloud Run deployable with its
-// own package.json, not built alongside the extension, so there is no shared
-// module to import from — keep the two in sync by hand if either changes.
-//
-// Wording deliberately does NOT say "Gemini" (unlike gemini.ts) — every other
-// message in this file speaks generically ("the managed AI", "the AI service")
-// since the proxy never discloses which model runs behind it.
-const MIN_VIABLE_ANSWER_LENGTH = 40;
-function classifyFinishReason(finishReason, text) {
-  if (finishReason === 'SAFETY') {
-    return 'This response was blocked for safety reasons. Try rephrasing.';
-  }
-  if (finishReason === 'RECITATION') {
-    return 'This response was blocked because it matched existing content too closely. Try rephrasing.';
-  }
-  // A short MAX_TOKENS answer means the output budget ran out almost
-  // immediately, not that a real answer got clipped near the end — same
-  // reasoning and threshold as gemini.ts. A substantial MAX_TOKENS answer is
-  // returned as-is; discarding a mostly-complete reply would be worse.
-  if (finishReason === 'MAX_TOKENS' && text.length < MIN_VIABLE_ANSWER_LENGTH) {
-    return 'The response was cut off before it could really start (ran out of output budget). Try again.';
-  }
-  return null;
-}
+// classifyFinishReason / MIN_VIABLE_ANSWER_LENGTH now live in ./classify.js —
+// pulled out so they can be imported by a real test (see #285). This file has
+// unconditional top-level side effects (VertexAI/Firestore clients, server
+// .listen below), so it can never itself be imported for testing.
 
 const server = http.createServer(async (req, res) => {
   if (req.method === 'OPTIONS') {

--- a/src/lib/ai/proxyClassify.test.ts
+++ b/src/lib/ai/proxyClassify.test.ts
@@ -1,0 +1,62 @@
+// server/classify.js has no top-level side effects (unlike server/index.js,
+// which fires off VertexAI/Firestore clients and server.listen the moment it
+// loads), so it's importable directly by a real test — see #285.
+
+import { describe, expect, it } from 'vitest';
+import { classifyFinishReason, MIN_VIABLE_ANSWER_LENGTH } from '../../../server/classify.js';
+
+describe('classifyFinishReason', () => {
+  it('returns the safety message for a SAFETY block, regardless of text', () => {
+    expect(classifyFinishReason('SAFETY', '')).toBe(
+      'This response was blocked for safety reasons. Try rephrasing.',
+    );
+    // A non-empty text alongside SAFETY still gets blocked — the finishReason
+    // is authoritative, not the text length.
+    expect(classifyFinishReason('SAFETY', 'x'.repeat(500))).toBe(
+      'This response was blocked for safety reasons. Try rephrasing.',
+    );
+  });
+
+  it('returns the recitation message for a RECITATION block, regardless of text', () => {
+    expect(classifyFinishReason('RECITATION', '')).toBe(
+      'This response was blocked because it matched existing content too closely. Try rephrasing.',
+    );
+    expect(classifyFinishReason('RECITATION', 'x'.repeat(500))).toBe(
+      'This response was blocked because it matched existing content too closely. Try rephrasing.',
+    );
+  });
+
+  it('returns the cut-off message for MAX_TOKENS with a short answer', () => {
+    expect(classifyFinishReason('MAX_TOKENS', 'x'.repeat(MIN_VIABLE_ANSWER_LENGTH - 1))).toBe(
+      'The response was cut off before it could really start (ran out of output budget). Try again.',
+    );
+  });
+
+  it('pins the exact MIN_VIABLE_ANSWER_LENGTH boundary', () => {
+    // One character under the threshold: still classified as "cut off".
+    expect(classifyFinishReason('MAX_TOKENS', 'x'.repeat(39))).not.toBeNull();
+    // Exactly at the threshold: no longer classified — a substantial answer,
+    // not one that ran out of budget almost immediately.
+    expect(classifyFinishReason('MAX_TOKENS', 'x'.repeat(40))).toBeNull();
+    expect(classifyFinishReason('MAX_TOKENS', 'x'.repeat(41))).toBeNull();
+  });
+
+  it('does not discard a substantial MAX_TOKENS answer', () => {
+    // A mostly-complete reply that simply hit the output cap is returned
+    // as-is — discarding it would be worse than a slightly truncated answer.
+    expect(classifyFinishReason('MAX_TOKENS', 'a real, substantial answer'.repeat(10))).toBeNull();
+  });
+
+  it('returns null for STOP with non-empty text (the normal, successful case)', () => {
+    expect(classifyFinishReason('STOP', 'a normal answer')).toBeNull();
+  });
+
+  it('returns null for an undefined finishReason with non-empty text', () => {
+    expect(classifyFinishReason(undefined, 'a normal answer')).toBeNull();
+  });
+
+  it('returns null for a genuinely empty response with no finishReason classification — the caller retries this case separately', () => {
+    expect(classifyFinishReason('STOP', '')).toBeNull();
+    expect(classifyFinishReason(undefined, '')).toBeNull();
+  });
+});


### PR DESCRIPTION
Closes #285.

## What changed

`classifyFinishReason` lived inline in `server/index.js`, which can never be imported for testing — the module fires unconditional top-level side effects the instant it loads (`new VertexAI(...)`, `new Firestore(...)`, `server.listen(...)`). `server/`'s only CI check is `node --check` (syntax only), so this exact logic — which decides whether a user sees "blocked for safety", "cut off before it could really start", or their actual answer, per the `MIN_VIABLE_ANSWER_LENGTH = 40` threshold — has shipped **twice** (#239, #284) with zero automated coverage. Both times I verified it by hand: `sed`-extracting the committed function body into a throwaway script and running it outside the repo.

## Fix

Pulled the pure decision logic into `server/classify.js` — same pattern this repo already uses for exactly this problem (`chooseOption` in `shared.ts`, `hostMatches` in `host.ts`). `server/index.js` now does `import { classifyFinishReason } from './classify.js'`.

- Still one deployable folder — `gcloud run deploy --source server` uploads the whole directory, nothing new needs shipping.
- `node --check` still covers both files (verified).
- The extracted function body is **byte-identical** to the original (diffed against the pre-change file to confirm) — only `export` and a JSDoc block were added. This is a pure extraction, not a rewrite.

## The `.d.ts` file

Importing a plain `.js` file into the TypeScript test fails typecheck without help:

```
error TS7016: Could not find a declaration file for module '../../../server/classify.js'.
```

Rather than turning on `allowJs` project-wide or pulling `server/` into `tsconfig.json`'s `include` (either of which changes what the whole project's typecheck considers), added `server/classify.d.ts` — a small hand-written declaration for just these two exports. Verified it resolves the error and the test still runs correctly under vitest.

## Tests

`src/lib/ai/proxyClassify.test.ts` — a **real import** (not the regex-scraping `src/lib/ai/modelAllowlist.test.ts` needs for `server/index.js`, since `classify.js` has no side effects to avoid). 8 tests, matching the issue's suggested matrix:

- `SAFETY` / `RECITATION` → curated message regardless of text length
- the exact `MIN_VIABLE_ANSWER_LENGTH` boundary — 39/40/41 chars
- a substantial `MAX_TOKENS` answer is returned as-is, not discarded
- `STOP` / undefined `finishReason` with non-empty text → `null`
- genuinely empty text with no blocking `finishReason` → `null` (the caller's retry case)

**Mutation-tested** two ways:
- Boundary: changed `<` to `<=` at the `MIN_VIABLE_ANSWER_LENGTH` check → the boundary-pinning test fails exactly as expected.
- Missing branch: removed the `SAFETY` check entirely → the SAFETY test fails exactly as expected.

`npm run lint`, `npm run typecheck`, `npm test` (31 files, **400 tests**), `npm run build` — all green. `node --check server/index.js` and `node --check server/classify.js` both pass; `npm ci` in `server/` clean, 0 vulnerabilities.

## Checklist

- [x] `npm run lint` passes
- [x] `npm run typecheck` passes
- [x] `npm test` passes
- [x] `npm run build` succeeds
- [x] `node --check server/index.js` passes
- [x] Tests added/updated if behavior changed
- [x] No secrets, keys, or personal data committed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of AI responses blocked for safety or content repetition, with clearer user-facing messages.
  - Added a specific message when an answer is cut off before reaching a useful length.
  - Responses that complete normally or contain sufficient content continue to display as expected.

- **Tests**
  - Added coverage for blocked, truncated, complete, empty, and boundary-length responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->