### PR TITLE
fix(options): show exact per-document AI-context usage, not just a trimmed flag

### DIFF
--- a/src/lib/profile.test.ts
+++ b/src/lib/profile.test.ts
@@ -5,7 +5,7 @@ import {
   DEFAULT_PROFILE,
   DOCUMENT_TEXT_BUDGET,
   RESUME_TEXT_BUDGET,
-  isDocumentTrimmed,
+  computeContextUsage,
   onProfileChanged,
   profileToContext,
   upsertDocument,
@@ -336,21 +336,122 @@ describe('profileToContext', () => {
   });
 });
 
-describe('isDocumentTrimmed', () => {
-  function doc(length: number): UploadedDoc {
-    return { id: 'd', name: 'd.pdf', text: 'x'.repeat(length), addedAt: 0 };
+describe('computeContextUsage', () => {
+  // The follow-up to #251: isDocumentTrimmed (a per-document, context-free
+  // check) couldn't say how many characters of a document actually reach the
+  // AI, because that's order-dependent — an earlier document or a large resume
+  // can squeeze out a later one even though it's individually under
+  // DOCUMENT_TEXT_BUDGET. computeContextUsage answers that precisely, and
+  // profileToContext is now built from its result (not a second, parallel
+  // walk), so the two can never disagree.
+  function doc(name: string, length: number): UploadedDoc {
+    return { id: name, name, text: 'x'.repeat(length), addedAt: 0 };
   }
 
-  it('is false at exactly the budget', () => {
-    expect(isDocumentTrimmed(doc(DOCUMENT_TEXT_BUDGET))).toBe(false);
+  it('reports full usage for a normal profile — nothing trimmed', () => {
+    const p: Profile = {
+      ...DEFAULT_PROFILE,
+      resumeText: 'A modest resume.',
+      documents: [doc('a.pdf', 500), doc('b.pdf', 300)],
+    };
+    const usage = computeContextUsage(p);
+    expect(usage.resume).toEqual({ usedChars: 16, totalChars: 16, usedText: 'A modest resume.' });
+    expect(usage.documents).toEqual([
+      { id: 'a.pdf', usedChars: 500, totalChars: 500, usedText: 'x'.repeat(500) },
+      { id: 'b.pdf', usedChars: 300, totalChars: 300, usedText: 'x'.repeat(300) },
+    ]);
   });
 
-  it('is true one character over the budget', () => {
-    expect(isDocumentTrimmed(doc(DOCUMENT_TEXT_BUDGET + 1))).toBe(true);
+  it('caps a single oversized document at DOCUMENT_TEXT_BUDGET', () => {
+    const p: Profile = { ...DEFAULT_PROFILE, documents: [doc('big.pdf', DOCUMENT_TEXT_BUDGET + 10_000)] };
+    const usage = computeContextUsage(p);
+    expect(usage.documents[0].usedChars).toBe(DOCUMENT_TEXT_BUDGET);
+    expect(usage.documents[0].totalChars).toBe(DOCUMENT_TEXT_BUDGET + 10_000);
+    expect(usage.documents[0].usedText).toBe('x'.repeat(DOCUMENT_TEXT_BUDGET));
   });
 
-  it('is false for a short document', () => {
-    expect(isDocumentTrimmed(doc(100))).toBe(false);
+  it('caps the resume at RESUME_TEXT_BUDGET', () => {
+    const p: Profile = { ...DEFAULT_PROFILE, resumeText: 'x'.repeat(RESUME_TEXT_BUDGET + 5_000) };
+    const usage = computeContextUsage(p);
+    expect(usage.resume.usedChars).toBe(RESUME_TEXT_BUDGET);
+    expect(usage.resume.totalChars).toBe(RESUME_TEXT_BUDGET + 5_000);
+  });
+
+  it('caps a document at whatever budget remains, not the full per-document cap, when remaining is smaller', () => {
+    // Grind the shared budget down to a value strictly between 0 and
+    // DOCUMENT_TEXT_BUDGET (7 full-cap documents: 60,000 - 7*8,000 = 4,000
+    // left), then give the 8th document more real text than that — it should
+    // be capped at the actual 4,000 remaining, not the 8,000 per-document cap.
+    const p: Profile = {
+      ...DEFAULT_PROFILE,
+      documents: [
+        ...Array.from({ length: 7 }, (_, i) => doc(`full-${i}.pdf`, DOCUMENT_TEXT_BUDGET)),
+        doc('last.pdf', 6_000),
+      ],
+    };
+    const usage = computeContextUsage(p);
+    expect(usage.documents[7]).toEqual({
+      id: 'last.pdf',
+      usedChars: 4_000,
+      totalChars: 6_000,
+      usedText: 'x'.repeat(4_000),
+    });
+  });
+
+  it('reports zero usage — not a partial slice — for a document dropped by shared-budget exhaustion', () => {
+    // Same fixture as profileToContext's "drops documents entirely" test:
+    // resume uses its full 20k slice, five documents at the 8k cap use exactly
+    // the remaining 40k, and the sixth has nothing left.
+    const p: Profile = {
+      ...DEFAULT_PROFILE,
+      resumeText: 'x'.repeat(RESUME_TEXT_BUDGET),
+      documents: Array.from({ length: 6 }, (_, i) => doc(`doc-${i}.pdf`, DOCUMENT_TEXT_BUDGET)),
+    };
+    const usage = computeContextUsage(p);
+    for (let i = 0; i < 5; i++) expect(usage.documents[i].usedChars).toBe(DOCUMENT_TEXT_BUDGET);
+    expect(usage.documents[5]).toEqual({
+      id: 'doc-5.pdf',
+      usedChars: 0,
+      totalChars: DOCUMENT_TEXT_BUDGET,
+      usedText: '',
+    });
+  });
+
+  it('does not let an empty document consume any of the shared budget', () => {
+    const p: Profile = {
+      ...DEFAULT_PROFILE,
+      documents: [doc('empty.pdf', 0), doc('after.pdf', 500)],
+    };
+    const usage = computeContextUsage(p);
+    expect(usage.documents[0]).toEqual({ id: 'empty.pdf', usedChars: 0, totalChars: 0, usedText: '' });
+    // The document after the empty one is unaffected — nothing was spent on it.
+    expect(usage.documents[1].usedChars).toBe(500);
+  });
+
+  it('agrees with profileToContext: every used slice appears verbatim, every dropped document does not appear at all', () => {
+    const profiles: Profile[] = [
+      // normal
+      { ...DEFAULT_PROFILE, resumeText: 'A modest resume.', documents: [doc('a.pdf', 500)] },
+      // per-document cap
+      { ...DEFAULT_PROFILE, documents: [doc('a.pdf', DOCUMENT_TEXT_BUDGET + 10_000), doc('b.pdf', DOCUMENT_TEXT_BUDGET + 10_000)] },
+      // shared-budget exhaustion (drops the last document)
+      {
+        ...DEFAULT_PROFILE,
+        resumeText: 'x'.repeat(RESUME_TEXT_BUDGET),
+        documents: Array.from({ length: 6 }, (_, i) => doc(`doc-${i}.pdf`, DOCUMENT_TEXT_BUDGET)),
+      },
+    ];
+    for (const p of profiles) {
+      const usage = computeContextUsage(p);
+      const context = profileToContext(p);
+      for (const d of usage.documents) {
+        if (d.usedChars > 0) {
+          expect(context).toContain(d.usedText);
+        } else {
+          expect(context).not.toContain(`Document "${d.id}"`);
+        }
+      }
+    }
   });
 });
 

--- a/src/lib/profile.ts
+++ b/src/lib/profile.ts
@@ -233,15 +233,63 @@ export const RESUME_TEXT_BUDGET = 20_000;
  */
 export const DOCUMENT_TEXT_BUDGET = 8_000;
 
+/** How much of a piece of source text actually makes it into the AI context. */
+export interface TextUsage {
+  /** Characters actually included in the AI context. */
+  usedChars: number;
+  /** Trimmed length of the source text (before any budget is applied). */
+  totalChars: number;
+  /** The exact slice sent to the AI — may be '' when nothing fit. */
+  usedText: string;
+}
+
+export interface DocumentUsage extends TextUsage {
+  id: string;
+}
+
+export interface ContextUsage {
+  resume: TextUsage;
+  /** One entry per Profile.documents, same order. */
+  documents: DocumentUsage[];
+}
+
 /**
- * True when this document's own text is long enough that profileToContext will
- * trim it. Options.tsx shows this next to the document instead of trimming
- * silently — see #251. (A document under this cap can still end up dropped
- * entirely if enough earlier resume/document text has already used up
- * CONTEXT_TEXT_BUDGET; this only flags the common, per-document case.)
+ * Computes exactly how much of the resume and each document ends up in the AI
+ * context, given the shared, order-dependent budget below. profileToContext
+ * builds its output from this (not a second, parallel walk of the same
+ * budget), and Options.tsx uses it to show the real per-document usage instead
+ * of the coarser "is this document individually oversized" check that used to
+ * live here as isDocumentTrimmed — see #251's follow-up: a document under
+ * DOCUMENT_TEXT_BUDGET on its own can still be partially or fully squeezed out
+ * by an earlier document or a large resume, which a per-document-only check
+ * can't see.
  */
-export function isDocumentTrimmed(doc: UploadedDoc): boolean {
-  return doc.text.trim().length > DOCUMENT_TEXT_BUDGET;
+export function computeContextUsage(p: Profile): ContextUsage {
+  const resumeFull = p.resumeText.trim();
+  const resumeUsedText = resumeFull.slice(0, RESUME_TEXT_BUDGET);
+  const resume: TextUsage = {
+    usedChars: resumeUsedText.length,
+    totalChars: resumeFull.length,
+    usedText: resumeUsedText,
+  };
+
+  // Remaining shared budget after the resume's priority slice. Each document is
+  // further capped at DOCUMENT_TEXT_BUDGET so a single huge upload can't eat the
+  // whole thing; once the shared budget itself runs out, later documents (in
+  // list order) get nothing rather than a useless sliver.
+  let remaining = CONTEXT_TEXT_BUDGET - resume.usedChars;
+  const documents: DocumentUsage[] = p.documents.map((doc) => {
+    const text = doc.text.trim();
+    if (!text || remaining <= 0) {
+      return { id: doc.id, usedChars: 0, totalChars: text.length, usedText: '' };
+    }
+    const cap = Math.min(DOCUMENT_TEXT_BUDGET, remaining);
+    const usedText = text.slice(0, cap);
+    remaining -= usedText.length;
+    return { id: doc.id, usedChars: usedText.length, totalChars: text.length, usedText };
+  });
+
+  return { resume, documents };
 }
 
 /**
@@ -281,24 +329,17 @@ export function profileToContext(p: Profile): string {
     }
   }
 
-  const resume = p.resumeText.trim();
-  if (resume) {
-    lines.push('\nResume:\n' + resume.slice(0, RESUME_TEXT_BUDGET));
+  const usage = computeContextUsage(p);
+  if (usage.resume.usedChars > 0) {
+    lines.push('\nResume:\n' + usage.resume.usedText);
   }
 
-  // Remaining shared budget after the resume's priority slice. Each document is
-  // further capped at DOCUMENT_TEXT_BUDGET so a single huge upload can't eat the
-  // whole thing; once the shared budget itself runs out, later documents (in
-  // list order) are dropped entirely rather than appended as a useless sliver.
-  let remaining = CONTEXT_TEXT_BUDGET - Math.min(resume.length, RESUME_TEXT_BUDGET);
-  for (const doc of p.documents) {
-    if (remaining <= 0) break;
-    const text = doc.text.trim();
-    if (!text) continue;
-    const cap = Math.min(DOCUMENT_TEXT_BUDGET, remaining);
-    lines.push(`\nDocument "${doc.name}":\n${text.slice(0, cap)}`);
-    remaining -= Math.min(text.length, cap);
-  }
+  p.documents.forEach((doc, i) => {
+    const u = usage.documents[i];
+    if (u.usedChars > 0) {
+      lines.push(`\nDocument "${doc.name}":\n${u.usedText}`);
+    }
+  });
 
   return lines.join('\n');
 }

--- a/src/options/Options.tsx
+++ b/src/options/Options.tsx
@@ -1,9 +1,8 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { Field } from './Field';
 import { DisabledSites } from './DisabledSites';
 import {
-  DOCUMENT_TEXT_BUDGET,
-  isDocumentTrimmed,
+  computeContextUsage,
   upsertDocument,
   type EducationEntry,
   type Profile,
@@ -78,6 +77,22 @@ function OptionsView({
   const [showApiKey, setShowApiKey] = useState(false);
   const [showProxyToken, setShowProxyToken] = useState(false);
   const [onDeviceAvailable, setOnDeviceAvailable] = useState<boolean | null>(null);
+
+  // Which uploaded documents have their "exact text sent to the AI" preview open.
+  const [expandedDocs, setExpandedDocs] = useState<Set<string>>(new Set());
+  function toggleDocExpanded(id: string): void {
+    setExpandedDocs((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  }
+  const contextUsage = useMemo(() => computeContextUsage(p), [p]);
+  const docUsage = useMemo(
+    () => new Map(contextUsage.documents.map((u) => [u.id, u])),
+    [contextUsage],
+  );
 
   useEffect(() => {
     let cancelled = false;
@@ -353,6 +368,13 @@ function OptionsView({
             onChange={(e) => update((prev) => ({ ...prev, resumeText: e.target.value }))}
           />
         </Field>
+        {contextUsage.resume.usedChars < contextUsage.resume.totalChars && (
+          <p className="warn">
+            Only {contextUsage.resume.usedChars.toLocaleString()} of{' '}
+            {contextUsage.resume.totalChars.toLocaleString()} chars are sent to the AI — shorten
+            the resume to use the rest.
+          </p>
+        )}
         <div style={{ display: 'flex', alignItems: 'center', gap: 12 }}>
           <button
             className="primary"
@@ -518,33 +540,61 @@ function OptionsView({
         />
         {p.documents.length > 0 && (
           <div style={{ margin: '10px 0' }}>
-            {p.documents.map((d) => (
-              <div key={d.id} className="list-item" style={{ display: 'flex', alignItems: 'center' }}>
-                <span style={{ flex: 1 }}>
-                  📄 {d.name} <span className="help">({d.text.length.toLocaleString()} chars)</span>
-                  {isDocumentTrimmed(d) && (
-                    <span
-                      className="warn"
-                      title={`Only the first ${DOCUMENT_TEXT_BUDGET.toLocaleString()} characters are sent to the AI.`}
-                    >
-                      {' '}
-                      — trimmed for AI context
+            {p.documents.map((d) => {
+              const u = docUsage.get(d.id);
+              const trimmed = !!u && u.usedChars < u.totalChars;
+              const expanded = expandedDocs.has(d.id);
+              return (
+                <div key={d.id} className="list-item">
+                  <div style={{ display: 'flex', alignItems: 'center' }}>
+                    <span style={{ flex: 1 }}>
+                      📄 {d.name} <span className="help">({d.text.length.toLocaleString()} chars)</span>
+                      {trimmed && (
+                        <span className="warn">
+                          {' — '}
+                          {u!.usedChars === 0
+                            ? 'not sent (AI context budget full)'
+                            : `${u!.usedChars.toLocaleString()} of ${u!.totalChars.toLocaleString()} chars used for AI`}
+                        </span>
+                      )}
                     </span>
+                    <button
+                      className="jobtoggle"
+                      title={expanded ? 'Hide what is sent to the AI' : 'Show what is sent to the AI'}
+                      aria-expanded={expanded}
+                      aria-label={`${expanded ? 'Hide' : 'Show'} the exact text sent to the AI for ${d.name}`}
+                      onClick={() => toggleDocExpanded(d.id)}
+                    >
+                      {expanded ? '▴' : '▾'}
+                    </button>
+                    <button
+                      className="danger"
+                      onClick={() =>
+                        update((prev) => ({
+                          ...prev,
+                          documents: prev.documents.filter((x) => x.id !== d.id),
+                        }))
+                      }
+                    >
+                      Remove
+                    </button>
+                  </div>
+                  {expanded && (
+                    <div className="jobpreview">
+                      <div className="jobmeta">
+                        <span>
+                          {(u?.usedChars ?? 0).toLocaleString()} of{' '}
+                          {(u?.totalChars ?? 0).toLocaleString()} chars sent to the AI
+                        </span>
+                      </div>
+                      <div className="jobsnippet">
+                        {u?.usedText || '(none of this document is sent to the AI)'}
+                      </div>
+                    </div>
                   )}
-                </span>
-                <button
-                  className="danger"
-                  onClick={() =>
-                    update((prev) => ({
-                      ...prev,
-                      documents: prev.documents.filter((x) => x.id !== d.id),
-                    }))
-                  }
-                >
-                  Remove
-                </button>
-              </div>
-            ))}
+                </div>
+              );
+            })}
           </div>
         )}
       </section>


### PR DESCRIPTION
## What changed

The document list showed a boolean "— trimmed for AI context" flag driven by `isDocumentTrimmed` — a per-document, context-free check (`doc.text.trim().length > DOCUMENT_TEXT_BUDGET`). That can't say how many characters actually reach the AI: the real amount is **order-dependent**. `profileToContext` spends a shared 60,000-char budget — resume first, then documents in list order, each capped at 8,000 but drawing from whatever's left of the shared pool. A document flagged "trimmed" could get the full 8,000, less than that, or **0** (fully dropped), depending on what came before it. The old tooltip always claimed "the first 8,000 characters are sent," which was wrong for any document once the shared budget started running low.

(Reported by the repo owner with a screenshot: two documents each showing "— trimmed for AI context" with no way to tell how much of either was actually used, or to see the exact text sent.)

## Fix

`computeContextUsage(p)` in `profile.ts` — one function that both `profileToContext` and the UI now consume, so the displayed numbers can never drift from what's actually sent. `profileToContext` is refactored to build its resume/document lines from this instead of independently re-walking the same budget.

Verified the refactor is behavior-preserving, not just similar: `remaining` is mutated via closure across a `.map()` in the same left-to-right order as the original `for` loop; `text.slice(0, cap).length === Math.min(text.length, cap)` always, so the budget decrement is identical; a document produces a non-empty line in both versions under exactly the same condition. The full existing `describe('context size budget (#251)', ...)` test suite (profileToContext's own tests, unmodified) passes unchanged, confirming no behavior change to what's sent to the AI.

`isDocumentTrimmed` is removed — fully superseded, and an unused narrower duplicate of the same logic was exactly the kind of drift risk this fix closes.

**UI** (`Options.tsx`): each document row stays visually silent when it isn't affected (matching prior behavior for the common case — most documents fit within budget). When a document *is* affected:
- partial trim: `"N of M chars used for AI"`
- fully dropped by shared-budget exhaustion: `"not sent (AI context budget full)"` — distinct wording, since these call for different reactions (nothing to do vs. reorder/shrink/remove something)

Added a per-row expand/collapse (▾) to preview the exact text sent, reusing the existing `jobtoggle`/`jobpreview`/`jobmeta`/`jobsnippet` pattern already built for `Popup.tsx`'s saved-job preview — no new CSS needed, `ui.css` is shared by Options and the side panel. Added a matching usage note next to the resume textarea (resume trimming had no indicator at all before this).

## Tests

New `describe('computeContextUsage', ...)` in `profile.test.ts`: normal/capped/dropped/empty-document cases, resume-over-budget, and a cross-check that every non-empty `usedText` appears verbatim in `profileToContext`'s output while every fully-dropped document's name does not appear at all.

**Mutation-testing caught a real, pre-existing coverage gap** (not something this PR introduced — it was already true of the original #251 code, just never exercised): changing the per-document cap line from `Math.min(DOCUMENT_TEXT_BUDGET, remaining)` to a bare `DOCUMENT_TEXT_BUDGET` initially passed **every** test silently. None of the existing #251 fixtures ever left `remaining` strictly between `0` and `DOCUMENT_TEXT_BUDGET` when reaching a document — they only ever hit "plenty left" or "exactly exhausted." Added a test that specifically constructs that in-between case (grind the budget down to 4,000 via 7 full-cap documents, then give an 8th document more real text than that); re-running the same mutation now fails it as expected.

`npm run lint`, `npm run typecheck`, `npm test` (32 files, **401 tests**), `npm run build` — all green.

## Manual verification

Built a temporary local harness (mocked `chrome.*` APIs, real `<Options />` component, not committed) and confirmed in a real browser:
- Live per-document counts match `computeContextUsage`'s output exactly (spot-checked against the reported screenshot's numbers: 33,191 and 29,963-char documents both correctly show "8,000 of N,NNN chars used").
- The preview toggle shows the exact slice sent — verified length and content character-for-character.
- The resume note appears and updates live when the resume is edited past budget.
- A newly uploaded document is correctly wired into the same computation.
- Small documents that fit stay visually silent, exactly as before.
- CSS renders correctly (`.warn` color verified against the computed style).

## Checklist

- [x] `npm run lint` passes
- [x] `npm run typecheck` passes
- [x] `npm test` passes
- [x] `npm run build` succeeds
- [x] Tests added/updated if behavior changed
- [x] No secrets, keys, or personal data committed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added detailed AI context usage tracking for resumes and uploaded documents.
  * Options now shows how many characters from each item are sent to the AI.
  * Added expandable previews displaying the exact text included in AI context.
  * Added indicators when the resume or documents are partially included or not sent due to budget limits.

* **Bug Fixes**
  * Improved consistency between displayed context usage and the content provided to the AI.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->