### PR TITLE
fix: preserve full AI error messages in content UI

### DIFF
--- a/src/content/buttonError.test.ts
+++ b/src/content/buttonError.test.ts
@@ -1,0 +1,64 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { CONTEXT_LOST_MESSAGE } from '../lib/messages';
+import { clearButtonError, showButtonError } from './buttonError';
+
+beforeEach(() => vi.useFakeTimers());
+afterEach(() => vi.useRealTimers());
+
+describe('AI button errors', () => {
+  const message = 'The AI service could not complete this request. Sign in again in Options and try again.';
+
+  it.each([32, 40])('keeps the complete error in the title with a %i-character label', (limit) => {
+    const button = { textContent: 'Thinking…', title: '' };
+    showButtonError(button, message, 'AI answer', limit);
+
+    expect(button.textContent).toBe('⚠ ' + message.slice(0, limit));
+    expect(button.textContent).not.toContain('Sign in again');
+    expect(button.title).toBe(message);
+  });
+
+  it.each(['', 'Re-read this posting with AI (more accurate on odd wording)'])(
+    'restores the label and original title (%j) together',
+    (title) => {
+      const button = { textContent: 'Analyzing…', title };
+      showButtonError(button, message, 'AI check', 32);
+
+      vi.advanceTimersByTime(3999);
+      expect(button.title).toBe(message);
+      vi.advanceTimersByTime(1);
+      expect(button).toEqual({ textContent: 'AI check', title });
+    },
+  );
+
+  it('preserves the full context-lost message until its shorter reset timeout', () => {
+    const button = { textContent: 'Thinking…', title: '' };
+    showButtonError(button, CONTEXT_LOST_MESSAGE, 'AI answer', 40, 3000);
+    expect(button.title).toBe(CONTEXT_LOST_MESSAGE);
+
+    vi.advanceTimersByTime(3000);
+    expect(button).toEqual({ textContent: 'AI answer', title: '' });
+  });
+
+  it('clears a stale tooltip on retry without resetting the new in-flight label', () => {
+    const button = { textContent: 'AI check', title: 'Check this posting' };
+    showButtonError(button, message, 'AI check', 32);
+    vi.advanceTimersByTime(1000);
+
+    clearButtonError(button);
+    button.textContent = 'Analyzing…';
+    vi.advanceTimersByTime(4000);
+    expect(button).toEqual({ textContent: 'Analyzing…', title: 'Check this posting' });
+  });
+
+  it('replaces an error without restoring its stale timer or tooltip', () => {
+    const button = { textContent: 'AI check', title: 'Check this posting' };
+    showButtonError(button, message, 'AI check', 32);
+    vi.advanceTimersByTime(1000);
+    showButtonError(button, CONTEXT_LOST_MESSAGE, 'AI check', 32);
+
+    vi.advanceTimersByTime(3000);
+    expect(button.title).toBe(CONTEXT_LOST_MESSAGE);
+    vi.advanceTimersByTime(1000);
+    expect(button).toEqual({ textContent: 'AI check', title: 'Check this posting' });
+  });
+});

--- a/src/content/buttonError.ts
+++ b/src/content/buttonError.ts
@@ -1,0 +1,32 @@
+type ErrorButton = Pick<HTMLButtonElement, 'textContent' | 'title'>;
+
+const pendingErrors = new WeakMap<ErrorButton, { timer: ReturnType<typeof setTimeout>; title: string }>();
+
+/** Remove a previous error's tooltip and timer before a retry changes the label. */
+export function clearButtonError(button: ErrorButton): void {
+  const pending = pendingErrors.get(button);
+  if (!pending) return;
+  clearTimeout(pending.timer);
+  button.title = pending.title;
+  pendingErrors.delete(button);
+}
+
+/** Keep the label compact, but make the full recovery instructions available on hover. */
+export function showButtonError(
+  button: ErrorButton,
+  message: string,
+  restoreLabel: string,
+  maxLength: number,
+  duration = 4000,
+): void {
+  clearButtonError(button);
+  const title = button.title;
+  button.textContent = '⚠ ' + message.slice(0, maxLength);
+  button.title = message;
+  const timer = setTimeout(() => {
+    button.textContent = restoreLabel;
+    button.title = title;
+    pendingErrors.delete(button);
+  }, duration);
+  pendingErrors.set(button, { timer, title });
+}

--- a/src/content/index.ts
+++ b/src/content/index.ts
@@ -17,6 +17,7 @@ import { workdayAdapter } from './adapters/workday';
 import { ashbyAdapter } from './adapters/ashby';
 import type { SiteAdapter } from './adapters/types';
 import { AI_BUTTON_CSS, BUTTON_CLASS } from './aiButtonStyles';
+import { clearButtonError, showButtonError } from './buttonError';
 import {
   CONTEXT_LOST_MESSAGE,
   isContextInvalidated,
@@ -206,6 +207,7 @@ function disarm(btn: HTMLButtonElement): void {
 }
 
 async function generateAnswer(q: OpenQuestion, btn: HTMLButtonElement): Promise<void> {
+  clearButtonError(btn);
   // Replacing text the applicant already has is destructive and unrecoverable,
   // so it takes two clicks. Regeneration stays available — it just has to be
   // deliberate.
@@ -232,8 +234,7 @@ async function generateAnswer(q: OpenQuestion, btn: HTMLButtonElement): Promise<
     const jobText = getScanText();
     const res = await sendToBackground<AIResult>({ type: 'AI_GENERATE_ANSWER', question, jobText });
     if (res.error) {
-      btn.textContent = '⚠️ ' + res.error.slice(0, 40);
-      setTimeout(() => (btn.textContent = original), 4000);
+      showButtonError(btn, res.error, original, 40);
     } else {
       fillInput(q.el, res.text);
       btn.textContent = '✓ filled';
@@ -242,11 +243,11 @@ async function generateAnswer(q: OpenQuestion, btn: HTMLButtonElement): Promise<
   } catch (e) {
     // A stale content script (extension reloaded/updated under an open tab) is
     // recoverable by refreshing, so say that rather than a bare "failed".
-    btn.textContent = isContextInvalidated(e)
-      ? '⚠️ ' + CONTEXT_LOST_MESSAGE.slice(0, 40)
-      : '⚠️ failed';
+    const message = isContextInvalidated(e)
+      ? CONTEXT_LOST_MESSAGE
+      : e instanceof Error ? e.message : String(e);
+    showButtonError(btn, message, original, 40, 3000);
     console.error('[JobAutofill] answer generation failed', e);
-    setTimeout(() => (btn.textContent = original), 3000);
   } finally {
     btn.disabled = false;
   }

--- a/src/content/sponsorship.ts
+++ b/src/content/sponsorship.ts
@@ -11,6 +11,7 @@ import { downloadLetter } from '../lib/coverLetter';
 import { downloadResume } from '../lib/resume';
 import { getProfile, saveProfile } from '../lib/profile';
 import { addDisabledHost, hostMatches } from '../lib/host';
+import { clearButtonError, showButtonError } from './buttonError';
 
 export type Verdict = 'yes' | 'no' | 'caution' | 'unknown';
 
@@ -1059,7 +1060,7 @@ function buildGeneratorSection(cfg: {
       cfg.download(res.text, company.value.trim(), role.value.trim());
       status.textContent = '✓ Downloaded PDF';
     } catch (e) {
-      status.textContent = '⚠ ' + String((e as Error).message).slice(0, 60);
+      status.textContent = '⚠ ' + String((e as Error).message);
     } finally {
       gen.disabled = false;
       gen.textContent = orig;
@@ -1171,7 +1172,7 @@ function renderBadge(a: SponsorAnalysis, meta: JobMeta): HTMLElement {
     .clform { margin-top: 8px; display: flex; flex-direction: column; gap: 6px; }
     .clform input { width: 100%; box-sizing: border-box; padding: 5px 7px; font-size: 12px;
                     border: 1px solid #cbd5e1; border-radius: 5px; font-family: inherit; color: #0f172a; }
-    .clstatus { font-size: 11px; color: #64748b; }
+    .clstatus { font-size: 11px; color: #64748b; overflow-wrap: anywhere; }
     .hidden { display: none; }
   `;
   root.appendChild(style);
@@ -1235,6 +1236,7 @@ function renderBadge(a: SponsorAnalysis, meta: JobMeta): HTMLElement {
     ai.textContent = 'AI check';
     ai.title = 'Re-read this posting with AI (more accurate on odd wording)';
     ai.addEventListener('click', async () => {
+      clearButtonError(ai);
       ai.textContent = 'Analyzing…';
       ai.disabled = true;
       // Snapshot what this click is FOR, before the await: on a split-view board
@@ -1266,11 +1268,8 @@ function renderBadge(a: SponsorAnalysis, meta: JobMeta): HTMLElement {
           document.body.appendChild(renderBadge(analysis, meta));
         }
       } catch (e) {
-        ai.textContent = `⚠ ${String((e as Error).message).slice(0, 32)}`;
+        showButtonError(ai, String((e as Error).message), 'AI check', 32);
         ai.disabled = false;
-        setTimeout(() => {
-          ai.textContent = 'AI check';
-        }, 4000);
       }
     });
     row.appendChild(ai);

--- a/src/lib/messages.ts
+++ b/src/lib/messages.ts
@@ -133,8 +133,8 @@ export const UNSUPPORTED_REPLY_DELAY_MS = 400;
  * the runtime. Every chrome.* call from that orphaned script then throws, and
  * the only cure is reloading the page so a fresh content script is injected.
  *
- * The action comes first because callers truncate this for display — the badge's
- * AI check cuts at 32 characters — so "Refresh this page" survives the slice.
+ * The action comes first so "Refresh this page" survives compact button labels.
+ * Their tooltips retain the full message, including why a refresh is needed.
  */
 export const CONTEXT_LOST_MESSAGE = 'Refresh this page — the extension was updated.';
 


### PR DESCRIPTION
## What & why

Closes #298.

The inline AI-answer and badge AI-check buttons currently cut off error messages before their recovery instructions and do not expose the full text on hover.

- Keep the existing 40/32-character button limits, but show the complete error in the tooltip, including context-lost errors.
- Restore the original label and tooltip together when the error expires. Clear the previous error timer and tooltip on retry so they cannot overwrite the new request's state.
- Show the complete cover-letter/resume error in the wrapping status line instead of truncating it at 60 characters.
- Update the context-lost message comment; the message itself is unchanged.

The two button paths share a small helper so their label, tooltip, and reset behavior stay together. No dependencies or AI-provider error strings changed.

## How I tested

- Added 7 regression cases for both label limits, full context-lost text, empty/existing tooltips, reset timing, retry, and repeated errors.
- `npm run lint` — passed.
- `npm run typecheck` — passed.
- `npm test` — 412 tests passed across 34 files.
- `npm run build` — passed. Vite reports a config-loader compatibility warning for unchanged configuration files.

Validation was automated; I did not manually load the extension into Chrome.

## Checklist

- [x] `npm run lint` passes
- [x] `npm run typecheck` passes
- [x] `npm test` passes
- [x] `npm run build` succeeds
- [x] Tests added/updated if behavior changed
- [x] No secrets, keys, or personal data committed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved error feedback on action buttons with concise labels and full details available in tooltips.
  - Error messages now restore buttons to their original state automatically.
  - Retrying an action clears outdated error details without disrupting the active progress label.
  - Long status messages now wrap cleanly instead of being cut off.
  - More specific error messages are displayed when actions fail.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->